### PR TITLE
NetKVM warning cleanup

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -145,8 +145,6 @@ static void GetConfigurationEntry(NDIS_HANDLE cfg, tConfigurationEntry *pEntry)
     PNDIS_CONFIGURATION_PARAMETER pParam = NULL;
     NDIS_PARAMETER_TYPE ParameterType = NdisParameterInteger;
     NdisInitializeString(&name, (PUCHAR)pEntry->Name);
-#pragma warning(push)
-#pragma warning(disable:6102)
     NdisReadConfiguration(
         &status,
         &pParam,
@@ -179,7 +177,6 @@ static void GetConfigurationEntry(NDIS_HANDLE cfg, tConfigurationEntry *pEntry)
             pEntry->Name,
             pEntry->ulValue));
     }
-#pragma warning(pop)
     if (name.Buffer) NdisFreeString(name);
 }
 
@@ -306,8 +303,6 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
                 NDIS_STATUS status;
                 PVOID p;
                 UINT  len = 0;
-#pragma warning(push)
-#pragma warning(disable:6102)
                 NdisReadNetworkAddress(&status, &p, &len, cfg);
                 if (status == NDIS_STATUS_SUCCESS && len == ETH_ALEN)
                 {
@@ -321,7 +316,6 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
                 {
                     DPrintf(4, ("[%s] Nothing read for MAC, error %X\n", __FUNCTION__, status));
                 }
-#pragma warning(pop)
             }
             NdisCloseConfiguration(cfg);
         }
@@ -2166,7 +2160,6 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
     if (ppr.ipCheckSum == ppresIPTooShort || ppr.xxpStatus == ppresXxpIncomplete)
     {
         res.flags.IpOK = FALSE;
-        #pragma warning(suppress: 4463)
         res.flags.IpFailed = TRUE;
         return res;
     }

--- a/NetKVM/Common/ParaNdis-Debug.cpp
+++ b/NetKVM/Common/ParaNdis-Debug.cpp
@@ -120,8 +120,6 @@ static void NetKVMDebugPrint(const char *fmt, ...)
 
 tDebugPrintFunc VirtioDebugPrintProc = NetKVMDebugPrint;
 
-#pragma warning (push)
-#pragma warning (disable:4055)
 void ParaNdis_DebugInitialize()
 {
     NDIS_STRING usRegister, usDeregister, usPrint;
@@ -146,7 +144,6 @@ void ParaNdis_DebugInitialize()
     res = BugCheckRegisterCallback(&CallbackRecord, ParaNdis_OnBugCheck, KbCallbackSecondaryDumpData, (const PUCHAR)"NetKvm");
     DPrintf(0, ("[%s] Crash callback %sregistered\n", __FUNCTION__, res ? "" : "NOT "));
 }
-#pragma warning (pop)
 
 void ParaNdis_DebugCleanup(PDRIVER_OBJECT  pDriverObject)
 {

--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -583,8 +583,6 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList& toWaitingList)
     return bRestartStatus;
 }
 
-#pragma warning(push)
-#pragma warning(disable:26135)
 bool CParaNdisTX::DoPendingTasks(CNBL *nblHolder)
 {
     PNET_BUFFER_LIST pNBLReturnNow = nullptr;
@@ -646,7 +644,6 @@ bool CParaNdisTX::DoPendingTasks(CNBL *nblHolder)
             CompleteOutstandingNBLChain(pNBLReturnNow, NDIS_SEND_COMPLETE_FLAGS_DISPATCH_LEVEL);
         }
     }
-#pragma warning(pop)
     return bRestartQueueStatus;
 }
 

--- a/NetKVM/Common/ParaNdis-Util.cpp
+++ b/NetKVM/Common/ParaNdis-Util.cpp
@@ -6,14 +6,11 @@ void NetKvmAssert(bool Statement, ULONG Code)
 {
     if (!Statement)
     {
-#pragma warning (push)
-#pragma warning (disable:28159)
         KeBugCheckEx(0x0ABCDEF0,
                      0x0ABCDEF0,
                      Code,
                      NDIS_MINIPORT_MAJOR_VERSION,
                      NDIS_MINIPORT_MINOR_VERSION);
-#pragma warning (pop)
     }
 }
 #endif
