### PR TITLE
support for multiple vendors

### DIFF
--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -13,6 +13,7 @@
  *
 **********************************************************************/
 #include "precomp.h"
+#include "..\..\Tools\vendor.check.h"
 
 #if defined(EVENT_TRACING)
 #include "balloon.tmh"

--- a/Balloon/sys/balloon.inx
+++ b/Balloon/sys/balloon.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2009-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    BALLOON.INF
@@ -17,8 +18,8 @@
 Signature="$WINDOWS NT$"
 Class=System
 ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
-Provider=%RHEL%
-DriverVer=05/19/2008,6.0.6000.16386
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=Balloon.cat
 DriverPackageType = PlugAndPlay
 DriverPackageDisplayName = %BALLOON.DeviceDesc%
@@ -38,7 +39,7 @@ balloon.sys  = 1,,
 ;*****************************************
 
 [Manufacturer]
-%RHEL%=Standard,NT$ARCH$
+%VENDOR%=Standard,NT$ARCH$
 
 [Standard.NT$ARCH$]
 %BALLOON.DeviceDesc%=BALLOON_Device, PCI\VEN_1AF4&DEV_1002&SUBSYS_00051AF4&REV_00
@@ -98,9 +99,8 @@ KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
 SPSVCINST_ASSOCSERVICE= 0x00000002
-RHEL = "Red Hat, Inc."
-DiskId1 = "VirtIO Balloon Installation Disk #1"
-BALLOON.DeviceDesc = "VirtIO Balloon Driver"
-BALLOON.SVCDESC = "VirtIO Balloon Service"
-ClassName       = "VirtIO Balloon Device"
-
+VENDOR = "INX_COMPANY"
+DiskId1 = "INX_PREFIX_VIRTIOVirtIO Balloon Installation Disk #1"
+BALLOON.DeviceDesc = "INX_PREFIX_VIRTIOVirtIO Balloon Driver"
+BALLOON.SVCDESC = "INX_PREFIX_VIRTIOVirtIO Balloon Service"
+ClassName       = "INX_PREFIX_VIRTIOVirtIO Balloon Device"

--- a/Balloon/sys/balloon.props
+++ b/Balloon/sys/balloon.props
@@ -1,0 +1,19 @@
+<!--
+***********************************************************************************************
+balloon.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_UsingWDF>true</Feature_UsingWDF>
+    <Feature_PackOne>true</Feature_PackOne>
+    <Feature_LegacyStampInf>true</Feature_LegacyStampInf>
+    <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <SourceInfFile>balloon.inx</SourceInfFile>
+    <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
+  </PropertyGroup>
+</Project>

--- a/Balloon/sys/balloon.rc
+++ b/Balloon/sys/balloon.rc
@@ -12,31 +12,13 @@
 #include <windows.h>
 #include <ntverp.h>
 
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat VirtIO Balloon driver"
-#define VER_INTERNALNAME_STR        "balloon.sys"
-#define VER_ORIGINALFILENAME_STR    "balloon.sys"
+#include "..\..\Tools\vendor.ver"
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2009-2016 Red Hat, Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         "Red Hat, Inc."
-
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         "Red Hat VirtIO Balloon controller"
-
-#define VER_LANGNEUTRAL
-
-#define VER_PRODUCTBUILD            _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE        _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION     _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION     _RHEL_RELEASE_VERSION_
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "VirtIO Balloon controller"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "VirtIO Balloon driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "balloon.sys"
 
 #include "common.ver"

--- a/Balloon/sys/balloon.vcxproj
+++ b/Balloon/sys/balloon.vcxproj
@@ -160,6 +160,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\balloon.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -298,6 +299,7 @@
     <ClCompile Include="utils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/Balloon/sys/balloon.vcxproj
+++ b/Balloon/sys/balloon.vcxproj
@@ -259,20 +259,8 @@
     <ClCompile>
       <DisableSpecificWarnings>4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
-    <PostBuildEvent>
-      <Command>
-        copy balloon.inx $(OutDir)\balloon.inf
-        stampinf -f $(OutDir)\balloon.inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION)
-        packOne.bat $(TargetOS) $(TargetArch) balloon "$(LegacyDDKDir)"
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(PlatformToolset)'!='v140_xp'">
-    <PostBuildEvent>
-      <Command>
-        packOne.bat $(TargetOS) $(TargetArch) balloon "$(WDKContentRoot)"
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/Balloon/sys/balloon.vcxproj.filters
+++ b/Balloon/sys/balloon.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="trace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ntddkex.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="balloon.rc">
@@ -52,7 +55,7 @@
     <ClCompile Include="Driver.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="queue.c">
+    <ClCompile Include="memstat.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="utils.c">

--- a/Tools/Driver.Common.props
+++ b/Tools/Driver.Common.props
@@ -1,55 +1,24 @@
 <!--
 ***********************************************************************************************
 Driver.Common.props
-Common property definitions used by all drivers.
+Common property definitions used by all drivers:
+    $(_NT_TARGET_MAJ)
+    $(TargetOS)
+    $(TargetArch)
+    $(InfArch)
+    including properties specific to Legacy DDK, when $(UseLegacyDDK) is true
 ***********************************************************************************************
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
-    <!-- Second component of driver version -->
-    <_RHEL_RELEASE_VERSION_ Condition="'$(_RHEL_RELEASE_VERSION_)' == ''">6</_RHEL_RELEASE_VERSION_>
-    <!-- Third component of driver version -->
-    <_BUILD_MAJOR_VERSION_ Condition="'$(_BUILD_MAJOR_VERSION_)' == ''">101</_BUILD_MAJOR_VERSION_>
-    <!-- Fourth component of driver version -->
-    <_BUILD_MINOR_VERSION_ Condition="'$(_BUILD_MINOR_VERSION_)' == ''">58000</_BUILD_MINOR_VERSION_>
-
     <!-- Define the legacy DDK directory required for downlevel targets -->
     <DDKINSTALLROOT Condition="'$(DDKINSTALLROOT)' == ''">C:\WINDDK\</DDKINSTALLROOT>
     <DDKVER Condition="'$(DDKVER)' == ''">7600.16385.1</DDKVER>
     <LegacyDDKDir>$(DDKINSTALLROOT)$(DDKVER)</LegacyDDKDir>
   </PropertyGroup>
 
-  <!-- _NT_TARGET_MAJ is the first component of driver version (always reflects target OS version) -->
-  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
-    <_NT_TARGET_MAJ>100</_NT_TARGET_MAJ>
-    <TargetOS>Win10</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Win8.1 Release' OR '$(Configuration)'=='Win8.1 Debug'">
-    <_NT_TARGET_MAJ>63</_NT_TARGET_MAJ>
-    <TargetOS>Win8.1</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Win8 Release' OR '$(Configuration)'=='Win8 Debug'">
-    <_NT_TARGET_MAJ>62</_NT_TARGET_MAJ>
-    <TargetOS>Win8</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Win7 Release' OR '$(Configuration)'=='Win7 Debug'">
-    <_NT_TARGET_MAJ>61</_NT_TARGET_MAJ>
-    <TargetOS>Win7</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Vista Release' OR '$(Configuration)'=='Vista Debug'">
-    <_NT_TARGET_MAJ>60</_NT_TARGET_MAJ>
-    <TargetOS>Wlh</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Win2k3 Release' OR '$(Configuration)'=='Win2k3 Debug'">
-    <_NT_TARGET_MAJ>52</_NT_TARGET_MAJ>
-    <TargetOS>Wnet</TargetOS>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='WinXP Release' OR '$(Configuration)'=='WinXP Debug'">
-    <_NT_TARGET_MAJ>51</_NT_TARGET_MAJ>
-    <TargetOS>Wxp</TargetOS>
-  </PropertyGroup>
-
+  <!-- $(TargetArch) -->
   <PropertyGroup Condition="'$(Platform)'=='Win32'">
     <TargetArch>x86</TargetArch>
   </PropertyGroup>
@@ -57,52 +26,43 @@ Common property definitions used by all drivers.
     <TargetArch>amd64</TargetArch>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <STAMPINF_VERSION>$(_NT_TARGET_MAJ).$(_RHEL_RELEASE_VERSION_).$(_BUILD_MAJOR_VERSION_).$(_BUILD_MINOR_VERSION_)</STAMPINF_VERSION>
-  </PropertyGroup>
-
+  <!-- _NT_TARGET_MAJ is one of the components of driver version (always reflects target OS version) -->
+  <!-- $(TargetOS) -->
   <!-- InfArch turns into the TargetOS inf file directive -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32' OR '$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">
-    <InfArch>x86.10.0</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
+    <_NT_TARGET_MAJ>100</_NT_TARGET_MAJ>
+    <TargetOS>Win10</TargetOS>
+    <InfArch>$(TargetArch).10.0</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8.1 Release|Win32' OR '$(Configuration)|$(Platform)'=='Win8.1 Debug|Win32'">
-    <InfArch>x86.6.3</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Win8.1 Release' OR '$(Configuration)'=='Win8.1 Debug'">
+    <_NT_TARGET_MAJ>63</_NT_TARGET_MAJ>
+    <TargetOS>Win8.1</TargetOS>
+    <InfArch>$(TargetArch).6.3</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32' OR '$(Configuration)|$(Platform)'=='Win8 Debug|Win32'">
-    <InfArch>x86.6.2</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Win8 Release' OR '$(Configuration)'=='Win8 Debug'">
+    <_NT_TARGET_MAJ>62</_NT_TARGET_MAJ>
+    <TargetOS>Win8</TargetOS>
+    <InfArch>$(TargetArch).6.2</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32' OR '$(Configuration)|$(Platform)'=='Win7 Debug|Win32'">
-    <InfArch>x86.6.1</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Win7 Release' OR '$(Configuration)'=='Win7 Debug'">
+    <_NT_TARGET_MAJ>61</_NT_TARGET_MAJ>
+    <TargetOS>Win7</TargetOS>
+    <InfArch>$(TargetArch).6.1</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Vista Release|Win32' OR '$(Configuration)|$(Platform)'=='Vista Debug|Win32'">
-    <InfArch>x86.6.0</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Vista Release' OR '$(Configuration)'=='Vista Debug'">
+    <_NT_TARGET_MAJ>60</_NT_TARGET_MAJ>
+    <TargetOS>Wlh</TargetOS>
+    <InfArch>$(TargetArch).6.0</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win2k3 Release|Win32' OR '$(Configuration)|$(Platform)'=='Win2k3 Debug|Win32'">
-    <InfArch>x86.5.2</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='Win2k3 Release' OR '$(Configuration)'=='Win2k3 Debug'">
+    <_NT_TARGET_MAJ>52</_NT_TARGET_MAJ>
+    <TargetOS>Wnet</TargetOS>
+    <InfArch>$(TargetArch).5.2</InfArch>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='WinXP Release|Win32' OR '$(Configuration)|$(Platform)'=='WinXP Debug|Win32'">
-    <InfArch>x86.5.1</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64' OR '$(Configuration)|$(Platform)'=='Win10 Debug|x64'">
-    <InfArch>amd64.10.0</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8.1 Release|x64' OR '$(Configuration)|$(Platform)'=='Win8.1 Debug|x64'">
-    <InfArch>amd64.6.3</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64' OR '$(Configuration)|$(Platform)'=='Win8 Debug|x64'">
-    <InfArch>amd64.6.2</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|x64' OR '$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
-    <InfArch>amd64.6.1</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Vista Release|x64' OR '$(Configuration)|$(Platform)'=='Vista Debug|x64'">
-    <InfArch>amd64.6.0</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win2k3 Release|x64' OR '$(Configuration)|$(Platform)'=='Win2k3 Debug|x64'">
-    <InfArch>amd64.5.2</InfArch>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='WinXP Release|x64' OR '$(Configuration)|$(Platform)'=='WinXP Debug|x64'">
-    <InfArch>amd64.5.1</InfArch>
+  <PropertyGroup Condition="'$(Configuration)'=='WinXP Release' OR '$(Configuration)'=='WinXP Debug'">
+    <_NT_TARGET_MAJ>51</_NT_TARGET_MAJ>
+    <TargetOS>Wxp</TargetOS>
+    <InfArch>$(TargetArch).5.1</InfArch>
   </PropertyGroup>
 
   <!-- Properties specific to the Legacy DDK -->
