### PR TITLE
BZ#1393772: Add null driver for SM Bus Controller

### DIFF
--- a/Q35/SMBus/smbus.inf
+++ b/Q35/SMBus/smbus.inf
@@ -1,0 +1,45 @@
+;-------------------------------------------------------------------------------
+; smbus.inf
+;
+; Red Hat SM Bus Q35
+;
+; Copyright (c) 2017 Red Hat, Inc.  All rights reserved.
+;
+;-------------------------------------------------------------------------------
+
+[Version]
+Signature = "$Windows NT$"
+Class = System
+ClassGuid = {4D36E97D-E325-11CE-BFC1-08002BE10318}
+Provider = %RedHat%
+DriverVer=04/27/2017,100.0.0.0
+DriverPackageType = PlugAndPlay
+DriverPackageDisplayName = %smbus.DeviceDesc%
+CatalogFile  = smbus.cat
+
+; ======
+; Following two lines are questionable works without them
+DriverPackageType = PlugAndPlay
+DriverPackageDisplayName = %smbus.DeviceDesc%
+
+[Manufacturer]
+%smbus.DeviceDesc% = Models, NTamd64
+
+[Models]
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&DEV_2930&SUBSYS_11001AF4
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&CC_0C0500
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&CC_0C05
+
+[Models.NTamd64]
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&DEV_2930&SUBSYS_11001AF4
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&CC_0C0500
+%smbus.DeviceDesc% = NullInstallSection, PCI\VEN_8086&CC_0C05
+
+[NullInstallSection]
+
+[NullInstallSection.Services]
+AddService = , 2                 ; null service install
+
+[Strings]
+RedHat = "Red Hat, Inc."
+smbus.DeviceDesc = "Red Hat Q35 SM Bus driver"

--- a/Q35/buildAll.bat
+++ b/Q35/buildAll.bat
@@ -1,0 +1,12 @@
+setlocal
+call clean.bat
+rem call ..\Tools\SetVsEnv 14 x64
+
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+mkdir Install
+
+copy smbus\smbus.* .\Install\
+inf2cat /driver:Install /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+
+endlocal

--- a/Q35/clean.bat
+++ b/Q35/clean.bat
@@ -1,0 +1,2 @@
+if exist Install rmdir /s /q Install
+if exist smbus.cat del /f /s /q smbus.cat

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -8,7 +8,7 @@ if errorlevel 1 goto :eof
 call tools\build.bat viostor\viostor.vcxproj "Win8_SDV Win10_SDV" %*
 if errorlevel 1 goto :eof
 
-for %%D in (pciserial fwcfg packaging) do (
+for %%D in (pciserial fwcfg packaging Q35) do (
   pushd %%D
   call buildAll.bat
   if errorlevel 1 goto :eof

--- a/clean.bat
+++ b/clean.bat
@@ -1,5 +1,5 @@
 @echo off
-for %%D in (VirtIO NetKVM viostor vioscsi Balloon vioserial viorng vioinput pvpanic pciserial fwcfg packaging) do (
+for %%D in (VirtIO NetKVM viostor vioscsi Balloon vioserial viorng vioinput pvpanic pciserial fwcfg packaging Q35) do (
   pushd %%D
   if exist cleanall.bat (
     call cleanall.bat


### PR DESCRIPTION
The device 8086:2930 has no built in driver in Windows 2008 and Win7 on
both x86 and x64 architectures, this commit adds a suitable null driver
for this device.

Signed-off-by: Sameeh Jubran <sjubran@redhat.com>
Signed-off-by: Daniel Rempel <daniel@daynix.com>