### PR TITLE
Merge stable to master: viostor and vioscsi

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -51,8 +51,7 @@ ENTER_FN();
         STARTIO_PERFORMANCE_PARAMETERS param;
         param.Size = sizeof(STARTIO_PERFORMANCE_PARAMETERS);
         status = StorPortGetStartIoPerfParams(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, &param);
-        if (status == STOR_STATUS_SUCCESS) {
-//            RhelDbgPrint(TRACE_LEVEL_FATAL, ("srb %p, cpu %d :: QueueNumber %lu, MessageNumber %lu, ChannelNumber %lu.\n", Srb, srbExt->cpu, QueueNumber, param.MessageNumber, param.ChannelNumber));
+        if (status == STOR_STATUS_SUCCESS && param.MessageNumber != 0) {
             MessageId = param.MessageNumber;
             QueueNumber = MessageId - 1;
         }

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -92,25 +92,7 @@ ENTER_FN();
 #if (NTDDI_VERSION > NTDDI_WIN7)
     if (adaptExt->num_queues > 1) {
         if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO)) {
-            ULONG msg = MessageId - 3;
-            PSTOR_SLIST_ENTRY   listEntryRev, listEntry;
-            status = StorPortInterlockedFlushSList(DeviceExtension, &adaptExt->srb_list[msg], &listEntryRev);
-            if ((status == STOR_STATUS_SUCCESS) && (listEntryRev != NULL)) {
-                listEntry = listEntryRev;
-                while(listEntry)
-                {
-                    PVirtIOSCSICmd  cmd = NULL;
-                    PSTOR_SLIST_ENTRY next = listEntry->Next;
-                    srbExt = CONTAINING_RECORD(listEntry,
-                                SRB_EXTENSION, list_entry);
-
-                    ASSERT(srExt);
-                    cmd = (PVirtIOSCSICmd)srbExt->priv;
-                    ASSERT(cmd);
-                    HandleResponse(DeviceExtension, cmd);
-                    listEntry = next;
-                }
-            }
+            ProcessQueue(DeviceExtension, MessageId, FALSE);
         }
     }
 #endif

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -44,12 +44,30 @@ ENTER_FN();
     SET_VA_PA();
 
     if (adaptExt->num_queues > 1) {
+#ifdef USE_CPU_TO_VQ_MAP
         QueueNumber = adaptExt->cpu_to_vq_map[srbExt->cpu] + VIRTIO_SCSI_REQUEST_QUEUE_0;
+        MessageId = QueueNumber + 1;
+#else // USE_CPU_TO_VQ_MAP
+        STARTIO_PERFORMANCE_PARAMETERS param;
+        param.Size = sizeof(STARTIO_PERFORMANCE_PARAMETERS);
+        status = StorPortGetStartIoPerfParams(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, &param);
+        if (status == STOR_STATUS_SUCCESS) {
+//            RhelDbgPrint(TRACE_LEVEL_FATAL, ("srb %p, cpu %d :: QueueNumber %lu, MessageNumber %lu, ChannelNumber %lu.\n", Srb, srbExt->cpu, QueueNumber, param.MessageNumber, param.ChannelNumber));
+            MessageId = param.MessageNumber;
+            QueueNumber = MessageId - 1;
+        }
+        else {
+            RhelDbgPrint(TRACE_LEVEL_FATAL, ("srb %p cpu %d status 0x%x.\n", Srb, srbExt->cpu, status));
+            QueueNumber = VIRTIO_SCSI_REQUEST_QUEUE_0;
+            MessageId = 3;
+        }
+#endif // USE_CPU_TO_VQ_MAP
     }
     else {
         QueueNumber = VIRTIO_SCSI_REQUEST_QUEUE_0;
+        MessageId = 3;
     }