@@ -40,10 +37,7 @@ void __CRTDECL operator delete(void *) throw()
 {
     NETKVM_ASSERT(FALSE);
 #ifdef DBG
-#pragma warning (push)
-#pragma warning (disable:28159)
     KeBugCheck(100);
-#pragma warning (pop)
 #endif
 }
 
@@ -51,10 +45,7 @@ void __CRTDECL operator delete(void *, UINT64) throw()
 {
     ASSERT(FALSE);
 #ifdef DBG
-#pragma warning (push)
-#pragma warning (disable:28159)
    KeBugCheck(100);
-#pragma warning (pop)
 #endif
 }
 
@@ -62,10 +53,7 @@ void __CRTDECL operator delete(void *, unsigned int) throw()
 {
     ASSERT(FALSE);
 #ifdef DBG
-#pragma warning (push)
-#pragma warning (disable:28159)
     KeBugCheck(100);
-#pragma warning (pop)
 #endif
 }
 
@@ -73,10 +61,7 @@ void __CRTDECL operator delete[](void *) throw()
 {
     NETKVM_ASSERT(FALSE);
 #ifdef DBG
-#pragma warning (push)
-#pragma warning (disable:28159)
     KeBugCheck(100);
-#pragma warning (pop)
 #endif
 }
 

--- a/NetKVM/Common/ParaNdis-Util.h
+++ b/NetKVM/Common/ParaNdis-Util.h
@@ -126,17 +126,12 @@ public:
     ~CNdisSpinLock()
     { NdisFreeSpinLock(&m_Lock); }
 
-#pragma warning(push)
-#pragma warning(disable:28167) // The function changes IRQL and doesn't restore
-#pragma warning(disable:26135)
     _Ndis_acquires_exclusive_lock_(this->m_Lock)
     void Lock()
     { NdisAcquireSpinLock(&m_Lock); }
-#pragma warning(disable:26110) // Caller failing to hold lock before calling function 'KeReleaseSpinLock'
     _Ndis_releases_lock_(this->m_Lock)
     void Unlock()
     { NdisReleaseSpinLock(&m_Lock); }
-#pragma warning(pop)
 
 private:
     NDIS_SPIN_LOCK m_Lock;
