### PR TITLE
viostor: Fix geometry updates with vectors=1

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -803,7 +803,14 @@ VirtIoStartIo(
 
         case SCSIOP_READ_CAPACITY16:
         case SCSIOP_READ_CAPACITY: {
-            UCHAR SrbStatus = RhelScsiGetCapacity(DeviceExtension, (PSRB_TYPE)Srb);
+            UCHAR SrbStatus;
+            if (adaptExt->msix_one_vector) {
+                /* We don't have a separate MSI vector for VirtIO config changes so
+                 * we simply poll the disk geometry here. See VirtIoMSInterruptRoutine.
+                 */
+                RhelGetDiskGeometry(DeviceExtension);
+            }
+            SrbStatus = RhelScsiGetCapacity(DeviceExtension, (PSRB_TYPE)Srb);
             CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SrbStatus);
             return TRUE;
         }


### PR DESCRIPTION
If the virtio-blk-pci device is configured with only one MSI vector,
the driver didn't refresh its geometry information on disk resize
because it's not easy to tell that the interrupt was triggered by
a config change.

Possible solutions include:
* checking the config generation field (virtio 1.0 only) to detect
  config changes
* checking the ISR status field (QEMU seems to always set bit 1 even
  if the device operates in MSI mode)
* re-reading the config in a rate-limited fashion (on every n-th
  interrupt, or every second, or something similar)

This commit fixes it by polling the config when we're asked for the
geometry info by the OS. RhelGetDiskGeometry just copies the info to
our internal structures anyway, so we're not losing much by not
doing it before Windows asks.

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1451572

Signed-off-by: Ladi Prosek <lprosek@redhat.com>