### PR TITLE
pciserial: Add a pci-serial (1x only) .inf for RHEL

### DIFF
--- a/pciserial/buildAll.bat
+++ b/pciserial/buildAll.bat
@@ -4,9 +4,12 @@ rem call ..\Tools\SetVsEnv 14 x64
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 
-inf2cat /driver:. /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+mkdir Install\rhel
 
-mkdir Install
 copy qemupciserial.* .\Install\
+inf2cat /driver:Install /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+
+copy rhel\qemupciserial.* .\Install\rhel
+inf2cat /driver:Install\rhel /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
 
 endlocal

--- a/pciserial/qemupciserial.inf
+++ b/pciserial/qemupciserial.inf
@@ -1,14 +1,14 @@
 ; qemupciserial.inf for QEMU, based on MSPORTS.INF
 
 ; The driver itself is shipped with Windows (serial.sys).  This is
-; just a inf file to tell windows which pci id the serial pci card
+; just a inf file to tell windows which PCI ID the serial PCI card
 ; emulated by qemu has, and to apply a name tag to it which windows
 ; will show in the device manager.
 
-; Installing the driver: Go to device manager.  You should find a "pci
-; serial card" tagged with a yellow question mark.  Open properties.
-; Pick "update driver".  Then "select driver manually".  Pick "Ports
-; (Com+Lpt)" from the list.  Click "Have a disk".  Select this file.
+; Installing the driver: Go to Device Manager.  You should find a "PCI
+; Serial Port" tagged with a yellow question mark.  Open properties.
+; Pick "Update Driver".  Then "Select driver manually".  Pick "Ports
+; (COM & LPT)" from the list.  Click "Have Disk".  Select this file.
 ; Procedure may vary a bit depending on the windows version.
 
 ; This file covers all options: pci-serial, pci-serial-2x, pci-serial-4x

--- a/pciserial/rhel/qemupciserial.inf
+++ b/pciserial/rhel/qemupciserial.inf
@@ -1,0 +1,113 @@
+; qemupciserial.inf for QEMU, based on MSPORTS.INF
+
+; The driver itself is shipped with Windows (serial.sys).  This is
+; just a inf file to tell windows which PCI ID the serial PCI card
+; emulated by qemu has, and to apply a name tag to it which windows
+; will show in the device manager.
+
+; Installing the driver: Go to Device Manager.  You should find a "PCI
+; Serial Port" tagged with a yellow question mark.  Open properties.
+; Pick "Update Driver".  Then "Select driver manually".  Pick "Ports
+; (COM & LPT)" from the list.  Click "Have Disk".  Select this file.
+; Procedure may vary a bit depending on the windows version.
+
+; This file covers pci-serial (1x only) for both 32 and 64 bit platforms.
+
+[Version]
+Signature="$CHICAGO$"
+Class=Ports
+ClassGuid={4D36E978-E325-11CE-BFC1-08002BE10318}
+CatalogFile=qemupciserial.cat
+Provider=%QEMU%
+DriverVer=05/09/2017,1.4.0
+
+[SourceDisksNames]
+3426=windows cd
+
+[SourceDisksFiles]
+serial.sys 		= 3426
+serenum.sys 		= 3426
+
+[DestinationDirs]
+DefaultDestDir  = 11        ;LDID_SYS
+ComPort.NT.Copy = 12        ;DIRID_DRIVERS
+SerialEnumerator.NT.Copy=12 ;DIRID_DRIVERS
+
+; Drivers
+;----------------------------------------------------------
+[Manufacturer]
+%QEMU%=QEMU,NTx86,NTamd64
+
+[QEMU.NTx86]
+%QEMU-PCI_SERIAL.DeviceDesc% = ComPort, "PCI\VEN_1b36&DEV_0002&CC_0700"
+
+[QEMU.NTamd64]
+%QEMU-PCI_SERIAL.DeviceDesc% = ComPort, "PCI\VEN_1b36&DEV_0002&CC_0700"
+
+; COM sections
+;----------------------------------------------------------
+[ComPort.AddReg]
+HKR,,PortSubClass,1,01
+
+[ComPort.NT]
+AddReg=ComPort.AddReg, ComPort.NT.AddReg
+LogConfig=caa
+SyssetupPnPFlags = 1
+
+[ComPort.NT.HW]
+AddReg=ComPort.NT.HW.AddReg
+
+[ComPort.NT.AddReg]
+HKR,,EnumPropPages32,,"MsPorts.dll,SerialPortPropPageProvider"
+
+[ComPort.NT.HW.AddReg]
+HKR,,"UpperFilters",0x00010000,"serenum"
+
+;-------------- Service installation
+; Port Driver (function driver for this device)
+[ComPort.NT.Services]
+AddService = Serial, 0x00000002, Serial_Service_Inst, Serial_EventLog_Inst
+AddService = Serenum,,Serenum_Service_Inst
+
+; -------------- Serial Port Driver install sections
+[Serial_Service_Inst]
+DisplayName    = %Serial.SVCDESC%
+ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
+StartType      = 1               ; SERVICE_SYSTEM_START (this driver may do detection)
+ErrorControl   = 0               ; SERVICE_ERROR_IGNORE
+ServiceBinary  = %12%\serial.sys
+LoadOrderGroup = Extended base
+
+; -------------- Serenum Driver install section
+[Serenum_Service_Inst]
+DisplayName    = %Serenum.SVCDESC%
+ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
+StartType      = 3               ; SERVICE_DEMAND_START
+ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
+ServiceBinary  = %12%\serenum.sys
+LoadOrderGroup = PNP Filter
+
+[Serial_EventLog_Inst]
+AddReg = Serial_EventLog_AddReg
+
+[Serial_EventLog_AddReg]
+HKR,,EventMessageFile,0x00020000,"%%SystemRoot%%\System32\IoLogMsg.dll;%%SystemRoot%%\System32\drivers\serial.sys"
+HKR,,TypesSupported,0x00010001,7
+
+; The following sections are COM port resource configs.
+; Section name format means:
+; Char 1 = c (COM port)
+; Char 2 = I/O config: 1 (3f8), 2 (2f8), 3 (3e8), 4 (2e8), a (any)
+; Char 3 = IRQ config: #, a (any)
+
+[caa]                   ; Any base, any IRQ
+ConfigPriority=HARDRECONFIG
+IOConfig=8@100-ffff%fff8(3ff::)
+IRQConfig=S:3,4,5,7,9,10,11,12,14,15
+
+[Strings]
+QEMU="QEMU"
+QEMU-PCI_SERIAL.DeviceDesc="QEMU Serial PCI Card"
+
+Serial.SVCDESC   = "Serial port driver"
+Serenum.SVCDESC = "Serenum Filter Driver"


