### PR TITLE
NetKVM: RSS2QueueMap fix

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1325,12 +1325,14 @@ VOID ParaNdis_CleanupContext(PARANDIS_ADAPTER *pContext)
         pContext->pPathBundles = nullptr;
     }
 
+#if PARANDIS_SUPPORT_RSS
     if (pContext->RSS2QueueMap)
     {
         NdisFreeMemoryWithTagPriority(pContext->MiniportHandle, pContext->RSS2QueueMap, PARANDIS_MEMORY_TAG);
         pContext->RSS2QueueMap = nullptr;
         pContext->RSS2QueueLength = 0;
     }
+#endif
 
     virtio_device_shutdown(&pContext->IODevice);
 

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -882,6 +882,7 @@ static NDIS_STATUS SetupDPCTarget(PARANDIS_ADAPTER *pContext)
 #if PARANDIS_SUPPORT_RSS
 NDIS_STATUS ParaNdis_SetupRSSQueueMap(PARANDIS_ADAPTER *pContext)
 {
+    KIRQL oldIrql;
     CPUPathesBundle **newMap = nullptr, **oldMap = nullptr;
     NDIS_STATUS status = NDIS_STATUS_SUCCESS;
 
@@ -965,9 +966,11 @@ NDIS_STATUS ParaNdis_SetupRSSQueueMap(PARANDIS_ADAPTER *pContext)
     }
 
 replace:
+    oldIrql = ExAcquireSpinLockExclusive(&pContext->RSS2QueueRwLock);
     oldMap = pContext->RSS2QueueMap;
     pContext->RSS2QueueLength = USHORT(rssTableSize);
     pContext->RSS2QueueMap = newMap;
+    ExReleaseSpinLockExclusive(&pContext->RSS2QueueRwLock, oldIrql);
 
     if (oldMap)
     {

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -419,6 +419,7 @@ typedef struct _tagPARANDIS_ADAPTER
 #if PARANDIS_SUPPORT_RSS
     CPUPathesBundle             **RSS2QueueMap;
     USHORT                      RSS2QueueLength;
+    EX_SPIN_LOCK                RSS2QueueRwLock;
 #endif
 
     PIO_INTERRUPT_MESSAGE_INFO  pMSIXInfoTable;

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -416,8 +416,10 @@ typedef struct _tagPARANDIS_ADAPTER
     CPUPathesBundle             *pPathBundles;
     UINT                        nPathBundles;
 
-    CPUPathesBundle            **RSS2QueueMap;
+#if PARANDIS_SUPPORT_RSS
+    CPUPathesBundle             **RSS2QueueMap;
     USHORT                      RSS2QueueLength;
+#endif
 
     PIO_INTERRUPT_MESSAGE_INFO  pMSIXInfoTable;
     NDIS_HANDLE                 DmaHandle;

--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -437,6 +437,10 @@ static VOID ParaNdis6_SendNetBufferLists(
             map = pContext->RSS2QueueMap;
             if (map)
             {
+                if (indirectionIndex >= pContext->RSS2QueueLength)
+                {
+                    indirectionIndex %= pContext->RSS2QueueLength;
+                }
                 p = map[indirectionIndex];
             }
             else


### PR DESCRIPTION
There is a race between ParaNdis_SetupRSSQueueMap and
ParaNdis6_SendNetBufferLists due to the lack of r/w sync:

Processor 1 call stack and code:
NDIS!ndisMInvokeOidRequest calls
    ParaNdis6_OidRequest calls (through OidsDB callback table)
    OIDENTRYPROC(OID_GEN_RECEIVE_SCALE_PARAMETERS,  0,0,0, ohfSet 
    | ohfSetMoreOK, RSSSetParameters),
        RSSSetParameters calls
            ParaNdis_SetupRSSQueueMap

```
if (pContext->RSS2QueueLength && 
    pContext->RSS2QueueLength < rssTableSize)
{
    DPrintf(0, ("[%s] Freeing RSS2Queue Map\n", __FUNCTION__));
```

-->     NdisFreeMemoryWithTagPriority(pContext->MiniportHandle,
            pContext->RSS2QueueMap, PARANDIS_MEMORY_TAG);
        pContext->RSS2QueueLength = 0;
    }

```
if (!pContext->RSS2QueueLength)
{
    pContext->RSS2QueueLength = USHORT(rssTableSize);
    pContext->RSS2QueueMap = (CPUPathesBundle **)
        NdisAllocateMemoryWithTagPriority(pContext->MiniportHandle,
        rssTableSize * sizeof(*pContext->RSS2QueueMap),
        PARANDIS_MEMORY_TAG, NormalPoolPriority);
    if (pContext->RSS2QueueMap == nullptr)
```

-->     {
            DPrintf(0, ("[%s] - Allocating RSS to queue mapping failed\n",
                **FUNCTION**));
            NdisFreeMemoryWithTagPriority(pContext->MiniportHandle,
                cpuIndexTable, PARANDIS_MEMORY_TAG);
            return NDIS_STATUS_RESOURCES;
        }

-->     NdisZeroMemory(pContext->RSS2QueueMap,
            sizeof(*pContext->RSS2QueueMap) \* pContext->RSS2QueueLength);
    }

Processor 2 call stack and code:
NDIS!NdisSendNetBufferLists calls
    netkvm!ParaNdis6_SendNetBufferLists

--> pContext->RSS2QueueMap[indirectionIndex]->txPath.Send(pNBL);

Another race is indirectionIndex calculation via RSSHashMask.
Mask can be updated before map update. So there is a need to check
that index fits into bounds. (We suppose that there is _NO_PROBLEM_
if packet will be sent not exactly in the proper queue by its hash value).

This patch set introduces r/w spinlock as well as index inbound validation.