-    MessageId = QueueNumber + 1;
+
     VioScsiVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
     if (virtqueue_add_buf(adaptExt->vq[QueueNumber],
                      &srbExt->sg[0],
@@ -59,7 +77,7 @@ ENTER_FN();
         notify = virtqueue_kick_prepare(adaptExt->vq[QueueNumber]);
     }
     else {
-        RhelDbgPrint(TRACE_LEVEL_ERROR, ("%s Can not add packet to queue.\n", __FUNCTION__));
+        RhelDbgPrint(TRACE_LEVEL_FATAL, ("%s Can not add packet to queue.\n", __FUNCTION__));
 //FIXME
     }
 #ifndef USE_WORK_ITEM

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -368,7 +368,6 @@ ENTER_FN();
     max_cpus = KeQueryMaximumProcessorCount();
 #endif
     adaptExt->num_queues = adaptExt->scsi_config.num_queues;
-
     if (adaptExt->dump_mode || !adaptExt->msix_enabled)
     {
         adaptExt->num_queues = 1;
@@ -655,9 +654,11 @@ ENTER_FN();
         for (index = VIRTIO_SCSI_CONTROL_QUEUE; index < adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0; ++index) {
               if ((adaptExt->num_queues > 1) &&
                   (index >= VIRTIO_SCSI_REQUEST_QUEUE_0)) {
+#ifdef USE_CPU_TO_VQ_MAP
                   if (!CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
                       adaptExt->cpu_to_vq_map[index - VIRTIO_SCSI_REQUEST_QUEUE_0] = (UCHAR)(index - VIRTIO_SCSI_REQUEST_QUEUE_0);
                   }
+#endif // USE_CPU_TO_VQ_MAP
 #if (NTDDI_VERSION > NTDDI_WIN7)
                   status = StorPortInitializeSListHead(DeviceExtension, &adaptExt->srb_list[index - VIRTIO_SCSI_REQUEST_QUEUE_0]); 
                   if (status != STOR_STATUS_SUCCESS) {
@@ -745,6 +746,7 @@ ENTER_FN();
                     adaptExt->perfFlags = 0;
                     RhelDbgPrint(TRACE_LEVEL_ERROR, ("%s StorPortInitializePerfOpts FALSE status = 0x%x\n", __FUNCTION__, status));
                 }
+#ifdef USE_CPU_TO_VQ_MAP
                 else if ((adaptExt->pmsg_affinity != NULL) && CHECKFLAG(perfData.Flags, STOR_PERF_ADV_CONFIG_LOCALITY)){
                     UCHAR msg = 0;
                     PGROUP_AFFINITY ga;
@@ -760,6 +762,7 @@ ENTER_FN();
                         }
                     }
                 }
+#endif // USE_CPU_TO_VQ_MAP
             }
             else {
                 RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("%s StorPortInitializePerfOpts TRUE status = 0x%x\n", __FUNCTION__, status));

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1708,15 +1708,29 @@ ENTER_FN();
 EXIT_FN();
 }
 
-void CopyWMIString(void* _pDest, const void* _pSrc, size_t _maxlength)
+void CopyUnicodeString(void* _pDest, const void* _pSrc, size_t _maxlength)
 {
      PUSHORT _pDestTemp = _pDest;
      USHORT  _length = _maxlength - sizeof(USHORT);
-                                                                                                                                                 \
      *_pDestTemp++ = _length;
-                                                                                                                                                 \
      _length = (USHORT)min(wcslen(_pSrc)*sizeof(WCHAR), _length);
      memcpy(_pDestTemp, _pSrc, _length);
+}
+
+void CopyAnsiToUnicodeString(void* _pDest, const void* _pSrc, size_t _maxlength)
+{
+    PUSHORT _pDestTemp = _pDest;
+    PWCHAR  dst;
+    PCHAR   src = (PCHAR)_pSrc;
+    USHORT  _length = _maxlength - sizeof(USHORT);
+    *_pDestTemp++ = _length;
+    dst = (PWCHAR)_pDestTemp;
+    _length = (USHORT)min(strlen((const char*)_pSrc) * sizeof(WCHAR), _length);
+    _length /= sizeof(WCHAR);
+    while (_length) {
+        *dst++ = *src++;
+        --_length;
+    };
 }
 
 BOOLEAN
@@ -1773,17 +1787,22 @@ ENTER_FN();
             pOutBfr->HBAStatus = HBA_STATUS_OK;
             pOutBfr->NumberOfPorts = 1;
             pOutBfr->VendorSpecificID = VENDORID | (PRODUCTID << 16);
