### PR TITLE
balloon: Remove BalloonEvtFileClose from the PAGE section

### DIFF
--- a/Balloon/sys/Device.c
+++ b/Balloon/sys/Device.c
@@ -25,7 +25,6 @@
 #pragma alloc_text(PAGE, BalloonEvtDeviceD0Exit)
 #pragma alloc_text(PAGE, BalloonEvtDeviceD0ExitPreInterruptsDisabled)
 #pragma alloc_text(PAGE, BalloonDeviceAdd)
-#pragma alloc_text(PAGE, BalloonEvtFileClose)
 #pragma alloc_text(PAGE, BalloonCloseWorkerThread)
 #endif
 
@@ -573,14 +572,12 @@ BalloonInterruptDisable(
 }
 
 VOID
-BalloonEvtFileClose (
+BalloonEvtFileClose(
     IN WDFFILEOBJECT    FileObject
     )
 {
     WDFDEVICE Device = WdfFileObjectGetDevice(FileObject);
     PDEVICE_CONTEXT devCtx = GetDeviceContext(Device);
-
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<-> %s\n", __FUNCTION__);
 


### PR DESCRIPTION
Commit 9b81256 added a call to WdfObjectAcquireLock which raises
IRQL to DISPATCH_LEVEL, but BalloonEvtFileClose still resides in
the PAGE section which requires IRQL <= APC_LEVEL to execute. This
commit fixes it by removing the function from the section. The
PAGED_CODE() macro - a bit of a misnomer because it checks IRQL
at function entry only, so technically it is still correct - is
removed also.

This is part of a fix for BZ #1419785.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>