@@ -188,16 +148,7 @@ Common property definitions used by all drivers.
     </Link>
   </ItemDefinitionGroup>
 
-  <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <PreprocessorDefinitions>_BUILD_MAJOR_VERSION_=$(_BUILD_MAJOR_VERSION_);_BUILD_MINOR_VERSION_=$(_BUILD_MINOR_VERSION_);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);_RHEL_RELEASE_VERSION_=$(_RHEL_RELEASE_VERSION_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <ResourceCompile>
-      <PreprocessorDefinitions>_BUILD_MAJOR_VERSION_=$(_BUILD_MAJOR_VERSION_);_BUILD_MINOR_VERSION_=$(_BUILD_MINOR_VERSION_);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);_RHEL_RELEASE_VERSION_=$(_RHEL_RELEASE_VERSION_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ResourceCompile>
-    <Inf>
-      <TimeStamp>$(STAMPINF_VERSION)</TimeStamp>
-    </Inf>
-  </ItemDefinitionGroup>
+  <!-- Import vendor specific properties -->
+  <Import Project="Driver.Vendor.props" />
+
 </Project>

--- a/Tools/Driver.Common.targets
+++ b/Tools/Driver.Common.targets
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Driver.Common.targets
+Common targets used by all drivers.
+
+Features (all feature are false by default):
+  1. $(Feature_UsingWDF) - do we use WDF?
+  2. $(Feature_AdjustInf) and $(Feature_AdjustInfLegacy)
+      executes SubstituteFileContent task
+      to substitute vendor specific strings in .inf/.inx files
+      with @(Substitution) from Driver.$(_VENDOR_).props
+     $(SourceInfFile) is required for Legacy case
+  3. $(Feature_LegacyStampInf) - executes stampinf tool for Legacy DDK
+  4. $(Feature_PackOne) - Import Driver.PackOne.targets
+***********************************************************************************************
+-->
+<Project ToolVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<!--
+look at https://msdn.microsoft.com/ru-ru/library/dd722601.aspx?f=255&MSPPError=-2147217396 for an example of TokenReplace task
+look at http://blogs.clariusconsulting.net/kzu/how-to-perform-regular-expression-based-replacements-on-files-with-msbuild/ for an example of RegexTransform task
+============================================================
+            SubstituteFileContent
+Replaces text in sources files with multiple substitutions.
+required Items: SourceFiles and Substituions (with Identity/ReplaceWith metadata)
+
+Example item:
+        <Substition Include="MACRO_VENDOR">
+            <ReplaceWith>Vendor Corp.</ReplaceWith>
+        </Substition>
+
+Invoking the task:
+    <SubstituteFileContent SourceFiles="@(SourceFile)" Substituions="@(Substition)" />
+============================================================
+-->
+  <UsingTask TaskName="SubstituteFileContent"
+             TaskFactory="CodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <SourceFiles ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Substituions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Using Namespace="Microsoft.Build.Framework" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        var substitutions = new Dictionary<string,string>();
+        foreach (var item in Substituions) {
+            var replaceWhat = item.GetMetadata("Identity");
+            var replaceWith = item.GetMetadata("ReplaceWith") ?? "---";
+            substitutions.Add(replaceWhat,replaceWith);
+            Log.LogMessage(MessageImportance.High,"Adding {0}=>{1}",replaceWhat,replaceWith);
+        }
+
+        foreach (var item in SourceFiles) {
+            string fileName = item.GetMetadata("FullPath");
+            string fileNameOrig = fileName + ".orig";
+            string fileNameNew = fileName + ".new";
+            Log.LogMessage(MessageImportance.High, "Processing file {0}", fileName);
+
+            if(!File.Exists(fileName))
+            {
+                Log.LogMessage(MessageImportance.High, "Could not find file: {0}", fileName);
+                continue;
+            }
+
+            Log.LogMessage(MessageImportance.High, "Saving original context to: {0}", fileNameOrig);
+            File.Copy(fileName, fileNameOrig, true);
+
+            string content = File.ReadAllText(fileName);
+            var regex = new Regex(String.Join("|",substitutions.Keys.Select(k => Regex.Escape(k))));
+            var substituted = regex.Replace(content,m => substitutions[m.Value]);
+            File.WriteAllText(fileName, substituted);
+
+            Log.LogMessage(MessageImportance.High, "Saving replaced context to: {0}", fileNameNew);
+            File.Copy(fileName, fileNameNew, true);
+        }
+
+        return !Log.HasLoggedErrors;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Adjust inf (for WDK) -->
+  <Target Condition="'$(Feature_AdjustInf)'=='true' AND '$(UseLegacyDDK)'!='true' AND '@(Inf)' != ''" Name="AdjustInf_WDK" AfterTargets="StampInf" BeforeTargets="InfVerif">
+    <Message Text="AdjustInf_WDK: for %(Inf.FullPath) stamped as %(Inf.CopyOutput)" Importance="high" />
+    <SubstituteFileContent Condition="'%(Inf.ExcludedFromBuild)'!='true'" SourceFiles="%(Inf.CopyOutput)" Substituions="@(Substitution)" />
+  </Target>
+
+  <!-- Adjust inf (for Legacy DDK) -->
+  <Target Condition="'$(Feature_AdjustInfLegacy)'=='true' AND '$(UseLegacyDDK)'=='true'" Name="AdjustInf_LegacyDDK" BeforeTargets="AfterBuild">
+    <Message Text="AdjustInf_LegacyDDK: for $(SourceInfFile) to $(OutDir)\$(TargetName).inf" Importance="high"/>
+    <Copy SourceFiles="$(SourceInfFile)" DestinationFiles="$(OutDir)\$(TargetName).inf"/>
+    <SubstituteFileContent SourceFiles="$(OutDir)\$(TargetName).inf" Substituions="@(Substitution)"/>
+  </Target>
+
+  <!-- Stampinf (for Legacy DDK) -->
+  <Target Condition="'$(Feature_LegacyStampInf)'=='true' AND '$(UseLegacyDDK)'=='true'" Name="StampInf_LegacyDDK" AfterTargets="AdjustInf_LegacyDDK" BeforeTargets="PackOneTarget">
+    <Message Text="StampInf_LegacyDDK: for $(OutDir)\$(TargetName).inf with Feature_UsingWDF=$(Feature_UsingWDF) and STAMPINF_VERSION=$(STAMPINF_VERSION)" Importance="high"/>
+    <Exec Condition="'$(Feature_UsingWDF)'=='false'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -v $(STAMPINF_VERSION)"/>
+    <Exec Condition="'$(Feature_UsingWDF)'=='true'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION)"/>
+  </Target>
+
+  <!-- Imports -->
+  <Import Condition="'$(Feature_PackOne)'=='true'" Project="Driver.PackOne.targets" />
+
+</Project>

--- a/Tools/Driver.PackOne.targets
+++ b/Tools/Driver.PackOne.targets
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+Driver.PackOne.targets
+This file replaces packOne.bat
+Enabling feature: set $(Feature_PackOne) to true
+Cusomizing feature:
+  $(PackOne_FileName) - $(TargetName) by default
+  @(PackOne_UnsupportedOS) - always Win8.1
+  $(PackOne_WlhAddWin7Mask) - true by default
+  $(PackOne_Win7AddWlhMask) - false by default
+  $(PackOne_DestinationPrefix)
+Related features:
+  $(Feature_UsingWDF) - should we copy wdf coinstaller or not
+***********************************************************************************************
+-->
+<Project ToolVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+                       Contained
+  ============================================================
+  Invoking the task:
+      <Contained Value="$(MyValue)" Item="@(MyItem)">
+        <Output TaskParameter="Result" PropertyName="MyResult"/>
+      </Contained>
+  ============================================================
+  -->
+  <UsingTask TaskName="Contained"
+             TaskFactory="CodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <Value Required="true" />
+      <Item ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Result ParameterType="System.Boolean" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        Result = false;
+        foreach (var item in Item)
+        {
+            string curr = item.GetMetadata("Identity");
+            if (Value==curr)
+            {
+                Result = true;
+                break;
+            }
+        }
+        return true;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- checking $(TargetOS) and $(TargetArch) -->
+  <Target Condition="'$(Feature_PackOne)'=='true'" Name="CheckPackOne" BeforeTargets="PackOneTarget">
+    <ItemGroup>
+      <PackOne_ValidOS Include="Wxp;Wnet;Wlh;Win7;Win8;Win8.1;Win10"/>
+      <PackOne_ValidArch Include="x86;amd64"/>
+    </ItemGroup>
+    <Message Text="Checking PackOne: TargetOS=$(TargetOS) and TargetArch=$(TargetArch)" Importance="high"/>
+    <Contained Value="$(TargetOS)" Item="@(PackOne_ValidOS)">
+      <Output TaskParameter="Result" PropertyName="PackOne_IsValidOS"/>
+    </Contained>
+    <Contained Value="$(TargetArch)" Item="@(PackOne_ValidArch)">
+      <Output TaskParameter="Result" PropertyName="PackOne_IsValidArch"/>
+    </Contained>
+    <Contained Value="$(TargetOS)" Item="@(PackOne_UnsupportedOS)">
+      <Output TaskParameter="Result" PropertyName="PackOne_IsUnsupportedOS"/>
+    </Contained>
+    <Message Text="TODO CheckPackOne: found IsValidOS=$(PackOne_IsValidOS) and IsValidArch=$(PackOne_IsValidArch) and IsUnsupportedOS=$(PackOne_IsUnsupportedOS)" Importance="high"/>
+    <Error Text="PackOne: Wrong OS parameter $(TargetOS)" Condition="'$(PackOne_IsValidOS)'=='false'" />
+    <Error Text="PackOne: Wrong Arch parameter $(TargetArch)" Condition="'$(PackOne_IsValidArch)'=='false'" />
+    <Error Text="PackOne: Unsupported OS parameter $(TargetOS)" Condition="'$(PackOne_IsUnsupportedOS)'=='true'" />
+  </Target>
+
+  <!-- default driver name -->
+  <PropertyGroup Condition="'$(PackOne_FileName)'==''">
+    <PackOne_FileName>$(TargetName)</PackOne_FileName>
+  </PropertyGroup>
+
+  <!-- Win8.1 $(TargetOS) is unsupported by PackOne -->
+  <ItemGroup>
+    <PackOne_UnsupportedOS Include="@(PackOne_UnsupportedOS);Win8.1" />
+  </ItemGroup>
+
+  <!-- default mask customization options -->
+  <PropertyGroup Condition="'$(PackOne_WlhAddWin7Mask)'==''">
+    <PackOne_WlhAddWin7Mask>true</PackOne_WlhAddWin7Mask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PackOne_Win7AddWlhMask)'==''">
+    <PackOne_Win7AddWlhMask>false</PackOne_Win7AddWlhMask>
+  </PropertyGroup>
+
+  <!-- from packone.bat create_xp variant
+       both Wxp and Wnet drivers have mask for both Windows XP and Server2003 OSes -->
+  <PropertyGroup Condition="'$(TargetOS)'=='Wxp' AND '$(TargetArch)'=='x86'">
+    <PackOne_OsMask>XP_X86,Server2003_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wxp' AND '$(TargetArch)'=='amd64'">
+    <PackOne_OsMask>XP_X64,Server2003_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wnet' AND '$(TargetArch)'=='x86'">
+    <PackOne_OsMask>XP_X86,Server2003_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wnet' AND '$(TargetArch)'=='amd64'">
+    <PackOne_OsMask>XP_X64,Server2003_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <!-- from packone.bat create_vista variant
+       if $(PackOne_WlhAddWin7Mask) is true has mask for both Vista(Server2008) and Win7(Server2008r2)
+       default true -->
+  <PropertyGroup Condition="'$(TargetOS)'=='Wlh' AND '$(TargetArch)'=='x86' AND '$(PackOne_WlhAddWin7Mask)'=='true'">
+    <PackOne_OsMask>Vista_X86,Server2008_X86,7_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wlh' AND '$(TargetArch)'=='amd64' AND '$(PackOne_WlhAddWin7Mask)'=='true'">
+    <PackOne_OsMask>Vista_X64,Server2008_X64,7_X64,Server2008R2_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wlh' AND '$(TargetArch)'=='x86' AND '$(PackOne_WlhAddWin7Mask)'!='true'">
+    <PackOne_OsMask>Vista_X86,Server2008_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Wlh' AND '$(TargetArch)'=='amd64' AND '$(PackOne_WlhAddWin7Mask)'!='true'">
+    <PackOne_OsMask>Vista_X64,Server2008_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <!-- from packone.bat create_win7 variant
+       if $(PackOne_Win7AddWlhMask) is true has mask for both Vista(Server2008) and Win7(Server2008r2)
+       default is false -->
+  <PropertyGroup Condition="'$(TargetOS)'=='win7' AND '$(TargetArch)'=='x86' AND '$(PackOne_Win7AddWlhMask)'=='true'">
+    <PackOne_OsMask>Vista_X86,Server2008_X86,7_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='win7' AND '$(TargetArch)'=='amd64' AND '$(PackOne_Win7AddWlhMask)'=='true'">
+    <PackOne_OsMask>Vista_X64,Server2008_X64,7_X64,Server2008R2_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='win7' AND '$(TargetArch)'=='x86' AND '$(PackOne_Win7AddWlhMask)'!='true'">
+    <PackOne_OsMask>7_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='win7' AND '$(TargetArch)'=='amd64' AND '$(PackOne_Win7AddWlhMask)'!='true'">
+    <PackOne_OsMask>7_X64,Server2008R2_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <!-- from packone.bat create_win8 variant -->
+  <PropertyGroup Condition="'$(TargetOS)'=='win8' AND '$(TargetArch)'=='x86'">
+    <PackOne_OsMask>8_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='win8' AND '$(TargetArch)'=='amd64'">
+    <PackOne_OsMask>8_X64,Server8_X64</PackOne_OsMask>
+  </PropertyGroup>
+  <!-- from packone.bat create_win10 variant -->
+  <PropertyGroup Condition="'$(TargetOS)'=='win10' AND '$(TargetArch)'=='x86'">
+    <PackOne_OsMask>10_X86</PackOne_OsMask>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='win10' AND '$(TargetArch)'=='amd64'">
+    <PackOne_OsMask>10_X64,Server10_X64</PackOne_OsMask>
+  </PropertyGroup>
+
+  <!-- $(PackOne_SourcePathArch) and $(PackOne_WdfArch) -->
+  <PropertyGroup Condition="'$(TargetArch)'=='x86'">
+    <PackOne_SourcePathArch>i386</PackOne_SourcePathArch>
+    <PackOne_WdfArch>x86</PackOne_WdfArch>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetArch)'=='amd64'">
+    <PackOne_SourcePathArch>amd64</PackOne_SourcePathArch>
+    <PackOne_WdfArch>x64</PackOne_WdfArch>
+  </PropertyGroup>
+
+  <!-- $(PackOne_SourcePath) and $(PackOne_DestinationPath) -->
+  <PropertyGroup>
+    <PackOne_SourcePath>objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
+    <PackOne_DestinationPath>$(PackOne_DestinationPrefix)Install2\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
+  </PropertyGroup>
+
+  <!-- $(PackOne_CopyWdf) and $(PackOne_WdfCoinstaller) -->
+  <PropertyGroup Condition="'$(Feature_UsingWDF)'!='false'">
+    <PackOne_CopyWdf>true</PackOne_CopyWdf>
+    <PackOne_WdfCoinstaller Condition="'$(UseLegacyDDK)'=='true'">$(LegacyDDKDir)\redist\wdf\$(TargetArch)\WdfCoInstaller01009.dll</PackOne_WdfCoinstaller>
+    <PackOne_WdfCoinstaller Condition="'$(TargetOS)'=='Win7'">$(WDKContentRoot)\redist\wdf\$(PackOne_WdfArch)\WdfCoInstaller01009.dll</PackOne_WdfCoinstaller>
+    <PackOne_WdfCoinstaller Condition="'$(TargetOS)'=='Win8'">$(WDKContentRoot)\redist\wdf\$(PackOne_WdfArch)\WdfCoInstaller01011.dll</PackOne_WdfCoinstaller>
+    <PackOne_WdfCoinstaller Condition="'$(TargetOS)'=='Win10'"></PackOne_WdfCoinstaller>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Feature_UsingWDF)'=='false' OR '$(PackOne_WdfCoinstaller)'==''">
+    <PackOne_CopyWdf>false</PackOne_CopyWdf>
+  </PropertyGroup>
+
+  <!-- @(PackOne_Files) -->
+  <ItemGroup>
+    <PackOne_Files Include="$(PackOne_SourcePath)\$(PackOne_FileName).sys"/>
+    <PackOne_Files Include="$(PackOne_SourcePath)\$(PackOne_FileName).pdb"/>
+    <PackOne_Files Include="$(PackOne_SourcePath)\$(PackOne_FileName).inf"/>
+    <PackOne_Files Condition="'$(PackOne_CopyWdf)'!='false'" Include="$(PackOne_WdfCoinstaller)"/>
+  </ItemGroup>
+
+  <!-- PackOne target (executing AfterBuild)-->
+  <Target Condition="'$(Feature_PackOne)'=='true'" Name="PackOneTarget" AfterTargets="AfterBuild">
+    <Message Text="PackOneTarget $(TargetOS) $(TargetArch) $(PackOne_FileName)" Importance="high"/>
+    <Message Text="Copying PackOne_Files=%(PackOne_Files.Identity) to $(PackOne_DestinationPath)" Importance="high"/>
+    <MakeDir Directories="$(PackOne_DestinationPath)"/>
+    <Delete Files="$(PackOne_DestinationPath)\*"/>
+    <Copy SourceFiles="@(PackOne_Files)"
+          DestinationFolder="$(PackOne_DestinationPath)"/>
+    <Message Text="Setting OS mask for: $(TargetOS) $(TargetArch) to $(PackOne_OsMask)" Importance="high"/>
+    <Exec Command="inf2cat /driver:$(PackOne_DestinationPath) /os:$(PackOne_OsMask)" />
+  </Target>
+
+</Project>

