### PR TITLE
vioserial: Improve error handling

### DIFF
--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -494,7 +494,7 @@ VIOSerialEvtDeviceD0Entry(
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "--> %s\n", __FUNCTION__);
 
-    if(!pContext->DeviceOK)
+    if (!pContext->DeviceOK)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "Setting VIRTIO_CONFIG_S_FAILED flag\n");
         VirtIOWdfSetDriverFailed(&pContext->VDevice);
@@ -504,7 +504,12 @@ VIOSerialEvtDeviceD0Entry(
         status = VIOSerialInitAllQueues(Device);
         if (NT_SUCCESS(status) && pContext->isHostMultiport)
         {
-            VIOSerialFillQueue(pContext->c_ivq, pContext->CVqLock);
+            status = VIOSerialFillQueue(pContext->c_ivq, pContext->CVqLock);
+        }
+
+        if (!NT_SUCCESS(status))
+        {
+            pContext->DeviceOK = FALSE;
         }
     }
 

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1394,7 +1394,6 @@ VIOSerialPortEvtDeviceD0Exit(
     )
 {
     PVIOSERIAL_PORT Port = RawPdoSerialPortGetData(Device)->port;
-    PPORT_BUFFER buf;
     PSINGLE_LIST_ENTRY iter;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "--> %s TargetState: %d\n",
@@ -1411,10 +1410,7 @@ VIOSerialPortEvtDeviceD0Exit(
 
     VIOSerialReclaimConsumedBuffers(Port);
 
-    while (buf = (PPORT_BUFFER)virtqueue_detach_unused_buf(GetInQueue(Port)))
-    {
-        VIOSerialFreeBuffer(buf);
-    }
+    VIOSerialDrainQueue(GetInQueue(Port));
 
     iter = PopEntryList(&Port->WriteBuffersList);
     while (iter != NULL)

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1356,6 +1356,10 @@ NTSTATUS VIOSerialPortEvtDeviceD0Entry(
 
     PAGED_CODE();
 
+    if (!pCtx->DeviceOK)
+    {
+        return STATUS_DEVICE_NOT_CONNECTED;
+    }
     if ((pCtx->in_vqs == NULL) || (pCtx->in_vqs[port->PortId] == NULL))
     {
         return STATUS_NOT_FOUND;

--- a/vioserial/sys/vioser.h
+++ b/vioserial/sys/vioser.h
@@ -175,6 +175,11 @@ VIOSerialFillQueue(
     IN WDFSPINLOCK Lock
 );
 
+VOID
+VIOSerialDrainQueue(
+    IN struct virtqueue *vq
+    );
+
 NTSTATUS
 VIOSerialAddInBuf(
     IN struct virtqueue *vq,


### PR DESCRIPTION
This work was prompted the crash reported in
https://bugzilla.redhat.com/show_bug.cgi?id=1419900

    vioserial: Introduce VIOSerialDrainQueue

    If VIOSerialFillQueue fails, its effects need to be undone.
    VIOSerialFillQueue is called from D0 entry callbacks, which are
    not followed by D0 exit callbacks on failure, so the buffers that
    may have been added to the queue need to be freed within the D0
    entry.

    This commit adds a new function VIOSerialDrainQueue to take care
    of freeing buffers on the queue. In addition do the D0 exit
    callbacks, the new function is called from VIOSerialFillQueue
    when it's about to return a failed NTSTATUS.


    vioserial: Propagate D0 entry failure from device to ports

    From the "Reporting Device Failures" MSDN page:
    If a bus driver's EvtDeviceD0Entry function returns a value for
    which NT_SUCCESS(status) equals FALSE, the framework might still
    call the EvtDeviceD0Entry functions of drivers associated with
    the bus driver's child devices.

    In the case of vioserial, VIOSerialEvtDeviceD0Entry may fail
    because it couldn't allocate memory or couldn't initialize
    virtqueues. As of this commit, this condition is communicated
    using the otherwise redundant DeviceOK flag to
    VIOSerialPortEvtDeviceD0Entry which fails fast if the flag is
    not TRUE.

    Also, the return value of VIOSerialFillQueue is no longer ignored
    in VIOSerialEvtDeviceD0Entry.

    Fixes the BSOD reported in https://bugzilla.redhat.com/show_bug.cgi?id=1419900