### PR TITLE
virtiolib: Make WDF mem_alloc_nonpaged_block return initialized memory

### DIFF
--- a/VirtIO/WDF/Callbacks.c
+++ b/VirtIO/WDF/Callbacks.c
@@ -49,10 +49,14 @@ static void *mem_alloc_nonpaged_block(void *context, size_t size)
 {
     PVIRTIO_WDF_DRIVER pWdfDriver = (PVIRTIO_WDF_DRIVER)context;
 
-    return ExAllocatePoolWithTag(
+    PVOID addr = ExAllocatePoolWithTag(
         NonPagedPool,
         size,
         pWdfDriver->MemoryTag);
+    if (addr) {
+        RtlZeroMemory(addr, size);
+    }
+    return addr;
 }
 
 static void mem_free_nonpaged_block(void *context, void *addr)


### PR DESCRIPTION
All implementations of mem_alloc_nonpaged_block except for WDF
return zero-inited memory. Make WDF do the same.

This commit fixes ACCESS_VIOLATION BSOD observed in:
https://bugzilla.redhat.com/show_bug.cgi?id=1455488

where mem_alloc_nonpaged_block is called by
virtio_reserve_queue_memory and virtio_delete_queues then
runs before all queues have been fully set up.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>