### PR TITLE
Fix cleanup scripts

### DIFF
--- a/NetKVM/Mof/Mof.vcxproj
+++ b/NetKVM/Mof/Mof.vcxproj
@@ -33,10 +33,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Header|x64'">
     <NMakeBuildCommandLine>build.cmd</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>build.cmd</NMakeReBuildCommandLine>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Header|Win32'">
     <NMakeBuildCommandLine>build.cmd</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>build.cmd</NMakeReBuildCommandLine>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
   </ItemDefinitionGroup>

--- a/NetKVM/Mof/clean.bat
+++ b/NetKVM/Mof/clean.bat
@@ -1,0 +1,19 @@
+@echo off
+goto start
+:rmdir
+if exist "%~1" rmdir "%~1" /s /q
+goto :eof
+
+:rmfiles
+if "%~1"=="" goto :eof
+if exist "%~1" del "%~1"
+shift
+goto rmfiles
+
+:start
+
+call :rmdir obj
+call :rmdir Win32
+call :rmdir x64
+
+call :rmfiles ..\Common\netkvmmof.h netkvm.bmf

--- a/NetKVM/clean.bat
+++ b/NetKVM/clean.bat
@@ -17,19 +17,17 @@ call :rmdir Install
 call :rmdir Install_Debug
 call :rmdir x64
 call :rmdir x86
-del build.err
-del build.log
-del buildfre_*.log
-del buildchk_*.log
-del msbuild.log
-del netkvm.DVL.XML
-del SDV-default.xml
-del sdv-user.sdv
+call :rmfiles build.err build.log buildfre_*.log buildchk_*.log msbuild.log
+call :rmfiles netkvm.DVL.XML SDV-default.xml sdv-user.sdv
 
 pushd CoInstaller
 call clean.bat
 popd
 
 pushd NDIS5
+call clean.bat
+popd
+
+pushd Mof
 call clean.bat
 popd

--- a/VirtIO/clean.bat
+++ b/VirtIO/clean.bat
@@ -5,3 +5,7 @@ rmdir /S /Q Win8Debug
 rmdir /S /Q x64
 
 del /F *.log *.wrn *.err
+
+cd WDF
+call clean.bat
+cd ..

--- a/vioinput/cleanAll.bat
+++ b/vioinput/cleanAll.bat
@@ -6,6 +6,6 @@ del /F *.log *.wrn *.err
 
 cd sys
 call cleanAll.bat
-cd ..\hidkmdf
+cd ..\hidpassthrough
 call cleanAll.bat
 cd ..


### PR DESCRIPTION
```
This commit fixes a few issues with the clean.bat / cleanAll.bat
scripts. All output and intermediate files are now deleted upon
executing clean.bat in the root of the repo.

Absolute IntDir and OutDir paths are added to NetKVM/Mof/Mof.vcxproj
to avoid leaving build artifacts in random directories.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>
```

Longer term, it would be nice to have the MSBuild Clean task do this work since the build knows what files it generates. Then we would be able to delete all these batch files.