### PR TITLE
netkvm: Disable WMI custom OIDs for Vista/2008

### DIFF
--- a/NetKVM/wlh/ParaNdis6-Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6-Oid.cpp
@@ -264,9 +264,12 @@ static NDIS_OID SupportedOids[] =
         OID_GEN_XMIT_OK,
         OID_GEN_RCV_OK,
         OID_GEN_VLAN_ID,
+#if NDIS_SUPPORT_NDIS61
+// disable WMI custom command on 2008 due to non-filtered NDIS test failure
         OID_GEN_SUPPORTED_GUIDS,
         OID_VENDOR_1,
         OID_VENDOR_2,
+#endif
         OID_OFFLOAD_ENCAPSULATION,
         OID_TCP_OFFLOAD_PARAMETERS,
 #if PARANDIS_SUPPORT_RSS
@@ -439,8 +442,10 @@ static NDIS_STATUS ParaNdis_OidQuery(PARANDIS_ADAPTER *pContext, tOidDesc *pOid)
             ulSize = sizeof(pContext->Statistics);
             break;
         case OID_GEN_SUPPORTED_GUIDS:
+#if NDIS_SUPPORT_NDIS61
             pInfo = (PVOID)&supportedGUIDs;
             ulSize = sizeof(supportedGUIDs);
+#endif
             break;
         case OID_VENDOR_1:
             pInfo = &virtioDebugLevel;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439085

WLK 1.6 does not recognize filter for '1c_wmicoverage' test
which fails if network driver supports custom OIDs mapped
to WMI GUIDs (on later operating systems and HCK 2.1 and up the
test also fails but the failure filtered properly).
Current commit disables custom OIDs for Vista/2008 to let all
certification tests pass.