### PR TITLE
netkvm: Send clone of original announcement NBL

### DIFF
--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -303,10 +303,10 @@ void CParaNdisTX::CompleteOutstandingNBLChain(PNET_BUFFER_LIST NBL, ULONG Flags)
 
 void CParaNdisTX::CompleteOutstandingInternalNBL(PNET_BUFFER_LIST NBL, BOOLEAN UnregisterOutstanding /*= TRUE*/)
 {
-    CGuestAnnouncePacketHolder *ARPPacket = CGuestAnnouncePackets::GetCGuestAnnouncePacketFromNBL(NBL);
     ULONG NBLNum = ParaNdis_CountNBLs(NBL);
 
-    ARPPacket->Release();
+    CGuestAnnouncePackets::NblCompletionCallback(NBL);
+
     if (UnregisterOutstanding)
     {
         m_StateMachine.UnregisterOutstandingItems(NBLNum);

--- a/NetKVM/Common/ParaNdis_GuestAnnounce.h
+++ b/NetKVM/Common/ParaNdis_GuestAnnounce.h
@@ -51,7 +51,8 @@ public:
     VOID CreateNBL(UINT32 IPV4);
     VOID CreateNBL(USHORT *IPV6);
     VOID SendNBLs();
-    static CGuestAnnouncePacketHolder *GetCGuestAnnouncePacketFromNBL(PNET_BUFFER_LIST NBL);
+    static void NblCompletionCallback(PNET_BUFFER_LIST NBL);
+    static const ULONG cloneFlags = NDIS_CLONE_FLAGS_USE_ORIGINAL_MDLS;
 private:
     VOID CreateNBL(PVOID packet, UINT size, bool isIPV4);
     EthernetArpFrame *CreateIPv4Packet(UINT32 IPV4);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1458626
When sending ARP packets out upon migration it is possible
that previously sent packet is still not completed when
host requests to send another one. In this case sending
the same NBL/NB again is not acceptable as the NB is still
mapped by HAL and double mapping/unmapping is not supported
by the operating system and causes BSOD on second unmapping.
In current commit we always send a clone of originally created
ARP NBL, using MDL/buffer of original (prototype) NBL.
This commit also fixes usage by NdisReserved field of NBL and
uses MiniportReserved instead.