### PR TITLE
Balloon: Remove devCtx->StatWorkItem=NULL from D0Exit

### DIFF
--- a/Balloon/sys/Device.c
+++ b/Balloon/sys/Device.c
@@ -450,11 +450,7 @@ BalloonEvtDeviceD0Exit(
     * interrupts were already disabled (between BalloonEvtDeviceD0ExitPreInterruptsDisabled and this call)
     * we should flush StatWorkItem before calling BalloonTerm which will delete virtio queues
     */
-    if (devCtx->StatWorkItem)
-    {
-        WdfWorkItemFlush(devCtx->StatWorkItem);
-        devCtx->StatWorkItem = NULL;
-    }
+    WdfWorkItemFlush(devCtx->StatWorkItem);
 #endif // !USE_BALLOON_SERVICE
 
     BalloonTerm(Device);


### PR DESCRIPTION
When the device power state is changed, or during the hardware resources
rebalancing (occurs after cpu hotplug, for example), BalloonEvtDeviceD0Entry
can be called again after BalloonEvtDeviceD0Exit. In this case, guest will
BSOD after the first Isr Dpc. In addition StatWorkItem is created in
BalloonDeviceAdd and will be automatically deleted by the framework along
with the device, so setting StatWorkItem to NULL in BalloonEvtDeviceD0Entry
is simply incorrect.

About a year ago AlekseyKostyushko already made a similar patch, which also
synchronize Dpc activity with D0Entry / D0Exit. Our tests and framework code
analysis showed that wdf really waits the Dpc rundown before D0Exit call so
additional synchronization is not required.

Signed-off-by: Ilya Rudakov <irudakov@virtuozzo.com>
Signed-off-by: Denis V. Lunev <den@openvz.org>