### PR TITLE
balloon: Add missing blnsvr.props

### DIFF
--- a/Balloon/app/blnsvr.props
+++ b/Balloon/app/blnsvr.props
@@ -1,0 +1,13 @@
+<!--
+***********************************************************************************************
+blnsvr.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
+    <CopyrightStrings>BalloonCopyrightStrings</CopyrightStrings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The file should have been added as part of commit 30e58ef. The
balloon service project fails to load and build without it.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>