### PR TITLE
Net-KVM: Fix a typo in the configuration entry settings

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -124,7 +124,7 @@ static const tConfigurationEntries defaultConfiguration =
     { "VlanId", 0, 0, MAX_VLAN_ID},
     { "PublishIndices", 1, 0, 1},
     { "MTU", 1500, 576, 65500},
-    { "NumberOfHandledRXPackersInDPC", MAX_RX_LOOPS, 1, 10000},
+    { "NumberOfHandledRXPacketsInDPC", MAX_RX_LOOPS, 1, 10000},
 #if PARANDIS_SUPPORT_RSS
     { "*RSS", 1, 0, 1},
     { "*NumRssQueues", 8, 1, PARANDIS_RSS_MAX_RECEIVE_QUEUES},

--- a/NetKVM/netkvm.inf
+++ b/NetKVM/netkvm.inf
@@ -239,12 +239,12 @@ HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "2",    0,      %Rx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "1",    0,      %Tx% 
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "0",    0,      %Disable% 
  
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       ParamDesc,  0,          %NumberOfHandledRXPackersInDPC% 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       type,       0,          "long" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       default,    0,          "1000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       min,        0,          "1" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       max,        0,          "10000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       step,       0,          "1" 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       ParamDesc,  0,          %NumberOfHandledRXPacketsInDPC% 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       type,       0,          "long" 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       default,    0,          "1000" 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       min,        0,          "1" 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       max,        0,          "10000" 
+HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       step,       0,          "1" 
  
 [kvmnet6.CopyFiles] 
 netkvm.sys,,,2 
@@ -298,7 +298,7 @@ DebugLevel = "Logging.Level"
 Tx = "Tx Enabled"; 
 Rx = "Rx Enabled"; 
 TxRx = "Rx & Tx Enabled"; 
-NumberOfHandledRXPackersInDPC = "TestOnly.RXThrottle" 
+NumberOfHandledRXPacketsInDPC = "TestOnly.RXThrottle" 
 Std.LsoV2IPv4 = "Large Send Offload V2 (IPv4)" 
 Std.LsoV2IPv6 = "Large Send Offload V2 (IPv6)" 
 Std.UDPChecksumOffloadIPv4 = "UDP Checksum Offload (IPv4)" 


### PR DESCRIPTION
I have mistakenly pushed a partial commit earlier (https://github.com/virtio-win/kvm-guest-drivers-windows/commit/5eb813024e0a7a915a5cb39687c5dee80ef123e0), this is the remains of it.