### PR TITLE
netkvm: Fix wrong access to zeroed m_NBL member

### DIFF
--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -26,12 +26,12 @@ CNBL::~CNBL()
     {
         auto NBL = DetachInternalObject();
         NETKVM_ASSERT(NET_BUFFER_LIST_NEXT_NBL(NBL) == nullptr);
-        if (CallCompletionForNBL(m_Context, m_NBL))
+        if (CallCompletionForNBL(m_Context, NBL))
         {
             m_ParentTXPath->CompleteOutstandingNBLChain(NBL);
         } else
         {
-            m_ParentTXPath->CompleteOutstandingInternalNBL(m_NBL);
+            m_ParentTXPath->CompleteOutstandingInternalNBL(NBL);
         }
     }
 }


### PR DESCRIPTION
In case the NBL shall be completed from the destructor of CNBL
object, the access causes BSOD.