### PR TITLE
vioinput: Switch from filter to bus/child architecture

### DIFF
--- a/vioinput/hidpassthrough/hidpassthrough.vcxproj
+++ b/vioinput/hidpassthrough/hidpassthrough.vcxproj
@@ -63,7 +63,9 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
-  <ItemGroup Label="WrappedTaskItems" />
+  <ItemGroup Label="WrappedTaskItems">
+    <ClInclude Include="pdo.h" />
+  </ItemGroup>
   <PropertyGroup>
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <TargetName>viohidkmdf</TargetName>

--- a/vioinput/hidpassthrough/hidpassthrough.vcxproj.filters
+++ b/vioinput/hidpassthrough/hidpassthrough.vcxproj.filters
@@ -28,4 +28,9 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pdo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/vioinput/hidpassthrough/pdo.h
+++ b/vioinput/hidpassthrough/pdo.h
@@ -1,0 +1,24 @@
+/* HID passthrough driver.
+ * Definitions shared by vioinput and hidpassthrough.
+ *
+ * Copyright (c) 2017 Red Hat, Inc.
+ * Author: Ladi Prosek <lprosek@redhat.com>
+ */
+
+#pragma once
+#include <wdm.h>
+
+#define PDO_EXTENSION_V1 1
+#define PDO_EXTENSION_VERSION PDO_EXTENSION_V1
+
+typedef struct _tagPdoExtension
+{
+    /* This extension is an interface between vioinput and hidpassthrough.
+     * It doesn't hurt to add a version field in case we need to extend it
+     * in the future.
+     */
+    ULONG           Version;
+
+    /* Pointer to the bus FDO that enumerated the PDO */
+    PDEVICE_OBJECT  BusFdo;
+} PDO_EXTENSION, *PPDO_EXTENSION;

--- a/vioinput/sys/vioinput.h
+++ b/vioinput/sys/vioinput.h
@@ -14,6 +14,7 @@
 **********************************************************************/
 #pragma once
 #include "public.h"
+#include "../hidpassthrough/pdo.h"
 
 // If defined, will expose absolute axes as a tablet device only if they
 // don't come with mouse buttons.
@@ -94,6 +95,9 @@ typedef struct _tagInputDevice
     HID_DESCRIPTOR         HidDescriptor;
     HID_DEVICE_ATTRIBUTES  HidDeviceAttributes;
     PHID_REPORT_DESCRIPTOR HidReportDescriptor;
+    UINT64                 HidReportDescriptorHash;
+
+    BOOLEAN                bChildPdoCreated;
 
     // array of pointers to input class descriptors, each responsible
     // for one device class (e.g. mouse)
@@ -102,6 +106,9 @@ typedef struct _tagInputDevice
 } INPUT_DEVICE, *PINPUT_DEVICE;
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(INPUT_DEVICE, GetDeviceContext)
+
+// PDO_EXTENSION is declared in hidpassthrough\pdo.h
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(PDO_EXTENSION, PdoGetExtension)
 
 #define VIOINPUT_DRIVER_MEMORY_TAG (ULONG)'niIV'
 

--- a/vioinput/sys/vioinput.inx
+++ b/vioinput/sys/vioinput.inx
@@ -55,9 +55,12 @@ viohidkmdf.sys = 1,,
 ; Hw Id is PCI\VEN_1AF4&DEV_1052&SUBSYS_11001AF4&CC_090200&REV_01
 ;
 %VirtioInput.DeviceDesc%=VirtioInput_Device, PCI\VEN_1AF4&DEV_1052&SUBSYS_11001AF4&REV_01
+%VirtioInput.ChildDesc%=VirtioInput_Child, VIOINPUT\REV_01
 
 [VirtioInput_Device.NT]
 CopyFiles=Drivers_Dir
+
+[VirtioInput_Child.NT]
 
 [VirtioInput_Device.NT.HW]
 AddReg=VirtioInput_AddReg
@@ -67,7 +70,6 @@ HKR,Interrupt Management,,0x00000010
 HKR,Interrupt Management\MessageSignaledInterruptProperties,,0x00000010
 HKR,Interrupt Management\MessageSignaledInterruptProperties,MSISupported,0x00010001,1
 HKR,Interrupt Management\MessageSignaledInterruptProperties,MessageNumberLimit,0x00010001,2
-HKR,,"LowerFilters",0x00010000,"VirtioInput"
 
 [Drivers_Dir]
 vioinput.sys
@@ -76,8 +78,10 @@ viohidkmdf.sys
 ;-------------- Service installation
 
 [VirtioInput_Device.NT.Services]
-AddService = VirtioInput, 0, VirtioInput_Service_Inst
-AddService = viohidkmdf,0x00000002,viohidkmdf_Service_Inst ;flag 0x2 sets this as the service for the device
+AddService = VirtioInput, 0x00000002, VirtioInput_Service_Inst  ;flag 0x2 sets this as the service for the device
+
+[VirtioInput_Child.NT.Services]
+AddService = viohidkmdf, 0x00000002, viohidkmdf_Service_Inst
 
 ; -------------- VirtioInput driver install sections
 [viohidkmdf_Service_Inst]
@@ -119,4 +123,5 @@ KmdfLibraryVersion = $KMDFVERSION$
 REDHAT = "Red Hat, Inc."
 DiskId1 = "VirtIO Input Installation Disk #1"
 VirtioInput.DeviceDesc = "VirtIO Input Driver"
+VirtioInput.ChildDesc = "VirtIO Input Driver Helper"
 VirtioInput.ServiceDesc = "VirtIO Input Service"


### PR DESCRIPTION
The canonical KMDF HID driver uses mshidkmdf.sys (or its equivalent
viohidkmdf.sys) as the FDO for the device and the actual KMDF driver
as its lower filter to work around PnP KMDF limitations. This works,
except for the case where the same device, in terms of USB or PCI or
any other bus location, may expose different HID collections every time
it's plugged in. Because the instance path of the HID PDO (like for
example "HID-compliant mouse") is constructed only from the instance
path of the parent - likely just by replacing the bus ID with "HID" -
the system will reuse pre-existing devnodes, even if the HID collection
and the report descriptor are completely different and a keyboard,
for example, should be created instead of a mouse.

It's not hard to run into this issue with the vioinput driver. E.g.
switching from
-device virtio-mouse-pci
to
-device virtio-keyboard-pci
for the same PCI slot will result in the system loading the mouse HID
driver and the keyboard not working.

This commit works around it by making the KMDF driver a bus driver
which enumerates one and only child PDO, functionally driven by
viohidkmdf.sys. IOCTL IRPs are forwarded from viohidkmdf to vioinput
and processed just like before. The key difference is that vioinput
now generates the instance ID of the child, thus having the ability
to alter the instance path depending on the shape of the input device.
Specifically, vioinput computes a simple hash out of the HID report
descriptor and uses it as the child instance ID.

The child device is hidden from Device Manager so as not to confuse
users. It's not meant to be manipulated except through its parent.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>