-            CopyWMIString(pOutBfr->Manufacturer, MANUFACTURER, sizeof(pOutBfr->Manufacturer));
-//FIXME
-//			CopyWMIString(pOutBfr->SerialNumber, adaptExt->ser_num ? adaptExt->ser_num : SERIALNUMBER, sizeof(pOutBfr->SerialNumber));
-			CopyWMIString(pOutBfr->SerialNumber, SERIALNUMBER, sizeof(pOutBfr->SerialNumber));
-            CopyWMIString(pOutBfr->Model, MODEL, sizeof(pOutBfr->Model));
-            CopyWMIString(pOutBfr->ModelDescription, MODELDESCRIPTION, sizeof(pOutBfr->ModelDescription));
-            CopyWMIString(pOutBfr->FirmwareVersion, FIRMWAREVERSION, sizeof(pOutBfr->FirmwareVersion));
-            CopyWMIString(pOutBfr->DriverName, DRIVERNAME, sizeof(pOutBfr->DriverName));
-            CopyWMIString(pOutBfr->HBASymbolicName, HBASYMBOLICNAME, sizeof(pOutBfr->HBASymbolicName));
-            CopyWMIString(pOutBfr->RedundantFirmwareVersion, FIRMWAREVERSION, sizeof(pOutBfr->RedundantFirmwareVersion));
-            CopyWMIString(pOutBfr->MfgDomain, MFRDOMAIN, sizeof(pOutBfr->MfgDomain));
+            CopyUnicodeString(pOutBfr->Manufacturer, MANUFACTURER, sizeof(pOutBfr->Manufacturer));
+            if (adaptExt->ser_num)
+            {
+                CopyAnsiToUnicodeString(pOutBfr->SerialNumber, adaptExt->ser_num, sizeof(pOutBfr->SerialNumber));
+            }
+            else
+            {
+                CopyUnicodeString(pOutBfr->SerialNumber, SERIALNUMBER, sizeof(pOutBfr->SerialNumber));
+            }
+            CopyUnicodeString(pOutBfr->Model, MODEL, sizeof(pOutBfr->Model));
+            CopyUnicodeString(pOutBfr->ModelDescription, MODELDESCRIPTION, sizeof(pOutBfr->ModelDescription));
+            CopyUnicodeString(pOutBfr->FirmwareVersion, FIRMWAREVERSION, sizeof(pOutBfr->FirmwareVersion));
+            CopyUnicodeString(pOutBfr->DriverName, DRIVERNAME, sizeof(pOutBfr->DriverName));
+            CopyUnicodeString(pOutBfr->HBASymbolicName, HBASYMBOLICNAME, sizeof(pOutBfr->HBASymbolicName));
+            CopyUnicodeString(pOutBfr->RedundantFirmwareVersion, FIRMWAREVERSION, sizeof(pOutBfr->RedundantFirmwareVersion));
+            CopyUnicodeString(pOutBfr->MfgDomain, MFRDOMAIN, sizeof(pOutBfr->MfgDomain));
 
             *InstanceLengthArray = size;
             status = SRB_STATUS_SUCCESS;

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -289,7 +289,9 @@ typedef struct _ADAPTER_EXTENSION {
     PVirtIOSCSIEventNode  events;
 
     ULONG                 num_queues;
+#ifdef USE_CPU_TO_VQ_MAP
     UCHAR                 cpu_to_vq_map[MAX_CPU];
+#endif
 #if (NTDDI_VERSION > NTDDI_WIN7)
     STOR_SLIST_HEADER     srb_list[MAX_CPU];
 #endif

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -224,6 +224,7 @@ typedef struct _SRB_EXTENSION {
     STOR_SLIST_ENTRY      list_entry;
 #endif
 #endif
+    LIST_ENTRY            process_list_entry;
     PSCSI_REQUEST_BLOCK   Srb;
     ULONG                 out;
     ULONG                 in;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -748,6 +748,7 @@ VirtIoStartIo(
         }
         case SRB_FUNCTION_PNP:
         case SRB_FUNCTION_POWER:
+        case SRB_FUNCTION_RESET_BUS:
         case SRB_FUNCTION_RESET_DEVICE:
         case SRB_FUNCTION_RESET_LOGICAL_UNIT: {
             CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_SUCCESS);


### PR DESCRIPTION
This is part of an effort to merge the stable branch (where Fedora and RHEL virtio-win drivers come from) into master.

@vrozenfe please review. Should the "dont use cpu-to-vq map" commit use ifdefs to keep the cpu-to-vq map enabled only if explicitly requested, similar to #ifdef USE_WORK_ITEM? Thanks!