--- a/Tools/Driver.PackOne.targets
+++ b/Tools/Driver.PackOne.targets
@@ -165,7 +165,7 @@ Related features:
   <!-- $(PackOne_SourcePath) and $(PackOne_DestinationPath) -->
   <PropertyGroup>
     <PackOne_SourcePath>objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
-    <PackOne_DestinationPath>$(PackOne_DestinationPrefix)Install2\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
+    <PackOne_DestinationPath>$(PackOne_DestinationPrefix)Install\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
   </PropertyGroup>
 
   <!-- $(PackOne_CopyWdf) and $(PackOne_WdfCoinstaller) -->

--- a/Tools/Driver.RHEL.props
+++ b/Tools/Driver.RHEL.props
@@ -1,0 +1,31 @@
+<!--
+***********************************************************************************************
+Driver.RHEL.props
+RHEL inf substitutions and versioning used by all drivers.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <!-- Second component of driver version -->
+    <_RHEL_RELEASE_VERSION_ Condition="'$(_RHEL_RELEASE_VERSION_)' == ''">6</_RHEL_RELEASE_VERSION_>
+    <!-- Third component of driver version -->
+    <_BUILD_MAJOR_VERSION_ Condition="'$(_BUILD_MAJOR_VERSION_)' == ''">101</_BUILD_MAJOR_VERSION_>
+    <!-- Fourth component of driver version -->
+    <_BUILD_MINOR_VERSION_ Condition="'$(_BUILD_MINOR_VERSION_)' == ''">58000</_BUILD_MINOR_VERSION_>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <STAMPINF_VERSION>$(_NT_TARGET_MAJ).$(_RHEL_RELEASE_VERSION_).$(_BUILD_MAJOR_VERSION_).$(_BUILD_MINOR_VERSION_)</STAMPINF_VERSION>
+  </PropertyGroup>
+
+  <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_BUILD_MAJOR_VERSION_=$(_BUILD_MAJOR_VERSION_);_BUILD_MINOR_VERSION_=$(_BUILD_MINOR_VERSION_);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);_RHEL_RELEASE_VERSION_=$(_RHEL_RELEASE_VERSION_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_BUILD_MAJOR_VERSION_=$(_BUILD_MAJOR_VERSION_);_BUILD_MINOR_VERSION_=$(_BUILD_MINOR_VERSION_);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);_RHEL_RELEASE_VERSION_=$(_RHEL_RELEASE_VERSION_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/Tools/Driver.RHEL.props
+++ b/Tools/Driver.RHEL.props
@@ -28,4 +28,25 @@ RHEL inf substitutions and versioning used by all drivers.
       <PreprocessorDefinitions>_BUILD_MAJOR_VERSION_=$(_BUILD_MAJOR_VERSION_);_BUILD_MINOR_VERSION_=$(_BUILD_MINOR_VERSION_);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);_RHEL_RELEASE_VERSION_=$(_RHEL_RELEASE_VERSION_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <Substitution Include="INX_COPYRIGHT_1">
+      <ReplaceWith>Copyright (c) 2009-2017 Red Hat Inc.</ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_COPYRIGHT_2">
+      <ReplaceWith></ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_COMPANY">
+      <ReplaceWith>Red Hat, Inc.</ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_VENDOR">
+      <ReplaceWith>Red Hat </ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_VIRTIO">
+      <ReplaceWith></ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_QEMU">
+      <ReplaceWith></ReplaceWith>
+    </Substitution>
+  </ItemGroup>
 </Project>

--- a/Tools/Driver.VZ.props
+++ b/Tools/Driver.VZ.props
@@ -1,0 +1,43 @@
+<!--
+***********************************************************************************************
+Driver.VZ.props
+VZ inf substitutions and versioning used by all drivers.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <!-- custom variant -->
+  <PropertyGroup Condition="'$(VZ_RELEASE_N)'==''">
+    <VZ_RELEASE_A>1</VZ_RELEASE_A>
+    <VZ_RELEASE_B>1</VZ_RELEASE_B>
+    <VZ_RELEASE_C>0</VZ_RELEASE_C>
+  </PropertyGroup>
+  <!-- experimental variant -->
+  <PropertyGroup Condition="'$(VZ_RELEASE_N)'!='' AND '$(VZ_RELEASE_N)'!='0'">
+    <VZ_RELEASE_A>1</VZ_RELEASE_A>
+    <VZ_RELEASE_B>2</VZ_RELEASE_B>
+    <VZ_RELEASE_C>$(VZ_RELEASE_N)</VZ_RELEASE_C>
+  </PropertyGroup>
+  <!-- build variant -->
+  <PropertyGroup Condition="'$(VZ_RELEASE_N)'=='0'">
+    <VZ_RELEASE_A Condition="'$(VZ_RELEASE_A)'==''">1</VZ_RELEASE_A>
+    <VZ_RELEASE_B Condition="'$(VZ_RELEASE_B)'==''">3</VZ_RELEASE_B>
+    <VZ_RELEASE_C Condition="'$(VZ_RELEASE_C)'==''">0</VZ_RELEASE_C>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <STAMPINF_VERSION>$(VZ_RELEASE_A).$(VZ_RELEASE_B).$(VZ_RELEASE_C).$(_NT_TARGET_MAJ)</STAMPINF_VERSION>
+  </PropertyGroup>
+
+  <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(VZ_RELEASE_N)'!=''">VZ_RELEASE_N=$(VZ_RELEASE_N);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VZ_RELEASE_A=$(VZ_RELEASE_A);VZ_RELEASE_B=$(VZ_RELEASE_B);VZ_RELEASE_C=$(VZ_RELEASE_C);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions Condition="'$(VZ_RELEASE_N)'!=''">VZ_RELEASE_N=$(VZ_RELEASE_N);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VZ_RELEASE_A=$(VZ_RELEASE_A);VZ_RELEASE_B=$(VZ_RELEASE_B);VZ_RELEASE_C=$(VZ_RELEASE_C);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/Tools/Driver.VZ.props
+++ b/Tools/Driver.VZ.props
@@ -40,4 +40,25 @@ VZ inf substitutions and versioning used by all drivers.
       <PreprocessorDefinitions>VZ_RELEASE_A=$(VZ_RELEASE_A);VZ_RELEASE_B=$(VZ_RELEASE_B);VZ_RELEASE_C=$(VZ_RELEASE_C);_NT_TARGET_MAJ=$(_NT_TARGET_MAJ);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <Substitution Include="INX_COPYRIGHT_1">
+      <ReplaceWith>Copyright (c) 2009-2017 Red Hat Inc.</ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_COPYRIGHT_2">
+      <ReplaceWith>Copyright (c) 2016-2017 Parallels IP Holdings GmbH</ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_COMPANY">
+      <ReplaceWith>Parallels IP Holdings GmbH</ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_VENDOR">
+      <ReplaceWith>Virtuozzo </ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_VIRTIO">
+      <ReplaceWith>Virtuozzo </ReplaceWith>
+    </Substitution>
+    <Substitution Include="INX_PREFIX_QEMU">
+      <ReplaceWith>Virtuozzo </ReplaceWith>
+    </Substitution>
+  </ItemGroup>
 </Project>

--- a/Tools/Driver.Vendor.props
+++ b/Tools/Driver.Vendor.props
@@ -1,0 +1,44 @@
+<!--
+***********************************************************************************************
+Driver.Vendor.props
+
+1. Uses RHEL as default vendor.
+Set $(Feature_AlwaysDefaultVendor) to false and set $(_VENDOR_) to override.
+
+2. Vendors' macros for .rc and property definitions for MSBuild used by all drivers:
+    VENDOR_VER <= $(_VENDOR_).ver
+    VER_OS     <= $(TargetOS)
+    VER_ARCH   <= $(TargetArch)
+
+3. Imports inf substitutions and versioning specific to vendor from Driver.$(_VENDOR_).props
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_VENDOR_ Condition="'$(_VENDOR_)'=='' OR '$(Feature_AlwaysDefaultVendor)'!='false'">RHEL</_VENDOR_>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetArch)'=='x86'">
+    <VerArch>x86</VerArch>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetArch)'=='amd64'">
+    <VerArch>x64</VerArch>
+  </PropertyGroup>
+
+  <Import Project="Driver.$(_VENDOR_).props" />
+
+  <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>VENDOR_VER=$(_VENDOR_).ver;VER_OS=$(TargetOS);VER_ARCH=$(VerArch);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VENDOR_VER=$(_VENDOR_).ver;VER_OS=$(TargetOS);VER_ARCH=$(VerArch);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Inf>
+      <TimeStamp>$(STAMPINF_VERSION)</TimeStamp>
+    </Inf>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/Tools/readme_msbuild.txt
+++ b/Tools/readme_msbuild.txt
@@ -1,0 +1,15 @@
+https://blogs.msdn.microsoft.com/visualstudio/2010/05/14/a-guide-to-vcxproj-and-props-file-structure/
+
+https://chrisa.wordpress.com/2014/07/18/customising-your-build-process/ - how to detail output window
+https://msdn.microsoft.com/ru-ru/library/ms171458.aspx - properties $
+https://msdn.microsoft.com/ru-ru/library/ms171453.aspx - elements @ aka ItemGroup
+https://msdn.microsoft.com/ru-ru/library/ms171462.aspx - targets
+https://msdn.microsoft.com/ru-ru/library/ms171466.aspx - tasks
+https://msdn.microsoft.com/ru-ru/library/ms164307.aspx - element Choose
+https://msdn.microsoft.com/en-us/ms164313.aspx?f=255&MSPPError=-2147217396 - well known item metadata
+https://msdn.microsoft.com/en-us/library/ms171473(VS.80).aspx - % batching
+https://msdn.microsoft.com/en-us/library/ms171474%28v=vs.80%29.aspx?f=255&MSPPError=-2147217396 - % batching
+https://msdn.microsoft.com/en-us/library/ms228229(v=vs.80).aspx - % batching
+https://msdn.microsoft.com/en-us/library/ms171476(v=vs.80).aspx - -> transforms
+https://msdn.microsoft.com/en-us/library/bb383819.aspx - special characters @,%,$
+https://msdn.microsoft.com/en-us/library/dd997067.aspx - comparing propetires and items

