### PR TITLE
Revert "Fix queue locking."

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -431,17 +431,30 @@ VioScsiVQLock(
 ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if (!isr) {
-        if (adaptExt->msix_enabled) {
-            if (!CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
-                // Queue numbers start at 0, message ids at 1.
-                NT_ASSERT(MessageID > VIRTIO_SCSI_REQUEST_QUEUE_0);
-                NT_ASSERT(MessageID <= VIRTIO_SCSI_REQUEST_QUEUE_0 + adaptExt->num_queues);
-                StorPortAcquireSpinLock(DeviceExtension, DpcLock, &adaptExt->dpc[MessageID - VIRTIO_SCSI_REQUEST_QUEUE_0 - 1], LockHandle);
+    if (!adaptExt->msix_enabled) {
+        if (!isr) {
+            StorPortAcquireSpinLock(DeviceExtension, InterruptLock, NULL, LockHandle);
+        }
+    }
+    else {
+        if (adaptExt->num_queues == 1) {
+            if (!isr) {
+                ULONG oldIrql = 0;
+                StorPortAcquireMSISpinLock(DeviceExtension, (adaptExt->msix_one_vector ? 0 : MessageID), &oldIrql);
+                LockHandle->Context.OldIrql = (KIRQL)oldIrql;
             }
         }
         else {
-            StorPortAcquireSpinLock(DeviceExtension, InterruptLock, NULL, LockHandle);
+            NT_ASSERT(MessageID > VIRTIO_SCSI_REQUEST_QUEUE_0);
+            NT_ASSERT(MessageID <= VIRTIO_SCSI_REQUEST_QUEUE_0 + adaptExt->num_queues);
+            if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_CONCURRENT_CHANNELS)) {
+                if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
+                    StorPortAcquireSpinLock(DeviceExtension, StartIoLock, &adaptExt->dpc[MessageID - VIRTIO_SCSI_REQUEST_QUEUE_0 - 1], LockHandle);
+                }
+                else {
+                    RhelDbgPrint(TRACE_LEVEL_FATAL, ("%s STOR_PERF_CONCURRENT_CHANNELS yes, STOR_PERF_ADV_CONFIG_LOCALITY no\n", __FUNCTION__));
+                }
+            }
         }
     }
 
@@ -461,9 +474,28 @@ VioScsiVQUnlock(
 ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if (!isr) {
-        if (!adaptExt->msix_enabled || !CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
+    if (!adaptExt->msix_enabled) {
+        if (!isr) {
             StorPortReleaseSpinLock(DeviceExtension, LockHandle);
+        }
+    }
+    else {
+        if (adaptExt->num_queues == 1) {
+            if (!isr) {
+                StorPortReleaseMSISpinLock(DeviceExtension, (adaptExt->msix_one_vector ? 0 : MessageID), LockHandle->Context.OldIrql);
+            }
+        }
+        else {
+            NT_ASSERT(MessageID > VIRTIO_SCSI_REQUEST_QUEUE_0);
+            NT_ASSERT(MessageID <= VIRTIO_SCSI_REQUEST_QUEUE_0 + adaptExt->num_queues);
+            if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_CONCURRENT_CHANNELS)) {
+                if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
+                    StorPortReleaseSpinLock(DeviceExtension, LockHandle);
+                }
+                else {
+                    RhelDbgPrint(TRACE_LEVEL_FATAL, ("%s STOR_PERF_CONCURRENT_CHANNELS yes, STOR_PERF_ADV_CONFIG_LOCALITY no\n", __FUNCTION__));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This reverts commit ed1d377efdd04223bdfbebc23ace1c230aa6a0eb.

By not acquiring MSI spin locks anymore, the commit breaks
synchronization in the driver. Both VioScsiMSInterruptWorker
and the code that calls VioScsiVQLock with isr=FALSE, like
SendSRB, access the request virtqueues and these accesses must
be serialized.

See comments in VirtioLib, for example:

 * virtqueue_add_buf - expose buffer to other end
 * ...
 * Caller must ensure we don't call this with other virtqueue operations
 * at the same time (except where noted).

 * virtqueue_get_buf - get the next used buffer
 * ...
 * Caller must ensure we don't call this with other virtqueue
 * operations at the same time (except where noted).

The issue manifests as the VM hanging under I/O stress, looping
in vioscsi!ProcessQueue indefinitely.

3: kd> k
 # Call Site
00 vioscsi!virtqueue_get_buf+0x4c [c:\kvm-guest-drivers-windows\virtio\virtioring.c @ 536]
01 vioscsi!ProcessQueue+0xee [c:\kvm-guest-drivers-windows\vioscsi\vioscsi.c @ 1287]
02 vioscsi!DispatchQueue+0x4f [c:\kvm-guest-drivers-windows\vioscsi\vioscsi.c @ 1258]
03 vioscsi!VioScsiMSInterruptWorker+0x63 [c:\kvm-guest-drivers-windows\vioscsi\vioscsi.c @ 986]
04 vioscsi!VioScsiMSInterrupt+0x23 [c:\kvm-guest-drivers-windows\vioscsi\vioscsi.c @ 1052]
05 storport!RaidpAdapterMSIInterruptRoutine+0x61
06 nt!KiCallInterruptServiceRoutine+0x87

Signed-off-by: Ladi Prosek <lprosek@redhat.com>