### PR TITLE
Add missing invokes to va_end macro

### DIFF
--- a/Balloon/sys/utils.c
+++ b/Balloon/sys/utils.c
@@ -57,6 +57,7 @@ static void DebugPrintFuncSerial(const char *format, ...)
         WRITE_PORT_BUFFER_UCHAR(RHEL_DEBUG_PORT, (PUCHAR)buf, len);
         WRITE_PORT_UCHAR(RHEL_DEBUG_PORT, '\r');
     }
+    va_end(list);
 }
 #endif
 
@@ -66,6 +67,7 @@ static void DebugPrintFunc(const char *format, ...)
     va_list list;
     va_start(list, format);
     vDbgPrintEx(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, format, list);
+    va_end(list);
 }
 #endif
 

--- a/NetKVM/Common/ParaNdis-Debug.cpp
+++ b/NetKVM/Common/ParaNdis-Debug.cpp
@@ -115,6 +115,7 @@ static void NetKVMDebugPrint(const char *fmt, ...)
         }
     }
 #endif
+    va_end(list);
 }
 
 tDebugPrintFunc VirtioDebugPrintProc = NetKVMDebugPrint;

--- a/vioinput/sys/utils.c
+++ b/vioinput/sys/utils.c
@@ -53,6 +53,7 @@ static void DebugPrintFuncSerial(const char *format, ...)
         WRITE_PORT_BUFFER_UCHAR(RHEL_DEBUG_PORT, (PUCHAR)buf, len);
         WRITE_PORT_UCHAR(RHEL_DEBUG_PORT, '\r');
     }
+    va_end(list);
 }
 #endif
 
@@ -62,6 +63,7 @@ static void DebugPrintFunc(const char *format, ...)
     va_list list;
     va_start(list, format);
     vDbgPrintEx(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, format, list);
+    va_end(list);
 }
 #endif
 

--- a/vioscsi/utils.c
+++ b/vioscsi/utils.c
@@ -44,6 +44,7 @@ static void DebugPrintFuncSerial(const char *format, ...)
         WRITE_PORT_BUFFER_UCHAR(RHEL_DEBUG_PORT, (PUCHAR)buf, len);
         WRITE_PORT_UCHAR(RHEL_DEBUG_PORT, '\r');
     }
+    va_end(list);
 }
 #endif
 
@@ -53,6 +54,7 @@ static void DebugPrintFunc(const char *format, ...)
     va_list list;
     va_start(list, format);
     vDbgPrintEx(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, format, list);
+    va_end(list);
 }
 #endif
 

--- a/vioserial/sys/utils.c
+++ b/vioserial/sys/utils.c
@@ -54,6 +54,7 @@ static void DebugPrintFuncSerial(const char *format, ...)
         WRITE_PORT_BUFFER_UCHAR(RHEL_DEBUG_PORT, (PUCHAR)buf, len);
         WRITE_PORT_UCHAR(RHEL_DEBUG_PORT, '\r');
     }
+    va_end(list);
 }
 #endif
 
@@ -63,6 +64,7 @@ static void DebugPrintFunc(const char *format, ...)
     va_list list;
     va_start(list, format);
     vDbgPrintEx(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, format, list);
+    va_end(list);
 }
 #endif
 

--- a/viostor/virtio_stor_utils.c
+++ b/viostor/virtio_stor_utils.c
@@ -46,6 +46,7 @@ static void DebugPrintFuncSerial(const char *format, ...)
         WRITE_PORT_BUFFER_UCHAR(RHEL_DEBUG_PORT, (PUCHAR)buf, len);
         WRITE_PORT_UCHAR(RHEL_DEBUG_PORT, '\r');
     }
+    va_end(list);
 }
 #endif
 
@@ -55,6 +56,7 @@ static void DebugPrintFunc(const char *format, ...)
     va_list list;
     va_start(list, format);
     vDbgPrintEx(DPFLTR_DEFAULT_ID, 9 | DPFLTR_MASK, format, list);
+    va_end(list);
 }
 #endif
 


### PR DESCRIPTION
According to documentation the va_end macro should be invoked before
the function returns whenever va_start has been invoked from that
function.

This commit fixes errors reported by cppcheck tool.

Error sample:
[kvm-guest-drivers-windows/Balloon/sys/utils.c:60]: (error) va_list 'list'
was opened but not closed by va_end().

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>