### PR TITLE
Viostor/vioscsi: Fix uncached extension layout

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -500,7 +500,7 @@ ENTER_FN();
      */
     adaptExt->pageAllocationVa = (PVOID)(((ULONG_PTR)(uncachedExtensionVa) + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1));
     if (adaptExt->poolAllocationSize > 0) {
-        adaptExt->poolAllocationVa = (PVOID)((ULONG_PTR)uncachedExtensionVa + adaptExt->pageAllocationSize);
+        adaptExt->poolAllocationVa = (PVOID)((ULONG_PTR)adaptExt->pageAllocationVa + adaptExt->pageAllocationSize);
     }
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("Page-aligned area at %p, size = %d\n", adaptExt->pageAllocationVa, adaptExt->pageAllocationSize));
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("Pool area at %p, size = %d\n", adaptExt->poolAllocationVa, adaptExt->poolAllocationSize));

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -485,7 +485,7 @@ VirtIoFindAdapter(
 
     adaptExt->pageAllocationVa = (PVOID)(((ULONG_PTR)(uncachedExtensionVa) + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1));
     if (adaptExt->poolAllocationSize > 0) {
-        adaptExt->poolAllocationVa = (PVOID)((ULONG_PTR)uncachedExtensionVa + adaptExt->pageAllocationSize);
+        adaptExt->poolAllocationVa = (PVOID)((ULONG_PTR)adaptExt->pageAllocationVa + adaptExt->pageAllocationSize);
     }
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("Page-aligned area at %p, size = %d\n", adaptExt->pageAllocationVa, adaptExt->pageAllocationSize));
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("Pool area at %p, size = %d\n", adaptExt->poolAllocationVa, adaptExt->poolAllocationSize));


### PR DESCRIPTION
The "pool" region of the uncached extension is meant to follow the
"page" region but due to a bug the two could overlap, leading to
memory corruptions.

adaptExt->pageAllocationVa is page-aligned and may be greater than
uncachedExtensionVa. adaptExt->poolAllocationVa must use the page-
aligned value to compute the end of the page region.

The bug was introduced in commit 4ab136a0 and then copied to viostor
as part of the MQ work.

cc @vrozenfe 