### PR TITLE
balloon: Put BalloonInit and BalloonTerm under device lock

### DIFF
--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -34,6 +34,8 @@ BalloonInit(
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "--> BalloonInit\n");
 
+    WdfObjectAcquireLock(WdfDevice);
+
     // inflate
     params[0].bEnableInterruptSuppression = false;
     params[0].Interrupt = devCtx->WdfInterrupt;
@@ -120,6 +122,8 @@ BalloonInit(
     {
         virtqueue_kick(devCtx->StatVirtQueue);
     }
+
+    WdfObjectReleaseLock(WdfDevice);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<-- BalloonInit\n");
     return status;
@@ -296,8 +300,12 @@ BalloonTerm(
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "--> BalloonTerm\n");
 
+    WdfObjectAcquireLock(WdfDevice);
+
     VirtIOWdfDestroyQueues(&devCtx->VDevice);
     devCtx->StatVirtQueue = NULL;
+
+    WdfObjectReleaseLock(WdfDevice);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<-- BalloonTerm\n");
 }


### PR DESCRIPTION
Some HCK tests can still crash the driver by running the
BalloonEvtFileClose callback in parallel with
BalloonEvtDeviceD0Entry. BalloonEvtFileClose uses the value
of StatVirtQueue to check whether the device is up. In the
pathological case, this field is still non-NULL when
BalloonEvtFileClose reads it, but the device is terminated
before it has a chance to finish sending the stats to the host.

In commit 9b81256 explicit device-level synchronization was
added to BalloonEvtFileClose which was believed to solve this
assuming that power callbacks are synchronized automatically.

MSDN says that "The framework always synchronizes each device's
PnP and power management callback functions." but it only means
that the callbacks are synchronized with each other.

This commit adds explicit device-level synchronization to
BalloonInit and BalloonTerm (called from D0 entry and D0 exit)
to fix this race for real.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>