### PR TITLE
[viostor] fix guest out-of-bounds accesses check error

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -934,7 +934,7 @@ VirtIoBuildIo(
 
     lba = RhelGetLba(DeviceExtension, cdb);
     blocks = (Srb->DataTransferLength + adaptExt->info.blk_size - 1) / adaptExt->info.blk_size;
-    if ((lba + blocks) > adaptExt->lastLBA) {
+    if ((lba + blocks - 1) > adaptExt->lastLBA) {
         PSENSE_DATA senseBuffer = (PSENSE_DATA)Srb->SenseInfoBuffer;
         Srb->SrbStatus = SRB_STATUS_ERROR | SRB_STATUS_AUTOSENSE_VALID;
         Srb->ScsiStatus = SCSISTAT_GOOD;


### PR DESCRIPTION
commit 56655aaabfc2f3378297d7185286d42e6ff63b44 add windows guest out-fo-bounds accesses check,
But the last block address when accessing should be (lba + blocks - 1) instead of (lba + blocks).

This bug will lead to GPT partition initializing  failed.
