### PR TITLE
balloon: Boost worker thread priority

### DIFF
--- a/Balloon/sys/Device.c
+++ b/Balloon/sys/Device.c
@@ -312,10 +312,12 @@ BalloonCreateWorkerThread(
 
         ObReferenceObjectByHandle(hThread, THREAD_ALL_ACCESS, NULL,
                                   KernelMode, (PVOID*)&devCtx->Thread, NULL);
+        KeSetPriorityThread(devCtx->Thread, LOW_REALTIME_PRIORITY);
+
         ZwClose(hThread);
     }
 
-    KeSetEvent(&devCtx->WakeUpThread, 0, FALSE);
+    KeSetEvent(&devCtx->WakeUpThread, EVENT_INCREMENT, FALSE);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "<-- %s\n", __FUNCTION__);
     return status;
@@ -336,7 +338,7 @@ BalloonCloseWorkerThread(
     if(NULL != devCtx->Thread)
     {
         devCtx->bShutDown = TRUE;
-        KeSetEvent(&devCtx->WakeUpThread, 0, FALSE);
+        KeSetEvent(&devCtx->WakeUpThread, EVENT_INCREMENT, FALSE);
         status = KeWaitForSingleObject(devCtx->Thread, Executive, KernelMode, FALSE, NULL);
         if(!NT_SUCCESS(status))
         {
@@ -497,7 +499,7 @@ BalloonInterruptDpc(
 
     if(bHostAck)
     {
-        KeSetEvent (&devCtx->HostAckEvent, IO_NO_INCREMENT, FALSE);
+        KeSetEvent (&devCtx->HostAckEvent, EVENT_INCREMENT, FALSE);
     }
 
     if (devCtx->StatVirtQueue)
@@ -530,7 +532,7 @@ BalloonInterruptDpc(
 
     if(devCtx->Thread)
     {
-       KeSetEvent(&devCtx->WakeUpThread, 0, FALSE);
+       KeSetEvent(&devCtx->WakeUpThread, EVENT_INCREMENT, FALSE);
     }
 }
 


### PR DESCRIPTION
The balloon worker thread may get starved and inflate/delate may
take an unreasonably long time if the system is under CPU stress.
This commit increases the base priority of the thread to
LOW_REALTIME_PRIORITY and adds the EVENT_INCREMENT dynamic priority
boost to all KeSetEvent calls.

Of course, there is no guarantee that the thread will be scheduled
and increasing the priority may be perceived as a peeing contest.
In this case though, given that the thread is idle and not scheduled
at all most of the time, and, in fact, logically an extension of the
DPC routine, higher priority is justified.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>