@@ -400,8 +395,6 @@ class CDpcIrqlRaiser
 {
 public:
 
-#pragma warning(push)
-#pragma warning(disable:28167) // The function changes IRQL and doesn't restore
 #if ((OSVERSION_MASK & NTDDI_VERSION) > NTDDI_VISTA)
     _IRQL_requires_max_(DISPATCH_LEVEL)
     _IRQL_raises_(DISPATCH_LEVEL)
@@ -417,8 +410,6 @@ public:
 #endif
     ~CDpcIrqlRaiser()
     { KeLowerIrql(m_OriginalIRQL); }
-#pragma warning(push)
-#pragma warning(disable:28167) // The function changes IRQL and doesn't restore
     CDpcIrqlRaiser(const CDpcIrqlRaiser&) = delete;
     CDpcIrqlRaiser& operator= (const CDpcIrqlRaiser&) = delete;
 

--- a/NetKVM/Common/osdep.h
+++ b/NetKVM/Common/osdep.h
@@ -12,17 +12,8 @@
 **********************************************************************/
 #pragma once
 
-#pragma warning (push)
-#pragma warning (disable:28301)
-#pragma warning (disable:28252)
-#pragma warning (disable:28251)
 #include <ndis.h>
-#pragma warning (pop)
-
-#pragma warning (push)
-#pragma warning (disable:6102)
 #include <Ntstrsafe.h>
-#pragma warning (pop)
 
 #if NTDDI_VERSION <= NTDDI_VISTASP1
 #define _Requires_lock_held_(lock)

--- a/NetKVM/Common/osdep.h
+++ b/NetKVM/Common/osdep.h
@@ -32,18 +32,6 @@ typedef struct _NETWORK_ADDRESS_IP6 {
 } NETWORK_ADDRESS_IP6, *PNETWORK_ADDRESS_IP6;
 #endif
 
-#define mb()   KeMemoryBarrier()
-#define rmb()  KeMemoryBarrier()
-#define wmb()  KeMemoryBarrier()
-
-#ifndef min
-#define min(_a, _b) (((_a) < (_b)) ? (_a) : (_b))
-#endif
-
-#ifndef max
-#define max(_a, _b) (((_a) > (_b)) ? (_a) : (_b))
-#endif
-
 #ifndef PARANDIS_MAJOR_DRIVER_VERSION
 #error PARANDIS_MAJOR_DRIVER_VERSION not defined
 #endif

--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -129,7 +129,6 @@ static NDIS_STATUS ParaNdis6_Initialize(
 
     UNREFERENCED_PARAMETER(miniportDriverContext);
     DEBUG_ENTRY(0);
-#pragma warning( suppress: 28197)
     /* allocate context structure */
     pContext = (PARANDIS_ADAPTER *)
         NdisAllocateMemoryWithTagPriority(
@@ -886,8 +885,6 @@ static NDIS_STATUS ReadGlobalConfigurationEntry(NDIS_HANDLE cfg, const char *_na
     const char *statusName;
     NDIS_PARAMETER_TYPE ParameterType = NdisParameterInteger;
     NdisInitializeString(&name, (PUCHAR)_name);
-#pragma warning(push)
-#pragma warning(disable:6102)
     NdisReadConfiguration(
         &status,
         &pParam,
@@ -903,7 +900,6 @@ static NDIS_STATUS ReadGlobalConfigurationEntry(NDIS_HANDLE cfg, const char *_na
     {
         statusName = "nothing";
     }
-#pragma warning(pop)
     DPrintf(2, ("[%s] %s read for %s - 0x%x\n", __FUNCTION__, statusName, _name, *pValue));
     if (name.Buffer) NdisFreeString(name);
     return status;
@@ -926,11 +922,8 @@ static void RetrieveDriverConfiguration()
         NDIS_STRING paramsName = {};
         NdisInitializeString(&paramsName, (PUCHAR)"Parameters");
 
-#pragma warning(push)
-#pragma warning(disable:6102) // Using <param> from failed function call at line...
         NdisOpenConfigurationKeyByName(&status, cfg, &paramsName, &params);
         if (status == NDIS_STATUS_SUCCESS)
-#pragma warning(pop)
         {
             ReadGlobalConfigurationEntry(params, "DisableMSI", &bDisableMSI);
             NdisCloseConfiguration(params);

--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -138,10 +138,7 @@ BOOLEAN ParaNdis_SynchronizeWithInterrupt(
     PVOID parameter)
 {
     NDIS_SYNC_PROC_TYPE syncProc;
-#pragma warning (push)
-#pragma warning (disable:4152)
     syncProc = (NDIS_SYNC_PROC_TYPE) procedure;
-#pragma warning (pop)
     return NdisMSynchronizeWithInterruptEx(pContext->InterruptHandle, messageId, syncProc, parameter);
 }
 

--- a/NetKVM/wlh/ParaNdis6-Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6-Oid.cpp
@@ -1047,7 +1047,6 @@ static NDIS_STATUS ApplyOffloadConfiguration(PARANDIS_ADAPTER *pContext,
     }
     else if (NDIS_OFFLOAD_PARAMETERS_LSOV1_ENABLED == pop->LsoV1 || NDIS_OFFLOAD_PARAMETERS_LSOV2_ENABLED  == pop->LsoV2IPv4)
     {
-        #pragma warning(suppress: 4463)
         if (fSupported.fTxLso) pf->fTxLso = 1;
         else
             bFailed = TRUE;
@@ -1059,7 +1058,6 @@ static NDIS_STATUS ApplyOffloadConfiguration(PARANDIS_ADAPTER *pContext,
     }
     else if (NDIS_OFFLOAD_PARAMETERS_LSOV2_ENABLED  == pop->LsoV2IPv6)
     {
-        #pragma warning(suppress: 4463)
         if (fSupported.fTxLsov6) pf->fTxLsov6 = 1;
         else
             bFailed = TRUE;


### PR DESCRIPTION
It turns out that none of the warning suppression #pragma's in the network driver are necessary. The first patch adds proper SAL annotation, the second patch deletes all #pragma warning's, and the last one is a small cleanup in osdep.h.