### PR TITLE
vioscsi: Allocate only one virtqueue in dump mode

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -394,10 +394,14 @@ ENTER_FN();
      * VioScsiFindAdapter again with more CPUs enabled. Unfortunately StorPortGetUncachedExtension
      * only allocates when called for the first time so we need to always use this upper bound.
      */
-    max_queues = min(max_cpus, adaptExt->scsi_config.num_queues);
-    if (adaptExt->num_queues > max_queues) {
-	RhelDbgPrint(TRACE_LEVEL_WARNING, ("Multiqueue can only use at most one queue per cpu."));
-        adaptExt->num_queues = max_queues;
+    if (adaptExt->dump_mode) {
+        max_queues = adaptExt->num_queues;
+    } else {
+        max_queues = min(max_cpus, adaptExt->scsi_config.num_queues);
+        if (adaptExt->num_queues > max_queues) {
+            RhelDbgPrint(TRACE_LEVEL_WARNING, ("Multiqueue can only use at most one queue per cpu."));
+            adaptExt->num_queues = max_queues;
+        }
     }
     
 


### PR DESCRIPTION
The driver currently computes max_queues using the configured
number of queues and maximum CPUs supported by the system, even
in dump mode. This results in attempts to allocate excessive
amount of memory and VioScsiFindAdapter failing.

Note that StorPortGetUncachedExtension can only allocate a
maximum of 64 kB on some Windows versions.

We know that we always use only one queue in dump mode. This
commit fixes the code accordingly.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>