### PR TITLE
[vioserial] fix VIRTIO_CONSOLE_PORT_OPEN fails

### DIFF
--- a/vioserial/sys/Control.c
+++ b/vioserial/sys/Control.c
@@ -159,6 +159,7 @@ VIOSerialHandleCtrlMsg(
         break;
 
         case VIRTIO_CONSOLE_PORT_OPEN:
+           WdfSpinLockAcquire(pContext->CCtrlLock);
            if (port)
            {
               BOOLEAN  Connected = (BOOLEAN)cpkt->value;
@@ -189,6 +190,7 @@ VIOSerialHandleCtrlMsg(
            {
               TraceEvents(TRACE_LEVEL_ERROR, DBG_PNP, "VIRTIO_CONSOLE_PORT_OPEN invalid id = %d\n", cpkt->id);
            }
+           WdfSpinLockRelease(pContext->CCtrlLock);
         break;
 
         case VIRTIO_CONSOLE_PORT_NAME:

--- a/vioserial/sys/vioser.h
+++ b/vioserial/sys/vioser.h
@@ -84,6 +84,7 @@ typedef struct _tagPortDevice
     struct virtqueue    *c_ivq, *c_ovq;
     struct virtqueue    **in_vqs, **out_vqs;
     WDFSPINLOCK         CVqLock;
+    WDFSPINLOCK         CCtrlLock;
 
     BOOLEAN             DeviceOK;
     UINT                DeviceId;


### PR DESCRIPTION
Handler of VIRTIO_CONSOLE_PORT_OPEN event may fail when guest OS reboot, because VIOSerialHandleCtrlMsg may be invoked concurrently, but  the procedure of this event is not protected by any lock.

For example:
[vioserial] [level-3] --> VIOSerialHandleCtrlMsg::123  Device:FFFFE00114549820 Devid:0 id:1 event:6 value:0 iodevice:FFFFE001145615F0
[vioserial] [level-3] --> VIOSerialHandleCtrlMsg::123  Device:FFFFE00114549820 Devid:0 id:1 event:6 value:1 iodevice:FFFFE001145615F0
[vioserial] [level-2] VIOSerialHandleCtrlMsg::179 port:org.qemu.guest_agent.0 VIRTIO_CONSOLE_PORT_OPEN id = 1, HostConnected = 0 current HostConnected:1
[vioserial] [level-2] VIOSerialHandleCtrlMsg::179 port:org.qemu.guest_agent.0 VIRTIO_CONSOLE_PORT_OPEN id = 1, HostConnected = 1 current HostConnected:1
[vioserial] [level-3] --> VIOSerialPortPnpNotify
[vioserial] [level-3] <-- VIOSerialHandleCtrlMsg::217
[vioserial] [level-3] <-- VIOSerialHandleCtrlMsg::217