--- a/Tools/rhel.ver
+++ b/Tools/rhel.ver
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (c) 2017  Parallels IP Holdings GmbH
+ *
+ * File: rhel.ver
+ *
+ * This file contains rhel vendor specific
+ * resource (version) definitions for all drivers
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ *
+**********************************************************************/
+
+/*
+ * rhel versioning
+ */
+#define VENDOR_VIRTIO_1            _NT_TARGET_MAJ
+#define VENDOR_VIRTIO_2            _RHEL_RELEASE_VERSION_
+#define VENDOR_VIRTIO_3            _BUILD_MAJOR_VERSION_
+#define VENDOR_VIRTIO_4            _BUILD_MINOR_VERSION_
+
+/*
+ * rhel strings
+ */
+#define VENDOR_VIRTIO_COPYRIGHT    "Copyright (C) 2008-2017 Red Hat, Inc."
+#define VENDOR_VIRTIO_COMPANY      "Red Hat,\040Inc."
+#define VENDOR_PREFIX              "Red Hat\040"
+#define VENDOR_PRODUCT_PREFIX      VENDOR_PREFIX
+#define QEMU_PRODUCT_PREFIX        "QEMU\040"
+#define VENDOR_DESC_PREFIX         VENDOR_PREFIX
+#define VENDOR_DESC_POSTFIX        ""
+
+/*
+ * remaining macro should be defined in project .rc file
+ *
+ * VENDOR_VIRTIO_PRODUCT, VER_FILEDESCRIPTION_STR, VER_INTERNALNAME_STR
+ */

