### PR TITLE
vioinput: Fuzz testing fixes

### DIFF
--- a/vioinput/sys/Array.c
+++ b/vioinput/sys/Array.c
@@ -89,6 +89,11 @@ VOID DynamicArrayDestroy(PDYNAMIC_ARRAY pArray)
     }
 }
 
+BOOLEAN DynamicArrayIsEmpty(PDYNAMIC_ARRAY pArray)
+{
+    return (pArray->Ptr == NULL || pArray->Size == 0);
+}
+
 PVOID DynamicArrayGet(PDYNAMIC_ARRAY pArray, SIZE_T *pcbSize)
 {
     PVOID Ptr = pArray->Ptr;

--- a/vioinput/sys/Hid.c
+++ b/vioinput/sys/Hid.c
@@ -455,7 +455,7 @@ VIOInputBuildReportDescriptor(PINPUT_DEVICE pContext)
         }
     }
 
-    // if we have any absolute axes left, we'll expose a table device
+    // if we have any absolute axes left, we'll expose a tablet device
     if (!InputCfgDataEmpty(&AbsData))
     {
         status = HIDTabletProbe(
@@ -506,22 +506,30 @@ VIOInputBuildReportDescriptor(PINPUT_DEVICE pContext)
         }
     }
 
-    // initialize the HID descriptor
-    pContext->HidReportDescriptor = (PHID_REPORT_DESCRIPTOR)DynamicArrayGet(
-        &ReportDescriptor,
-        &cbReportDescriptor);
-    if (!pContext->HidReportDescriptor)
+    if (DynamicArrayIsEmpty(&ReportDescriptor))
     {
-        status = STATUS_INSUFFICIENT_RESOURCES;
+        // we are not exposing any device
+        pContext->HidReportDescriptor = NULL;
     }
     else
     {
-        pContext->HidDescriptor = G_DefaultHidDescriptor;
-        pContext->HidDescriptor.DescriptorList[0].wReportLength = (USHORT)cbReportDescriptor;
+        // initialize the HID descriptor
+        pContext->HidReportDescriptor = (PHID_REPORT_DESCRIPTOR)DynamicArrayGet(
+            &ReportDescriptor,
+            &cbReportDescriptor);
+        if (!pContext->HidReportDescriptor)
+        {
+            status = STATUS_INSUFFICIENT_RESOURCES;
+        }
+        else
+        {
+            pContext->HidDescriptor = G_DefaultHidDescriptor;
+            pContext->HidDescriptor.DescriptorList[0].wReportLength = (USHORT)cbReportDescriptor;
 
-        pContext->HidReportDescriptorHash = ComputeHash(pContext->HidReportDescriptor, cbReportDescriptor);
+            pContext->HidReportDescriptorHash = ComputeHash(pContext->HidReportDescriptor, cbReportDescriptor);
 
-        DumpReportDescriptor(pContext->HidReportDescriptor, cbReportDescriptor);
+            DumpReportDescriptor(pContext->HidReportDescriptor, cbReportDescriptor);
+        }
     }
 
 Exit:

--- a/vioinput/sys/Hid.c
+++ b/vioinput/sys/Hid.c
@@ -353,6 +353,15 @@ static u8 SelectInputConfig(PINPUT_DEVICE pContext, u8 cfgSelect, u8 cfgSubSel)
     return size;
 }
 
+BOOLEAN InputCfgDataHasBit(PVIRTIO_INPUT_CFG_DATA pData, ULONG bit)
+{
+    if (pData->size <= (bit / 8))
+    {
+        return FALSE;
+    }
+    return (pData->u.bitmap[bit / 8] & (1 << (bit % 8)));
+}
+
 static BOOLEAN InputCfgDataEmpty(PVIRTIO_INPUT_CFG_DATA pCfgData)
 {
     UCHAR i;

--- a/vioinput/sys/vioinput.h
+++ b/vioinput/sys/vioinput.h
@@ -342,6 +342,11 @@ DecodeNextBit(
     PUCHAR pValue
 );
 
+BOOLEAN InputCfgDataHasBit(
+    PVIRTIO_INPUT_CFG_DATA pData,
+    ULONG bit
+);
+
 VOID
 GetAbsAxisInfo(
     PINPUT_DEVICE pContext,

--- a/vioinput/sys/vioinput.h
+++ b/vioinput/sys/vioinput.h
@@ -312,6 +312,11 @@ DynamicArrayDestroy(
     PDYNAMIC_ARRAY pArray
 );
 
+BOOLEAN
+DynamicArrayIsEmpty(
+    PDYNAMIC_ARRAY pArray
+);
+
 PVOID
 DynamicArrayGet(
     PDYNAMIC_ARRAY pArray,


### PR DESCRIPTION
Fixes for virtio-input bugs found with a random input device generator.
https://github.com/ladipro/linux/blob/input_fuzzer/drivers/input/misc/input-fuzzer.c

The test re-loads the input-fuzzer module in a loop, attaching the evdev device to a Windows VM and using the QEMU guest agent to execute "devcon status" to see if the guest driver is loaded without errors.