### PR TITLE
virtiolib: Remember interrupt message numbers

### DIFF
--- a/VirtIO/WDF/private.h
+++ b/VirtIO/WDF/private.h
@@ -27,6 +27,19 @@ typedef struct virtio_wdf_bar {
     bool              bPortSpace;
 } VIRTIO_WDF_BAR, *PVIRTIO_WDF_BAR;
 
+typedef struct virtio_wdf_interrupt_context {
+    /* This is a workaround for a WDF bug where on resource rebalance
+     * it does not preserve the MessageNumber field of its internal
+     * data structures describing interrupts. As a result, we fail to
+     * report the right MSI message number to the virtio device when
+     * re-initializing it and it may stop working.
+     */
+    USHORT            uMessageNumber;
+    bool              bMessageNumberSet;
+} VIRTIO_WDF_INTERRUPT_CONTEXT, *PVIRTIO_WDF_INTERRUPT_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VIRTIO_WDF_INTERRUPT_CONTEXT, GetInterruptContext)
+
 NTSTATUS PCIAllocBars(WDFCMRESLIST ResourcesTranslated,
                       PVIRTIO_WDF_DRIVER pWdfDriver);
 
@@ -36,5 +49,7 @@ int PCIReadConfig(PVIRTIO_WDF_DRIVER pWdfDriver,
                   int where,
                   void *buffer,
                   size_t length);
+
+NTSTATUS PCIRegisterInterrupt(WDFINTERRUPT Interrupt);
 
 u16 PCIGetMSIInterruptVector(WDFINTERRUPT Interrupt);

--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -51,7 +51,7 @@ VIOSerialInitInterruptHandling(
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_HW_ACCESS, "--> %s\n", __FUNCTION__);
 
-    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, PORTS_DEVICE);
+    WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
     WDF_INTERRUPT_CONFIG_INIT(
                                  &interruptConfig,
                                  VIOSerialInterruptIsr,


### PR DESCRIPTION
This is a workaround for a WDF bug, last seen in version 1.9 and
confirmed fixed in 1.11. On resource rebalance WDF does not
preserve the MessageNumber field of its internal data structures
describing interrupts. As a result, we fail to report the right
MSI message number to the virtio device when re-initializing it
and it may stop working.

This manifests as a hang while trying to write to a virtual serial
port after a CPU is hotplugged to Windows 2008 R2, for example.

The fix is to keep the message number in a separate context
structure, attached to the interrupt object the first time it is
passed to us. Getting the message number can be subsequently
satisfied from this context, rather than from the buggy
WdfInterruptGetInfo call.

---

The first commit is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1435778

The second commit fixes a minor issue found when working on the bug.
It is not related to BZ #1435778 other than by also touching interrupt context.