### PR TITLE
viostor: Fix potential NULL dereference

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1341,8 +1341,10 @@ RhelScsiGetCapacity(
         PSENSE_DATA senseBuffer = NULL;
         UCHAR ScsiStatus = SCSISTAT_CHECK_CONDITION;
         SRB_GET_SENSE_INFO_BUFFER(Srb, senseBuffer);
-        senseBuffer->SenseKey = SCSI_SENSE_ILLEGAL_REQUEST;
-        senseBuffer->AdditionalSenseCode = SCSI_ADSENSE_INVALID_CDB;
+        if (senseBuffer) {
+            senseBuffer->SenseKey = SCSI_SENSE_ILLEGAL_REQUEST;
+            senseBuffer->AdditionalSenseCode = SCSI_ADSENSE_INVALID_CDB;
+        }
         SRB_SET_SCSI_STATUS(((PSRB_TYPE)Srb), ScsiStatus);
         return SrbStatus;
     }


### PR DESCRIPTION
The static driver verifier build flags this as a potential NULL
dereference. If SRB_GET_SENSE_INFO_BUFFER fails senseBuffer will
be NULL.

  viostor\virtio_stor.c(1342): warning C6011: Dereferencing NULL pointer 'senseBuffer'.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>

cc @vrozenfe 