--- a/Tools/rhel.ver
+++ b/Tools/rhel.ver
@@ -12,6 +12,16 @@
 **********************************************************************/
 
 /*
+ * These defines are only for Visual Studio built-in rc editor
+ */
+#ifndef _NT_TARGET_MAJ
+    #define _NT_TARGET_MAJ 1
+    #define _RHEL_RELEASE_VERSION_ 20
+    #define _BUILD_MAJOR_VERSION_ 300
+    #define _BUILD_MINOR_VERSION_ 5800
+#endif
+
+/*
  * rhel versioning
  */
 #define VENDOR_VIRTIO_1            _NT_TARGET_MAJ

--- a/Tools/vendor.check.h
+++ b/Tools/vendor.check.h
@@ -1,0 +1,29 @@
+/* Some test definition here */
+#define DEFINED_BUT_NO_VALUE
+#define DEFINED_INT 3
+#define DEFINED_STR "ABC"
+
+/* definition to expand macro then apply to pragma message */
+#define VALUE_TO_STRING(x) #x
+#define VALUE(x) VALUE_TO_STRING(x)
+#define VAR_NAME_VALUE(var) #var "="  VALUE(var)
+
+#pragma warning(disable:4003)
+/* Some example here */
+//#pragma message(VAR_NAME_VALUE(NOT_DEF) )
+//#pragma message(VAR_NAME_VALUE(DEFINED_BUT_NO_VALUE) )
+//#pragma message(VAR_NAME_VALUE(DEFINED_INT) )
+//#pragma message(VAR_NAME_VALUE(DEFINED_STR) )
+
+#pragma message(VAR_NAME_VALUE(VZ_RELEASE_N) )
+#pragma message(VAR_NAME_VALUE(VZ_RELEASE_A) )
+#pragma message(VAR_NAME_VALUE(VZ_RELEASE_B) )
+#pragma message(VAR_NAME_VALUE(VZ_RELEASE_C) )
+
+#pragma message(VAR_NAME_VALUE(_NT_TARGET_MAJ) )
+#pragma message(VAR_NAME_VALUE(_RHEL_RELEASE_VERSION_) )
+#pragma message(VAR_NAME_VALUE(_BUILD_MAJOR_VERSION_) )
+#pragma message(VAR_NAME_VALUE(_BUILD_MINOR_VERSION_) )
+
+#pragma message(VAR_NAME_VALUE(NTDDI_VERSION) )
+//#error STOP

--- a/Tools/vendor.ver
+++ b/Tools/vendor.ver
@@ -12,6 +12,24 @@
 **********************************************************************/
 
 /*
+ * These defines are only for Visual Studio built-in rc editor
+ *
+ * VER_OS <= $(TargetOS) for description postfix
+ * VER_ARCH <= $(VerArch) for description postfix
+ * VENDOR_VER <= $(_VENDOR_).ver (rhel by default)
+ */
+#ifndef VER_OS
+    #define VER_OS Win??
+#endif
+#ifndef VER_ARCH
+    #define VER_ARCH x??
+#endif
+#ifndef VENDOR_VER
+    #define VENDOR_VER rhel.ver
+    //#define VENDOR_VER vz.ver
+#endif
+
+/*
  * AUTO: these defines are defined in common.ver
  *    VER_PRODUCTVERSION          <= VER_PRODUCTMAJORVERSION,VER_PRODUCTMINORVERSION,VER_PRODUCTBUILD,VER_PRODUCTBUILD_QFE
  *    VER_FILEVERSION             <= VER_PRODUCTVERSION

--- a/Tools/vendor.ver
+++ b/Tools/vendor.ver
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (c) 2017  Parallels IP Holdings GmbH
+ *
+ * File: vendor.ver
+ *
+ * This file contains resource (version) definitions for all drivers
+ * that are independent from vendor.
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ *
+**********************************************************************/
+
+/*
+ * AUTO: these defines are defined in common.ver
+ *    VER_PRODUCTVERSION          <= VER_PRODUCTMAJORVERSION,VER_PRODUCTMINORVERSION,VER_PRODUCTBUILD,VER_PRODUCTBUILD_QFE
+ *    VER_FILEVERSION             <= VER_PRODUCTVERSION
+ *    VER_FILEVERSION_STR         <= VER_PRODUCTVERSION_STR
+ *    VER_ORIGINALFILENAME_STR    <= VER_INTERNALNAME_STR
+ */
+
+/*
+ * COMMON: these defines are strictly required
+ */
+#define VER_LANGNEUTRAL
+#define VER_FILETYPE                VFT_DRV
+#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
+#define VER_FILEDESCRIPTION_STR     "File Description required"
+#define VER_INTERNALNAME_STR        "File Name required"
+
+/*
+ * STRINGIFY
+ */
+#define STRINGIFY_AUX(X) #X
+#define STRINGIFY(X)     STRINGIFY_AUX(X)
+
+/*
+ * VENDOR SPECIFIC
+ */
+#include STRINGIFY(VENDOR_VER)
+
+/*
+ * Applying vendor specific
+ */
+#undef  VER_PRODUCTBUILD
+#undef  VER_PRODUCTBUILD_QFE
+#undef  VER_PRODUCTMAJORVERSION
+#undef  VER_PRODUCTMINORVERSION
+
+#define VER_PRODUCTMAJORVERSION    VENDOR_VIRTIO_1
+#define VER_PRODUCTMINORVERSION    VENDOR_VIRTIO_2
+#define VER_PRODUCTBUILD           VENDOR_VIRTIO_3
+#define VER_PRODUCTBUILD_QFE       VENDOR_VIRTIO_4
+
+#undef  VER_LEGALTRADEMARKS_STR
+#undef  VER_LEGALCOPYRIGHT_STR
+#undef  VER_COMPANYNAME_STR
+#undef  VER_PRODUCTNAME_STR
+
+#define VER_LEGALTRADEMARKS_STR    ""
+#define VER_LEGALCOPYRIGHT_STR     VENDOR_VIRTIO_COPYRIGHT
+#define VER_COMPANYNAME_STR        VENDOR_VIRTIO_COMPANY
+#define VER_PRODUCTNAME_STR        VENDOR_VIRTIO_PRODUCT

--- a/Tools/vz.ver
+++ b/Tools/vz.ver
@@ -12,6 +12,16 @@
 **********************************************************************/
 
 /*
+ * These defines are only for Visual Studio built-in rc editor
+ */
+#ifndef _NT_TARGET_MAJ
+    #define VZ_RELEASE_A 1
+    #define VZ_RELEASE_B 20
+    #define VZ_RELEASE_C 300
+    #define _NT_TARGET_MAJ 4000
+#endif
+
+/*
  * vz build variants
  */
 #ifndef VZ_RELEASE_N

--- a/Tools/vz.ver
+++ b/Tools/vz.ver
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (c) 2017  Parallels IP Holdings GmbH
+ *
+ * File: vz.ver
+ *
+ * This file contains vz vendor specific
+ * resource (version) definitions for all drivers
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ *
+**********************************************************************/
+
+/*
+ * vz build variants
+ */
+#ifndef VZ_RELEASE_N
+    //custom
+    #define VENDOR_DESC_PREFIX  "Custom\040"
+    #define VENDOR_DESC_POSTFIX "\040" STRINGIFY(VER_OS) "\040for\040" STRINGIFY(VER_ARCH)
+#elif (VZ_RELEASE_N != 0)
+    //experimental
+    #define VENDOR_DESC_PREFIX  "Experimental\040"
+    #define VENDOR_DESC_POSTFIX "\040" STRINGIFY(VER_OS) "\040for\040" STRINGIFY(VER_ARCH)
+#elif (VZ_RELEASE_N == 0)
+    //build
+    #define VENDOR_DESC_PREFIX  VENDOR_PREFIX
+    #define VENDOR_DESC_POSTFIX "\040(" STRINGIFY(VER_ARCH) ")"
+#endif
+
+/*
+ * vz versioning
+ */
+#define VENDOR_VIRTIO_1 VZ_RELEASE_A
+#define VENDOR_VIRTIO_2 VZ_RELEASE_B
+#define VENDOR_VIRTIO_3 VZ_RELEASE_C
+#define VENDOR_VIRTIO_4 _NT_TARGET_MAJ
+
+/*
+ * vz strings
+ */
+#define VENDOR_VIRTIO_COPYRIGHT    "Copyright (c) 2016-2017 Parallels IP Holdings GmbH"
+#define VENDOR_VIRTIO_COMPANY      "Parallels IP Holdings GmbH"
+#define VENDOR_PREFIX              "Virtuozzo\040"
+#define VENDOR_PRODUCT_PREFIX      VENDOR_PREFIX
+#define QEMU_PRODUCT_PREFIX        VENDOR_PREFIX "QEMU\040"
+
+/*
+ * remaining macro should be defined in project .rc file
+ *
+ * VENDOR_VIRTIO_PRODUCT, VER_FILEDESCRIPTION_STR, VER_INTERNALNAME_STR
+ */

--- a/pvpanic/PVPanic Package/PVPanic Package.vcxproj
+++ b/pvpanic/PVPanic Package/PVPanic Package.vcxproj
@@ -152,6 +152,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\pvpanic.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -244,6 +245,7 @@
     <Inf Include="..\pvpanic\pvpanic.inf" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/pvpanic/PVPanic Package/pvpanic.props
+++ b/pvpanic/PVPanic Package/pvpanic.props
@@ -1,0 +1,13 @@
+<!--
+***********************************************************************************************
+pvpanic.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+  </PropertyGroup>
+</Project>

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -25,6 +25,7 @@
 
 #include "pvpanic.h"
 #include "pvpanic.tmh"
+#include "..\..\Tools\vendor.check.h"
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(INIT, DriverEntry)

--- a/pvpanic/pvpanic/pvpanic.inf
+++ b/pvpanic/pvpanic/pvpanic.inf
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2015-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    pvpanic.inf
@@ -16,10 +17,10 @@
 Signature       = "$WINDOWS NT$"
 Class           = System
 ClassGuid       = {4d36e97d-e325-11ce-bfc1-08002be10318}
-Provider        = %RedHatMfg%
+Provider        = %VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile     = pvpanic.cat
 PnpLockdown     = 1
-DriverVer       = 02/20/2015,1.0.0.0
 
 [DestinationDirs]
 DefaultDestDir = 12
@@ -35,9 +36,9 @@ pvpanic.sys = 1,,
 ; ---------------
 
 [Manufacturer]
