### PR TITLE
Move {RHEL,VZ}_COPYRIGHT_STARTING_YEAR out of driver props files

### DIFF
--- a/Balloon/sys/balloon.props
+++ b/Balloon/sys/balloon.props
@@ -15,7 +15,6 @@ Enabling and customizing virtio build features
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <SourceInfFile>balloon.inx</SourceInfFile>
     <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2009</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>BalloonCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/Tools/Driver.Common.targets
+++ b/Tools/Driver.Common.targets
@@ -74,10 +74,7 @@ Invoking the task:
             var content = File.ReadAllText(fileName);
 
             var regex = new Regex(String.Join("|", substitutions.Keys.Select(k => Regex.Escape(k))));
-            for (;;) {
-              content = regex.Replace(content, m => substitutions[m.Value]);
-              if (!regex.IsMatch(content)) break;
-            }
+            content = regex.Replace(content, m => substitutions[m.Value]);
 
             File.WriteAllText(fileName, content);
             Log.LogMessage(MessageImportance.High, "Saving replaced context to: {0}", fileNameNew);

--- a/Tools/Driver.RHEL.props
+++ b/Tools/Driver.RHEL.props
@@ -17,7 +17,14 @@ RHEL inf substitutions and versioning used by all drivers.
 
   <PropertyGroup>
     <STAMPINF_VERSION>$(_NT_TARGET_MAJ).$(_RHEL_RELEASE_VERSION_).$(_BUILD_MAJOR_VERSION_).$(_BUILD_MINOR_VERSION_)</STAMPINF_VERSION>
-    <!-- Copyright starting year should be defined in each project -->
+    <!-- CopyrightStrings should be defined in each project -->
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'BalloonCopyrightStrings'">2009</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'PVPanicCopyrightStrings'">2015</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioInputCopyrightStrings'">2016</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioRNGCopyrightStrings'">2014</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioScsiCopyrightStrings'">2012</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioSerialCopyrightStrings'">2010</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioStorCopyrightStrings'">2008</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(RHEL_COPYRIGHT_STARTING_YEAR)' == ''">20??</RHEL_COPYRIGHT_STARTING_YEAR>
   </PropertyGroup>
 
@@ -35,7 +42,7 @@ RHEL inf substitutions and versioning used by all drivers.
 
   <ItemGroup>
     <Substitution Include="INX_COPYRIGHT_1">
-      <ReplaceWith>Copyright (c) INX_COPYRIGHT_YEAR Red Hat Inc.</ReplaceWith>
+      <ReplaceWith>Copyright (c) $(RHEL_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR) Red Hat Inc.</ReplaceWith>
     </Substitution>
     <Substitution Include="INX_COPYRIGHT_2">
       <ReplaceWith></ReplaceWith>
@@ -51,9 +58,6 @@ RHEL inf substitutions and versioning used by all drivers.
     </Substitution>
     <Substitution Include="INX_PREFIX_QEMU">
       <ReplaceWith></ReplaceWith>
-    </Substitution>
-    <Substitution Include="INX_COPYRIGHT_YEAR">
-      <ReplaceWith>$(RHEL_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR)</ReplaceWith>
     </Substitution>
   </ItemGroup>
 </Project>

--- a/Tools/Driver.VZ.props
+++ b/Tools/Driver.VZ.props
@@ -27,9 +27,16 @@ VZ inf substitutions and versioning used by all drivers.
 
   <PropertyGroup>
     <STAMPINF_VERSION>$(VZ_RELEASE_A).$(VZ_RELEASE_B).$(VZ_RELEASE_C).$(_NT_TARGET_MAJ)</STAMPINF_VERSION>
-    <!-- Copyright starting year should be defined in each project -->
+    <!-- CopyrightStrings should be defined in each project -->
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'BalloonCopyrightStrings'">2009</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'PVPanicCopyrightStrings'">2015</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioInputCopyrightStrings'">2016</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioRNGCopyrightStrings'">2014</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioScsiCopyrightStrings'">2012</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioSerialCopyrightStrings'">2010</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioStorCopyrightStrings'">2008</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(RHEL_COPYRIGHT_STARTING_YEAR)' == ''">20??</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR Condition="'$(VZ_COPYRIGHT_STARTING_YEAR)' == ''">20??</VZ_COPYRIGHT_STARTING_YEAR>
+    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
   </PropertyGroup>
 
   <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
@@ -48,10 +55,10 @@ VZ inf substitutions and versioning used by all drivers.
 
   <ItemGroup>
     <Substitution Include="INX_COPYRIGHT_1">
-      <ReplaceWith>Copyright (c) INX_COPYRIGHT_YEAR1 Red Hat Inc.</ReplaceWith>
+      <ReplaceWith>Copyright (c) $(RHEL_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR) Red Hat Inc.</ReplaceWith>
     </Substitution>
     <Substitution Include="INX_COPYRIGHT_2">
