### PR TITLE
Fix for BZ#1442322 - Cannot enlarge/shrink disk with virtio-blk-pci

### DIFF
--- a/viostor/virtio_pci.c
+++ b/viostor/virtio_pci.c
@@ -196,7 +196,7 @@ static void *pci_map_address_range(void *context, int bar, size_t offset, size_t
 static u16 vdev_get_msix_vector(void *context, int queue)
 {
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)context;
-    u16 vector;
+    u16 vector = VIRTIO_MSI_NO_VECTOR;
 
     if (queue >= 0) {
         /* queue interrupt */
@@ -206,12 +206,12 @@ static u16 vdev_get_msix_vector(void *context, int queue)
             } else {
                 vector = queue + 1;
             }
-        } else {
-            vector = VIRTIO_MSI_NO_VECTOR;
         }
     } else {
         /* on-device-config-change interrupt */
-        vector = VIRTIO_MSI_NO_VECTOR;
+        if (!adaptExt->msix_one_vector) {
+            vector = VIRTIO_BLK_MSIX_CONFIG_VECTOR;
+        }
     }
 
     return vector;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1097,17 +1097,25 @@ VirtIoMSInterruptRoutine (
 {
     PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if (MessageID == 0) {
-        RhelGetDiskGeometry(DeviceExtension);
-        return TRUE;
-    }
-    if (!CompleteDPC(DeviceExtension, MessageID)) {
-        VioStorCompleteRequest(DeviceExtension, MessageID, TRUE);
-    }
     if (MessageID > adaptExt->msix_vectors) {
         RhelDbgPrint(TRACE_LEVEL_ERROR, ("%s MessageID = %d\n", __FUNCTION__, MessageID));
         return FALSE;
     }
+
+    if (adaptExt->msix_one_vector) {
+        MessageID = 1;
+    } else {
+        if (MessageID == VIRTIO_BLK_MSIX_CONFIG_VECTOR) {
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, ("%s RhelGetDiskGeometry\n", __FUNCTION__));
+            RhelGetDiskGeometry(DeviceExtension);
+            return TRUE;
+        }
+    }
+
+    if (!CompleteDPC(DeviceExtension, MessageID)) {
+        VioStorCompleteRequest(DeviceExtension, MessageID, TRUE);
+    }
+
     return TRUE;
 }
 #endif

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -74,6 +74,8 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 
 #define VIRTIO_BLK_QUEUE_LAST   MAX_CPU
 
+#define VIRTIO_BLK_MSIX_CONFIG_VECTOR   0
+
 #define VIRTIO_RING_F_INDIRECT_DESC     28
 
 #define BLOCK_SERIAL_STRLEN     20


### PR DESCRIPTION
device.
The following patch fixes problem with config MSI message processing.
While this bugfix works as expected for the most of the use cases,
there is still a problem with one vestor configuration reported in
Bug 1451572 - [virtio-win][viostor] can not resize the disk with
"-device virtio-blk-pci, ..., vectors=1"
This problem is a special case that probably will be addressed in
a separate patch.

Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>