-%RedHatMfg% = RedHat,NT$ARCH$
+%VENDOR% = Vendor,NT$ARCH$
 
-[RedHat.NT$ARCH$]
+[Vendor.NT$ARCH$]
 %PVPanic.DeviceDesc% = PVPanic_Device, ACPI\QEMU0001
 
 [PVPanic_Device.NT]
@@ -88,7 +89,7 @@ KmdfService = PVPanic, PVPanic_wdfsect
 KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
-RedHatMfg           = "Red Hat, Inc."
-DiskName            = "QEMU PVPanic Installation Disk"
-PVPanic.DeviceDesc  = "QEMU PVPanic Device"
-PVPanic.Service     = "QEMU PVPanic Service"
+VENDOR = "INX_COMPANY"
+DiskName            = "INX_PREFIX_QEMUQEMU PVPanic Installation Disk"
+PVPanic.DeviceDesc  = "INX_PREFIX_QEMUQEMU PVPanic Device"
+PVPanic.Service     = "INX_PREFIX_QEMUQEMU PVPanic Service"

--- a/pvpanic/pvpanic/pvpanic.rc
+++ b/pvpanic/pvpanic/pvpanic.rc
@@ -28,31 +28,13 @@
 #include <windows.h>
 #include <ntverp.h>
 
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat PVPanic Driver"
-#define VER_INTERNALNAME_STR        "pvpanic.sys"
-#define VER_ORIGINALFILENAME_STR    "pvpanic.sys"
+#include "..\..\Tools\vendor.ver"
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2015-2016 Red Hat Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         "Red Hat Inc."
-
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         "QEMU PVPanic Device"
-
-#define VER_LANGNEUTRAL
-
-#define VER_PRODUCTBUILD                _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE            _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION         _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION         _RHEL_RELEASE_VERSION_
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "PVPanic Device"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "PVPanic Driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "pvpanic.sys"
 
 #include "common.ver"

--- a/vioinput/sys/Driver.c
+++ b/vioinput/sys/Driver.c
@@ -14,6 +14,7 @@
 
 #include "precomp.h"
 #include "vioinput.h"
+#include "..\..\Tools\vendor.check.h"
 
 #if defined(EVENT_TRACING)
 #include "Driver.tmh"

--- a/vioinput/sys/vioinput.inx
+++ b/vioinput/sys/vioinput.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    vioinput.inf
@@ -16,8 +17,8 @@
 Signature="$WINDOWS NT$"
 Class=HIDClass
 ClassGuid={745a17a0-74d3-11d0-b6fe-00a0c90f57da}
-Provider=%REDHAT%
-DriverVer=01/22/2016,6.0.1000.10000
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=vioinput.cat
 DriverPackageType = PlugAndPlay
 DriverPackageDisplayName = %VirtioInput.DeviceDesc%
@@ -48,7 +49,7 @@ viohidkmdf.sys = 1,,
 ;*****************************************
 
 [Manufacturer]
-%REDHAT%=VirtioInput,NT$ARCH$
+%VENDOR%=VirtioInput,NT$ARCH$
 
 [VirtioInput.NT$ARCH$]
 ;
@@ -116,7 +117,7 @@ KmdfService =  VirtioInput, VirtioInput_wdfsect
 KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
-REDHAT = "Red Hat, Inc."
-DiskId1 = "VirtIO Input Installation Disk #1"
-VirtioInput.DeviceDesc = "VirtIO Input Driver"
-VirtioInput.ServiceDesc = "VirtIO Input Service"
+VENDOR = "INX_COMPANY"
+DiskId1 = "INX_PREFIX_VIRTIOVirtIO Input Installation Disk #1"
+VirtioInput.DeviceDesc = "INX_PREFIX_VIRTIOVirtIO Input Driver"
+VirtioInput.ServiceDesc = "INX_PREFIX_VIRTIOVirtIO Input Service"

--- a/vioinput/sys/vioinput.props
+++ b/vioinput/sys/vioinput.props
@@ -1,0 +1,25 @@
+<!--
+***********************************************************************************************
+vioinput.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_UsingWDF>true</Feature_UsingWDF>
+    <Feature_PackOne>true</Feature_PackOne>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <!-- there was only Server2008_Xnn mask without VISTA_Xnn in packone.bat
+         for Win7 and this is wrong
+         either remove it (set feature below to false)
+         or keep VISTA masks too (set feature to true) -->
+    <PackOne_Win7AddWlhMask>true</PackOne_Win7AddWlhMask>
+    <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackOne_UnsupportedOS Include="@(PackOne_UnsupportedOS);Wxp;Wnet;Wlh" />
+  </ItemGroup>
+</Project>

--- a/vioinput/sys/vioinput.rc
+++ b/vioinput/sys/vioinput.rc
@@ -12,32 +12,13 @@
 #include <windows.h>
 #include <ntverp.h>
 
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat VirtIO Input driver"
-#define VER_INTERNALNAME_STR        "vioinput.sys"
-#define VER_ORIGINALFILENAME_STR    "vioinput.sys"
+#include "..\..\Tools\vendor.ver"
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2016 Red Hat, Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         "Red Hat, Inc."
-
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         "Red Hat VirtIO Input controller"
-
-#define VER_LANGNEUTRAL
-
-#define VER_PRODUCTBUILD            _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE        _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION     _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION     _RHEL_RELEASE_VERSION_
-
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "VirtIO Input controller"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "VirtIO Input driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "vioinput.sys"
 
 #include "common.ver"

--- a/vioinput/sys/vioinput.vcxproj
+++ b/vioinput/sys/vioinput.vcxproj
@@ -162,11 +162,6 @@
       <Version>6.1</Version>
       <AdditionalOptions>/osversion:6.1 %(AdditionalOptions)</AdditionalOptions>
     </Link>
-    <PostBuildEvent>
-      <Command>
-        packOne.bat $(TargetOS) $(TargetArch) vioinput "$(WDKContentRoot)"
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/vioinput/sys/vioinput.vcxproj
+++ b/vioinput/sys/vioinput.vcxproj
@@ -97,6 +97,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\vioinput.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -202,6 +203,7 @@
     <ClCompile Include="utils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/vioscsi/resources.h
+++ b/vioscsi/resources.h
@@ -21,7 +21,7 @@
 #define MODEL                         L"VirtIO-SCSI"
 #define MODELDESCRIPTION              L"Red Hat VirtIO SCSI pass-through controller"
 #define HARDWAREVERSION               L"v1.0"
-#define DRIVERVERSION                 _BUILD_MAJOR_VERSION_
+#define DRIVERVERSION                 VENDOR_VIRTIO_3
 //#define OPTIONROMVERSION              L"OptionROMVersion"
 #define FIRMWAREVERSION               L"v1.0"
 #define DRIVERNAME                    L"vioscsi.sys"

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -16,6 +16,7 @@
 #include "utils.h"
 #include "helper.h"
 #include "vioscsidt.h"
+#include "..\Tools\vendor.check.h"
 
 #define MS_SM_HBA_API
 #include <hbapiwmi.h>
@@ -26,7 +27,7 @@
 #define VioScsiWmi_MofResourceName        L"MofResource"
 
 #include "resources.h"
-
+#include "..\Tools\vendor.ver"
 
 #define VIOSCSI_SETUP_GUID_INDEX 0
 #define VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX 1

--- a/vioscsi/vioscsi.inx
+++ b/vioscsi/vioscsi.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2012-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    vioscsi.inf
@@ -17,11 +18,11 @@
 Signature="$Windows NT$"
 Class=SCSIAdapter
 ClassGUID={4D36E97B-E325-11CE-BFC1-08002BE10318}
-Provider=%RHEL%
-DriverVer=05/03/2010,6.0.6001.16640
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=vioscsi.cat
 DriverPackageType = PlugAndPlay
-DriverPackageDisplayName = %RHELScsi.DeviceDesc%
+DriverPackageDisplayName = %VENDOR.DeviceDesc%
 
 ;
 ; Source file information
@@ -45,11 +46,11 @@ vioscsi_Files_Driver = 12
 ;
 
 [Manufacturer]
-%RHEL%   = RHEL,NT$ARCH$
+%VENDOR%   = VENDOR,NT$ARCH$
 
-[RHEL.NT$ARCH$]
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1004&SUBSYS_00081AF4&REV_00
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1048&SUBSYS_11001AF4&REV_01
+[VENDOR.NT$ARCH$]
+%VENDOR.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1004&SUBSYS_00081AF4&REV_00
+%VENDOR.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1048&SUBSYS_11001AF4&REV_01
 
 ;
 ; General installation section
@@ -58,17 +59,18 @@ vioscsi_Files_Driver = 12
 [vioscsi_Files_Driver]
 vioscsi.sys,,,2
 
-[rhelscsi_inst]
+[scsi_inst]
 CopyFiles=vioscsi_Files_Driver
 
 ;
 ; Service Installation
 ;
 
-[rhelscsi_inst.Services]
-AddService = vioscsi, 0x00000002 , rhelscsi_Service_Inst, rhelscsi_EventLog_Inst
+[scsi_inst.Services]
+AddService = vioscsi, 0x00000002 , scsi_Service_Inst, scsi_EventLog_Inst
 
-[rhelscsi_Service_Inst]
+[scsi_Service_Inst]
+DisplayName    = %VENDOR.SVCDESC%
 ServiceType    = %SERVICE_KERNEL_DRIVER%
 StartType      = %SERVICE_BOOT_START%
 ErrorControl   = %SERVICE_ERROR_NORMAL%
@@ -76,13 +78,13 @@ ServiceBinary  = %12%\vioscsi.sys
 LoadOrderGroup = SCSI miniport
 AddReg         = pnpsafe_pci_addreg
 
-[rhelscsi_inst.HW]
+[scsi_inst.HW]
 AddReg         = pnpsafe_pci_addreg_msix
 
-[rhelscsi_EventLog_Inst]
-AddReg = rhelscsi_EventLog_AddReg
+[scsi_EventLog_Inst]
+AddReg = scsi_EventLog_AddReg
 
-[rhelscsi_EventLog_AddReg]
+[scsi_EventLog_AddReg]
 HKR,,EventMessageFile,%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\IoLogMsg.dll"
 HKR,,TypesSupported,%REG_DWORD%,7
 
@@ -105,9 +107,10 @@ HKR, "Interrupt Management\Affinity Policy", DevicePriority, 0x00010001, 3
 ;
 ; Localizable Strings
 ;
