### PR TITLE
Changes to keep "Static Driver Verification" (SDV) happy.

### DIFF
--- a/vioscsi/utils.c
+++ b/vioscsi/utils.c
@@ -107,11 +107,10 @@ tDebugPrintFunc VirtioDebugPrintProc;
 char *DbgGetScsiOpStr(IN PSCSI_REQUEST_BLOCK Srb)
 {
     PCDB pCdb = SRB_CDB(Srb);
-    UCHAR scsiOp = pCdb->CDB6GENERIC.OperationCode;
     char *scsiOpStr = "?";
 
     if (pCdb) {
-        switch (scsiOp){
+        switch (pCdb->CDB6GENERIC.OperationCode) {
             #undef MAKE_CASE
             #define MAKE_CASE(scsiOpCode) case scsiOpCode: scsiOpStr = #scsiOpCode; break;
 


### PR DESCRIPTION
Most of the changes in this patch are to prevent SDV from complaining
about NULL pointer accesses, and don't need any explanation. However,
the change about max_cpus and num_cpus warrants some explanation. The
problem is that the SDV complains that the vioscsi and viostor drivers
fail the StorPortSpinLock3 rule. Debugging showed that the SDV does not
understand the value returned by KeQueryMaximumProcessorCountEx(). That
function is expected to return a ULONG value, but SDV does not correctly
interpret the returned value. That results in num_queues ending up as
zero, which in turn results in MaxIOsPerLun and InitialLunQueueDepth in
the PORT_CONFIGURATION_INFORMATION structure being set to zeroes, and
that makes SDV conclude that the driver is failing the StorPortSpinLock3
rule. Tried changing

  max_cpus = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);

to

  max_cpus = max(1, KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS));

to set max_cpus to a sane value, but SDV does not understand that
either! Hence the addition of the lines (num_cpus also suffers the
same problem)

  num_cpus = max(1, num_cpus);
  max_cpus = max(1, max_cpus);

SDV correctly understands these statements, and the StorPortSpinLock3
rule passes.

Signed-off-by: Venu Busireddy <venu.busireddy@oracle.com>
Reviewed-by: Mihai Carabas <mihai.carabas@oracle.com>