### PR DESCRIPTION
The combined pci-serial & pci-serial-2x & pci-serial-4x .inf
file cannot pass WHQL tests due to what looks like a bug in
MF.sys (Windows inbox component).

https://bugzilla.redhat.com/show_bug.cgi?id=1443019

This commit adds an alternative version of the file based on
what was shipped in RHEL 7.3. RHEL QEMU supports only the
single-port device (-device pci-serial) so it can get away
without the MF.sys dependency for now.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>


Here's the diff between RHEL 7.3 qemupciserial.inf and the new file:

```
4c4
< ; just a inf file to tell windows which pci id the serial pci card
---
> ; just a inf file to tell windows which PCI ID the serial PCI card
8,11c8,11
< ; Installing the driver: Go to device manager.  You should find a "pci
< ; serial card" tagged with a yellow question mark.  Open properties.
< ; Pick "update driver".  Then "select driver manually".  Pick "Ports
< ; (Com+Lpt)" from the list.  Click "Have a disk".  Select this file.
---
> ; Installing the driver: Go to Device Manager.  You should find a "PCI
> ; Serial Port" tagged with a yellow question mark.  Open properties.
> ; Pick "Update Driver".  Then "Select driver manually".  Pick "Ports
> ; (COM & LPT)" from the list.  Click "Have Disk".  Select this file.
14c14
< ; FIXME: This file covers the single port version only.
---
> ; This file covers pci-serial (1x only) for both 32 and 64 bit platforms.
19a20
> CatalogFile=qemupciserial.cat
21c22
< DriverVer=09/24/2012,1.3.0
---
> DriverVer=05/09/2017,1.4.0
38c39
< %QEMU%=QEMU,NTx86
---
> %QEMU%=QEMU,NTx86,NTamd64
40a42,44
> %QEMU-PCI_SERIAL.DeviceDesc% = ComPort, "PCI\VEN_1b36&DEV_0002&CC_0700"
> 
> [QEMU.NTamd64]
```

* added CatalogFile
* added amd64 section
* comment tweaks

The new file is dropped to a newly created "rhel" directory in the raw build, keeping the upstream qemupciserial.inf and qemupciserial.cat where they are, i.e. in the root.