-diskId1 = "Red Hat VirtIO SCSI pass-through controller Installation Disk"
-RHELScsi.DeviceDesc = "Red Hat VirtIO SCSI pass-through controller"
-RHEL = "Red Hat, Inc."
+VENDOR = "INX_COMPANY"
+diskId1 = "INX_PREFIX_VENDORVirtIO SCSI pass-through controller Installation Disk"
+VENDOR.DeviceDesc = "INX_PREFIX_VENDORVirtIO SCSI pass-through controller"
+VENDOR.SVCDESC = "INX_PREFIX_VENDORVirtIO SCSI pass-through Service"
 
 ;
 ; Non-Localizable Strings
@@ -118,4 +121,3 @@ REG_DWORD      = 0x00010001
 SERVICE_KERNEL_DRIVER  = 1
 SERVICE_BOOT_START     = 0
 SERVICE_ERROR_NORMAL   = 1
-

--- a/vioscsi/vioscsi.props
+++ b/vioscsi/vioscsi.props
@@ -1,0 +1,27 @@
+<!--
+***********************************************************************************************
+vioscsi.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_UsingWDF>false</Feature_UsingWDF>
+    <Feature_PackOne>true</Feature_PackOne>
+    <Feature_LegacyStampInf>true</Feature_LegacyStampInf>
+    <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <!-- there was only Server2008_Xnn mask without VISTA_Xnn in packone.bat
+         for Win7 and this is wrong
+         either remove it (set feature below to false)
+         or keep VISTA masks too (set feature to true) -->
+    <PackOne_Win7AddWlhMask>false</PackOne_Win7AddWlhMask>
+    <SourceInfFile>vioscsi.inx</SourceInfFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackOne_UnsupportedOS Include="@(PackOne_UnsupportedOS);Wxp;Wnet" />
+  </ItemGroup>
+</Project>

--- a/vioscsi/vioscsi.rc
+++ b/vioscsi/vioscsi.rc
@@ -11,33 +11,16 @@
 **********************************************************************/
 #include <windows.h>
 #include <ntverp.h>
+
 #include "resources.h"
+#include "..\Tools\vendor.ver"
 
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat VirtIO SCSI pass-through driver"
-#define VER_INTERNALNAME_STR        DRIVERNAME
-#define VER_ORIGINALFILENAME_STR    DRIVERNAME
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
-
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2012-2016 Red, Hat Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         MANUFACTURER
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         HBASYMBOLICNAME
-
-#define VER_LANGNEUTRAL
-
-#define VER_PRODUCTBUILD            _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE        _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION     _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION     _RHEL_RELEASE_VERSION_
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "VirtIO SCSI pass-through controller"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "VirtIO SCSI pass-through driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "vioscsi.sys"
 
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 MOFRESOURCE MOFDATA MOVEABLE PURE   "vioscsi.bmf"

--- a/vioscsi/vioscsi.vcxproj
+++ b/vioscsi/vioscsi.vcxproj
@@ -205,20 +205,8 @@
         wmimofck -t$(OutDir)\vioscsi.vbs $(OutDir)\vioscsi.bmf
       </Command>
     </PreBuildEvent>
-    <PostBuildEvent>
-      <Command>
-        copy vioscsi.inx $(OutDir)\vioscsi.inf
-        stampinf -f $(OutDir)\vioscsi.inf -a $(InfArch) -v $(STAMPINF_VERSION)
-        packOne.bat $(TargetOS) $(TargetArch) vioscsi
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(PlatformToolset)'!='v140_xp'">
-    <PostBuildEvent>
-      <Command>
-        packOne.bat $(TargetOS) $(TargetArch) vioscsi
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
     <ClCompile>

--- a/vioscsi/vioscsi.vcxproj
+++ b/vioscsi/vioscsi.vcxproj
@@ -111,6 +111,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\vioscsi.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -302,6 +303,7 @@
     <Mofcomp Include="vioscsi.mof" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/vioserial/sys/Driver.c
+++ b/vioserial/sys/Driver.c
@@ -15,7 +15,7 @@
 
 #include "precomp.h"
 #include "vioser.h"
-
+#include "..\..\Tools\vendor.check.h"
 
 #if defined(EVENT_TRACING)
 #include "Driver.tmh"

--- a/vioserial/sys/vioser.inx
+++ b/vioserial/sys/vioser.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2010-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    vioser.inf
@@ -17,8 +18,8 @@
 Signature="$WINDOWS NT$"
 Class=System
 ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
-Provider=%REDHAT%
-DriverVer=02/22/2010,6.0.1000.10000
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=vioser.cat
 DriverPackageType = PlugAndPlay
 DriverPackageDisplayName = %VirtioSerial.DeviceDesc%
@@ -39,7 +40,7 @@ vioser.sys  = 1,,
 ;*****************************************
 
 [Manufacturer]
-%REDHAT%=VirtioSerial,NT$ARCH$
+%VENDOR%=VirtioSerial,NT$ARCH$
 
 [VirtioSerial.NT$ARCH$]
 ;
@@ -100,7 +101,7 @@ KmdfService =  VirtioSerial, VirtioSerial_wdfsect
 KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
-REDHAT = "Red Hat, Inc."
-DiskId1 = "VirtIO Serial Installation Disk #1"
-VirtioSerial.DeviceDesc = "VirtIO Serial Driver"
-VirtioSerial.ServiceDesc = "VirtIO Serial Service"
+VENDOR = "INX_COMPANY"
+DiskId1 = "INX_PREFIX_VIRTIOVirtIO Serial Installation Disk #1"
+VirtioSerial.DeviceDesc = "INX_PREFIX_VIRTIOVirtIO Serial Driver"
+VirtioSerial.ServiceDesc = "INX_PREFIX_VIRTIOVirtIO Serial Service"

--- a/vioserial/sys/vioser.props
+++ b/vioserial/sys/vioser.props
@@ -1,0 +1,24 @@
+<!--
+***********************************************************************************************
+vioser.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_UsingWDF>true</Feature_UsingWDF>
+    <Feature_PackOne>true</Feature_PackOne>
+    <Feature_LegacyStampInf>true</Feature_LegacyStampInf>
+    <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <!-- there was only Server2008_Xnn mask without VISTA_Xnn in packone.bat
+         for Win7 and this is wrong
+         either remove it (set feature below to false)
+         or keep VISTA masks too (set feature to true) -->
+    <PackOne_Win7AddWlhMask>false</PackOne_Win7AddWlhMask>
+    <SourceInfFile>vioser.inx</SourceInfFile>
+    <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
+  </PropertyGroup>
+</Project>

--- a/vioserial/sys/vioser.rc
+++ b/vioserial/sys/vioser.rc
@@ -12,32 +12,13 @@
 #include <windows.h>
 #include <ntverp.h>
 
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat VirtIO Serial driver"
-#define VER_INTERNALNAME_STR        "vioser.sys"
-#define VER_ORIGINALFILENAME_STR    "vioser.sys"
+#include "..\..\Tools\vendor.ver"
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2010-2016 Red Hat, Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         "Red Hat, Inc."
-
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         "Red Hat VirtIO Serial controller"
-
-#define VER_LANGNEUTRAL
-
-#define VER_PRODUCTBUILD            _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE        _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION     _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION     _RHEL_RELEASE_VERSION_
-
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "VirtIO Serial controller"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "VirtIO Serial driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "vioser.sys"
 
 #include "common.ver"

--- a/vioserial/sys/vioser.vcxproj
+++ b/vioserial/sys/vioser.vcxproj
@@ -157,6 +157,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\vioser.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -291,6 +292,7 @@
     <ClCompile Include="utils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/vioserial/sys/vioser.vcxproj
+++ b/vioserial/sys/vioser.vcxproj
@@ -251,20 +251,8 @@
     <ClCompile>
       <DisableSpecificWarnings>4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
-    <PostBuildEvent>
-      <Command>
-        copy vioser.inx $(OutDir)\vioser.inf
-        stampinf -f $(OutDir)\vioser.inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION)
-        packOne.bat $(TargetOS) $(TargetArch) vioser "$(LegacyDDKDir)"
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(PlatformToolset)'!='v140_xp'">
-    <PostBuildEvent>
-      <Command>
-        packOne.bat $(TargetOS) $(TargetArch) vioser "$(WDKContentRoot)"
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/viostor/viostor.inx
+++ b/viostor/viostor.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2008-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    viostor.inf
@@ -17,11 +18,11 @@
 Signature="$Windows NT$"
 Class=SCSIAdapter
 ClassGUID={4D36E97B-E325-11CE-BFC1-08002BE10318}
-Provider=%RHEL%
-DriverVer=05/03/2010,6.0.6001.16640
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=viostor.cat
 DriverPackageType = PlugAndPlay
-DriverPackageDisplayName = %RHELScsi.DeviceDesc%
+DriverPackageDisplayName = %VENDORScsi.DeviceDesc%
 
 ;
 ; Source file information
@@ -45,11 +46,11 @@ viostor_Files_Driver = 12
 ;
 
 [Manufacturer]
-%RHEL%   = RHEL,NT$ARCH$
+%VENDOR%   = VENDOR,NT$ARCH$
 
-[RHEL.NT$ARCH$]
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
+[VENDOR.NT$ARCH$]
+%VENDORScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
+%VENDORScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
 
 ;
 ; General installation section
@@ -58,17 +59,17 @@ viostor_Files_Driver = 12
 [viostor_Files_Driver]
 viostor.sys,,,2
 
-[rhelscsi_inst]
+[scsi_inst]
 CopyFiles=viostor_Files_Driver
 
 ;
 ; Service Installation
 ;
 
-[rhelscsi_inst.Services]
-AddService = viostor, 0x00000002 , rhelscsi_Service_Inst, rhelscsi_EventLog_Inst
+[scsi_inst.Services]
+AddService = viostor, 0x00000002 , scsi_Service_Inst, scsi_EventLog_Inst
 
-[rhelscsi_Service_Inst]
+[scsi_Service_Inst]
 ServiceType    = %SERVICE_KERNEL_DRIVER%
 StartType      = %SERVICE_BOOT_START%
 ErrorControl   = %SERVICE_ERROR_NORMAL%
@@ -76,13 +77,13 @@ ServiceBinary  = %12%\viostor.sys
 LoadOrderGroup = SCSI miniport
 AddReg         = pnpsafe_pci_addreg
 
-[rhelscsi_inst.HW]
+[scsi_inst.HW]
 AddReg         = pnpsafe_pci_addreg_msix
 
-[rhelscsi_EventLog_Inst]
-AddReg = rhelscsi_EventLog_AddReg
+[scsi_EventLog_Inst]
+AddReg = scsi_EventLog_AddReg
 