-      <ReplaceWith>Copyright (c) INX_COPYRIGHT_YEAR2 Parallels IP Holdings GmbH</ReplaceWith>
+      <ReplaceWith>Copyright (c) $(VZ_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR) Parallels IP Holdings GmbH</ReplaceWith>
     </Substitution>
     <Substitution Include="INX_COMPANY">
       <ReplaceWith>Parallels IP Holdings GmbH</ReplaceWith>
@@ -64,12 +71,6 @@ VZ inf substitutions and versioning used by all drivers.
     </Substitution>
     <Substitution Include="INX_PREFIX_QEMU">
       <ReplaceWith>Virtuozzo </ReplaceWith>
-    </Substitution>
-    <Substitution Include="INX_COPYRIGHT_YEAR1">
-      <ReplaceWith>$(RHEL_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR)</ReplaceWith>
-    </Substitution>
-    <Substitution Include="INX_COPYRIGHT_YEAR2">
-      <ReplaceWith>$(VZ_COPYRIGHT_STARTING_YEAR)-$(COPYRIGHT_CURRENT_YEAR)</ReplaceWith>
     </Substitution>
   </ItemGroup>
 </Project>

--- a/pvpanic/PVPanic Package/pvpanic_pack.props
+++ b/pvpanic/PVPanic Package/pvpanic_pack.props
@@ -9,7 +9,6 @@ Enabling and customizing virtio build features
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
     <Feature_AdjustInf>true</Feature_AdjustInf>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2015</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>PVPanicCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/pvpanic/pvpanic/pvpanic.props
+++ b/pvpanic/pvpanic/pvpanic.props
@@ -8,7 +8,6 @@ Enabling and customizing virtio build features
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2015</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>PVPanicCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/vioinput/hidpassthrough/hidpassthrough.props
+++ b/vioinput/hidpassthrough/hidpassthrough.props
@@ -8,7 +8,6 @@ Enabling and customizing virtio build features
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2016</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioInputCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/vioinput/sys/vioinput.props
+++ b/vioinput/sys/vioinput.props
@@ -12,8 +12,7 @@ Enabling and customizing virtio build features
     <Feature_PackOne>true</Feature_PackOne>
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2016</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioInputCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/viorng/VirtRNG Package/viorng_pack.props
+++ b/viorng/VirtRNG Package/viorng_pack.props
@@ -9,7 +9,6 @@ Enabling and customizing virtio build features
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
     <Feature_AdjustInf>true</Feature_AdjustInf>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2014</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioRNGCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/viorng/cng/um/viorngum.props
+++ b/viorng/cng/um/viorngum.props
@@ -8,7 +8,6 @@ Enabling and customizing virtio build features
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2014</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioRNGCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/viorng/coinstaller/viorngci.props
+++ b/viorng/coinstaller/viorngci.props
@@ -8,7 +8,6 @@ Enabling and customizing virtio build features
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2014</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioRNGCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/viorng/viorng/viorng.props
+++ b/viorng/viorng/viorng.props
@@ -8,7 +8,6 @@ Enabling and customizing virtio build features
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2014</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioRNGCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/vioscsi/vioscsi.props
+++ b/vioscsi/vioscsi.props
@@ -14,8 +14,7 @@ Enabling and customizing virtio build features
     <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <SourceInfFile>vioscsi.inx</SourceInfFile>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2012</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioScsiCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vioserial/sys/vioser.props
+++ b/vioserial/sys/vioser.props
@@ -15,7 +15,6 @@ Enabling and customizing virtio build features
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <SourceInfFile>vioser.inx</SourceInfFile>
     <PackOne_DestinationPrefix>..\</PackOne_DestinationPrefix>
-    <RHEL_COPYRIGHT_STARTING_YEAR>2010</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioSerialCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>

--- a/viostor/viostor.props
+++ b/viostor/viostor.props
@@ -14,7 +14,6 @@ Enabling and customizing virtio build features
     <Feature_AdjustInfLegacy>true</Feature_AdjustInfLegacy>
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <!-- $(SourceInfFile) is already defined in .vcxproj -->
-    <RHEL_COPYRIGHT_STARTING_YEAR>2008</RHEL_COPYRIGHT_STARTING_YEAR>
-    <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
+    <CopyrightStrings>VioStorCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Defines a new CopyrightStrings property which is then used in
vendor specific files to compose copyright strings. This way
a new vendor FOO will define their copyright string policy in
Driver.FOO.props
foo.ver
etc.

without touching driver props files.

Keeping vendor specific properties in their separate files makes
introducing a new vendor a purely additive process, without the
need to edit existing files. The vendor may even keep their files
"downstream only" if they choose so.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>