### PR TITLE
netkvm: Set target hw address to zero in ARP announcement

### DIFF
--- a/NetKVM/Common/ParaNdis_GuestAnnounce.cpp
+++ b/NetKVM/Common/ParaNdis_GuestAnnounce.cpp
@@ -47,7 +47,8 @@ EthernetArpFrame *CGuestAnnouncePackets::CreateIPv4Packet(UINT32 IPV4)
         packet->frame.sender_hardware_address.address[i] = (UINT8)m_Context->CurrentMacAddress[i];
         packet->frame.target_hardware_address.address[i] = 0xFF;
         packet->data.sender_hardware_address.address[i] = m_Context->CurrentMacAddress[i];
-        packet->data.target_hardware_address.address[i] = 0xFF;
+        // according to RFC 5227 ARP announcement shall set target hardware address to zero
+        packet->data.target_hardware_address.address[i] = 0;
     }
     packet->data.sender_ipv4_address.address = packet->data.target_ipv4_address.address = IPV4;
     return packet;


### PR DESCRIPTION
See RFC 5227
https://tools.ietf.org/html/rfc5227#section-2.3
https://tools.ietf.org/html/rfc5227#section-2.1.1

Target hardware address in ARP payload should be set to 0

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>