-[rhelscsi_EventLog_AddReg]
+[scsi_EventLog_AddReg]
 HKR,,EventMessageFile,%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\IoLogMsg.dll"
 HKR,,TypesSupported,%REG_DWORD%,7
 
@@ -104,9 +105,9 @@ HKR, "Interrupt Management\Affinity Policy", DevicePolicy, 0x00010001, 5
 ;
 ; Localizable Strings
 ;
-diskId1 = "Red Hat VirtIO SCSI controller Installation Disk"
-RHELScsi.DeviceDesc = "Red Hat VirtIO SCSI controller"
-RHEL = "Red Hat, Inc."
+VENDOR = "INX_COMPANY"
+diskId1 = "INX_PREFIX_VENDORVirtIO SCSI controller Installation Disk"
+VENDORScsi.DeviceDesc = "INX_PREFIX_VENDORVirtIO SCSI controller"
 
 ;
 ; Non-Localizable Strings

--- a/viostor/viostor.props
+++ b/viostor/viostor.props
@@ -1,0 +1,23 @@
+<!--
+***********************************************************************************************
+viostor.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <Feature_UsingWDF>false</Feature_UsingWDF>
+    <Feature_PackOne>true</Feature_PackOne>
+    <Feature_LegacyStampInf>true</Feature_LegacyStampInf>
+    <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <!-- there was only Server2008_Xnn mask without VISTA_Xnn in packone.bat
+         for Win7 and this is wrong
+         either remove it (set feature below to false)
+         or keep VISTA masks too (set feature to true) -->
+    <PackOne_Win7AddWlhMask>false</PackOne_Win7AddWlhMask>
+    <!-- $(SourceInfFile) is already defined in .vcxproj -->
+  </PropertyGroup>
+</Project>

--- a/viostor/viostor.vcxproj
+++ b/viostor/viostor.vcxproj
@@ -120,6 +120,7 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(MSBuildProjectDirectory)\viostor.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\Tools\Driver.Common.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -288,6 +289,7 @@
     <ClCompile Include="virtio_stor_utils.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(MSBuildProjectDirectory)\..\Tools\Driver.Common.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/viostor/viostor.vcxproj
+++ b/viostor/viostor.vcxproj
@@ -205,20 +205,8 @@
       <EntryPointSymbol Condition="'$(Platform)'=='Win32'">GsDriverEntry@8</EntryPointSymbol>
       <EntryPointSymbol Condition="'$(Platform)'=='x64'">GsDriverEntry</EntryPointSymbol>
     </Link>
-    <PostBuildEvent>
-      <Command>
-        copy $(SourceInfFile) $(OutDir)\viostor.inf
-        stampinf -f $(OutDir)\viostor.inf -a $(InfArch) -v $(STAMPINF_VERSION)
-        packOne.bat $(TargetOS) $(TargetArch) viostor
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(PlatformToolset)'!='v140_xp'">
-    <PostBuildEvent>
-      <Command>
-        packOne.bat $(TargetOS) $(TargetArch) viostor
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Win8 Release'">
     <ClCompile>

--- a/viostor/viostor_no_msi.inx
+++ b/viostor/viostor_no_msi.inx
@@ -1,6 +1,7 @@
 ;/*++
 ;
-;Copyright (c) 2008-2016 Red Hat Inc.
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
 ;Module Name:
 ;    viostor.inf
@@ -17,11 +18,11 @@
 Signature="$Windows NT$"
 Class=SCSIAdapter
 ClassGUID={4D36E97B-E325-11CE-BFC1-08002BE10318}
-Provider=%RHEL%
-DriverVer=05/03/2010,6.0.6001.16640
+Provider=%VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 CatalogFile=viostor.cat
 DriverPackageType = PlugAndPlay
-DriverPackageDisplayName = %RHELScsi.DeviceDesc%
+DriverPackageDisplayName = %VENDORScsi.DeviceDesc%
 
 ;
 ; Source file information
@@ -45,11 +46,11 @@ viostor_Files_Driver = 12
 ;
 
 [Manufacturer]
-%RHEL%   = RHEL,NT$ARCH$
+%VENDOR%   = VENDOR,NT$ARCH$
 
-[RHEL.NT$ARCH$]
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
-%RHELScsi.DeviceDesc% = rhelscsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
+[VENDOR.NT$ARCH$]
+%VENDORScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
+%VENDORScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
 
 ;
 ; General installation section
@@ -58,17 +59,17 @@ viostor_Files_Driver = 12
 [viostor_Files_Driver]
 viostor.sys,,,2
 
-[rhelscsi_inst]
+[scsi_inst]
 CopyFiles=viostor_Files_Driver
 
 ;
 ; Service Installation
 ;
 
-[rhelscsi_inst.Services]
-AddService = viostor, 0x00000002 , rhelscsi_Service_Inst, rhelscsi_EventLog_Inst
+[scsi_inst.Services]
+AddService = viostor, 0x00000002 , scsi_Service_Inst, scsi_EventLog_Inst
 
-[rhelscsi_Service_Inst]
+[scsi_Service_Inst]
 ServiceType    = %SERVICE_KERNEL_DRIVER%
 StartType      = %SERVICE_BOOT_START%
 ErrorControl   = %SERVICE_ERROR_NORMAL%
@@ -76,10 +77,10 @@ ServiceBinary  = %12%\viostor.sys
 LoadOrderGroup = SCSI miniport
 AddReg         = pnpsafe_pci_addreg
 
-[rhelscsi_EventLog_Inst]
-AddReg = rhelscsi_EventLog_AddReg
+[scsi_EventLog_Inst]
+AddReg = scsi_EventLog_AddReg
 
-[rhelscsi_EventLog_AddReg]
+[scsi_EventLog_AddReg]
 HKR,,EventMessageFile,%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\IoLogMsg.dll"
 HKR,,TypesSupported,%REG_DWORD%,7
 
@@ -91,9 +92,9 @@ HKR, "Parameters", "BusType", %REG_DWORD%, 0x00000001
 ;
 ; Localizable Strings
 ;
-diskId1 = "Red Hat VirtIO SCSI controller Installation Disk"
-RHELScsi.DeviceDesc = "Red Hat VirtIO SCSI controller"
-RHEL = "Red Hat, Inc."
+VENDOR = "INX_COMPANY"
+diskId1 = "INX_PREFIX_VENDORVirtIO SCSI controller Installation Disk"
+VENDORScsi.DeviceDesc = "INX_PREFIX_VENDORVirtIO SCSI controller"
 
 ;
 ; Non-Localizable Strings

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -13,6 +13,7 @@
  *
 **********************************************************************/
 #include "virtio_stor.h"
+#include "..\Tools\vendor.check.h"
 
 BOOLEAN IsCrashDumpMode;
 

--- a/viostor/virtio_stor.rc
+++ b/viostor/virtio_stor.rc
@@ -12,36 +12,13 @@
 #include <windows.h>
 #include <ntverp.h>
 
-#undef  VER_PRODUCTBUILD
-#undef  VER_PRODUCTBUILD_QFE
-#undef  VER_PRODUCTMAJORVERSION
-#undef  VER_PRODUCTMINORVERSION
+#include "..\Tools\vendor.ver"
 
-#undef	VER_LEGALTRADEMARKS_STR
-#define	VER_LEGALTRADEMARKS_STR     ""
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
 
-#undef  VER_LEGALCOPYRIGHT_STR
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2008-2016 Red Hat, Inc."
-
-#undef  VER_COMPANYNAME_STR
-#define VER_COMPANYNAME_STR         "Red Hat, Inc."
-
-#undef  VER_PRODUCTNAME_STR
-#define VER_PRODUCTNAME_STR         "Red Hat VirtIO SCSI controller"
-
-#define VER_PRODUCTBUILD            _BUILD_MAJOR_VERSION_
-#define VER_PRODUCTBUILD_QFE        _BUILD_MINOR_VERSION_
-#define VER_PRODUCTMAJORVERSION     _NT_TARGET_MAJ
-#define VER_PRODUCTMINORVERSION     _RHEL_RELEASE_VERSION_
-
-#define VER_LANGNEUTRAL
-
-#define VER_FILETYPE                VFT_DRV
-#define VER_FILESUBTYPE             VFT2_DRV_SYSTEM
-#define VER_FILEDESCRIPTION_STR     "Red Hat VirtIO SCSI driver"
-#define VER_INTERNALNAME_STR        "viostor.sys"
-#define VER_ORIGINALFILENAME_STR    "viostor.sys"
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "VirtIO SCSI controller"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "VirtIO SCSI driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "viostor.sys"
 
 #include "common.ver"
-
-


### PR DESCRIPTION
(v4) - tools and all drivers except NetKVM and viorng
(Balloon, pvpanic, vioinput, vioserial, vioscsi, viostor)

Introduce $(_VENDOR_) property (rhel by default).

There is no way to make substitutions inside inf file
except custom MSBuild target imported from .vcxproj

WDK/LegacyDDK scenarios are slightly different:

In case of WDK all that is needed is to execute inf substitution task
just after StampInf target had stamped .inx/.inf and moved it into
$(OutDir) and before InfVerif target.

In case of LegacyDDK we need to do things in the middle of PostBuild event
that copyes inf files, calls stampinf and calls packone.bat
That's why this logic was translated into MSBuild targets

Driver.Common.targets contains inf substituion and copying/stampinf as it
was in PostBuildEvent
Driver.PackOne.targets replaces packone.bat

Features (all feature are false by default):
1. $(Feature_UsingWDF) - do we use WDF?
2. $(Feature_AdjustInf) and $(Feature_AdjustInfLegacy)
   executes SubstituteFileContent task
   to substitute vendor specific strings in .inf/.inx files
   with @(Substitution) from Driver.$(_VENDOR_).props
   $(SourceInfFile) is required for Legacy case
3. $(Feature_LegacyStampInf) - executes
   stampinf tool for Legacy DDK
4. $(Feature_PackOne) - Import Driver.PackOne.targets

Removed rhel versioning from Driver.Common.props,
added import of Driver.Vendor.props,
and simplified InfArch definitions

Driver.Vendor.props introduces schema to support different vendors
Driver.RHEL.props contains versioning and inf substitutions for Red Hat
Driver.VZ.props contains same for Virtuozzo

Due to the fact that version info
in .rc files for all drivers is almost the same this patch introduces
a schema for simplifying them.
.rc files should only declare VENDOR_VIRTIO_PRODUCT,
VER_FILEDESCRIPTION_STR, VER_INTERNALNAME_STR