### PR TITLE
Fix build break with WDK 10.0.15063.0

### DIFF
--- a/Tools/Driver.Common.targets
+++ b/Tools/Driver.Common.targets
@@ -103,8 +103,8 @@ Invoking the task:
   <!-- Stampinf (for Legacy DDK) -->
   <Target Condition="'$(Feature_LegacyStampInf)'=='true' AND '$(UseLegacyDDK)'=='true'" Name="StampInf_LegacyDDK" AfterTargets="AdjustInf_LegacyDDK" BeforeTargets="PackOneTarget">
     <Message Text="StampInf_LegacyDDK: for $(OutDir)$(TargetName).inf with Feature_UsingWDF=$(Feature_UsingWDF) and STAMPINF_VERSION=$(STAMPINF_VERSION)" Importance="high"/>
-    <Exec Condition="'$(Feature_UsingWDF)'=='false'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -v $(STAMPINF_VERSION)"/>
-    <Exec Condition="'$(Feature_UsingWDF)'=='true'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION)"/>
+    <Exec Condition="'$(Feature_UsingWDF)'=='false'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -v $(STAMPINF_VERSION) -d *"/>
+    <Exec Condition="'$(Feature_UsingWDF)'=='true'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION) -d *"/>
   </Target>
 
   <!-- Imports -->


### PR DESCRIPTION
stampinf.exe in the latest Win10 WDK appears to have a bug and writes
out an empty DriverVer= directive when passed a command line like below:

  stampinf -f <inf> -a <arch> -v <version>

Adding -d seems to work around it:

  stampinf -f <inf> -a <arch> -v <version> -d *

Signed-off-by: Ladi Prosek <lprosek@redhat.com>

---

Reported by @jackli577 in https://github.com/virtio-win/kvm-guest-drivers-windows/issues/159