### PR TITLE
vioscsi: DPC fixes

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -432,18 +432,15 @@ ENTER_FN();
 
     if (!isr) {
         if (adaptExt->msix_enabled) {
-            if (!CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
-                // Queue numbers start at 0, message ids at 1.
-                NT_ASSERT(MessageID > VIRTIO_SCSI_REQUEST_QUEUE_0);
-                NT_ASSERT(MessageID <= VIRTIO_SCSI_REQUEST_QUEUE_0 + adaptExt->num_queues);
-                StorPortAcquireSpinLock(DeviceExtension, DpcLock, &adaptExt->dpc[MessageID - VIRTIO_SCSI_REQUEST_QUEUE_0 - 1], LockHandle);
-            }
+            // Queue numbers start at 0, message ids at 1.
+            NT_ASSERT(MessageID > VIRTIO_SCSI_REQUEST_QUEUE_0);
+            NT_ASSERT(MessageID <= VIRTIO_SCSI_REQUEST_QUEUE_0 + adaptExt->num_queues);
+            StorPortAcquireSpinLock(DeviceExtension, DpcLock, &adaptExt->dpc[MessageID - VIRTIO_SCSI_REQUEST_QUEUE_0 - 1], LockHandle);
         }
         else {
             StorPortAcquireSpinLock(DeviceExtension, InterruptLock, NULL, LockHandle);
         }
     }
-
 EXIT_FN();
 }
 
@@ -461,10 +458,7 @@ ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
     if (!isr) {
-        if (!adaptExt->msix_enabled || !CHECKFLAG(adaptExt->perfFlags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
-            StorPortReleaseSpinLock(DeviceExtension, LockHandle);
-        }
+        StorPortReleaseSpinLock(DeviceExtension, LockHandle);
     }
-
 EXIT_FN();
 }

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -774,7 +774,7 @@ ENTER_FN();
             }
 #endif
         }
-        if ((adaptExt->num_queues > 1) && !adaptExt->dpc_ok && !StorPortEnablePassiveInitialization(DeviceExtension, VioScsiPassiveInitializeRoutine)) {
+        if (!adaptExt->dpc_ok && !StorPortEnablePassiveInitialization(DeviceExtension, VioScsiPassiveInitializeRoutine)) {
             RhelDbgPrint(TRACE_LEVEL_FATAL, ("%s StorPortEnablePassiveInitialization FAILED\n", __FUNCTION__));
             return FALSE;
         }
@@ -1263,7 +1263,7 @@ ENTER_FN();
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if ((adaptExt->num_queues > 1) && adaptExt->dpc_ok && MessageID > 0) {
+    if (!adaptExt->dump_mode && adaptExt->dpc_ok && MessageID > 0) {
         StorPortIssueDpc(DeviceExtension,
             &adaptExt->dpc[MessageID-3],
             ULongToPtr(MessageID),

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -100,6 +100,10 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_SCSI_REQUEST_QUEUE_0            2
 #define VIRTIO_SCSI_QUEUE_LAST                 VIRTIO_SCSI_REQUEST_QUEUE_0 + MAX_CPU
 
+/* MSI messages and virtqueue indices are offset by 1, MSI 0 is not used */
+#define QUEUE_TO_MESSAGE(QueueId)              ((QueueId) + 1)
+#define MESSAGE_TO_QUEUE(MessageId)            ((MessageId) - 1)
+
 /* SCSI command request, followed by data-out */
 #pragma pack(1)
 typedef struct {

--- a/vioscsi/virtio_pci.c
+++ b/vioscsi/virtio_pci.c
@@ -194,7 +194,7 @@ static u16 vdev_get_msix_vector(void *context, int queue)
             if (adaptExt->msix_one_vector) {
                 vector = 0;
             } else {
-                vector = queue + 1;
+                vector = QUEUE_TO_MESSAGE(queue);
             }
         } else {
             vector = VIRTIO_MSI_NO_VECTOR;


### PR DESCRIPTION
This is a follow-up to https://github.com/virtio-win/kvm-guest-drivers-windows/pull/103 where we decided to keep the simplified locking logic and complete requests in DPC even when running with only one queue.