### PR TITLE
serial: remove RETRY_THRESHOLD limit from c_ovq poll loop

### DIFF
--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -260,13 +260,24 @@ VIOSerialEvtDevicePrepareHardware(
         attributes.ParentObject = Device;
         status = WdfSpinLockCreate(
                                 &attributes,
-                                &pContext->CVqLock
+                                &pContext->CInVqLock
                                 );
         if (!NT_SUCCESS(status))
         {
            TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
                 "WdfSpinLockCreate failed 0x%x\n", status);
            return status;
+        }
+
+        status = WdfWaitLockCreate(
+                                &attributes,
+                                &pContext->COutVqLock
+                                );
+        if (!NT_SUCCESS(status))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
+                "WdfWaitLockCreate failed 0x%x\n", status);
+            return status;
         }
     }
     else
@@ -521,7 +532,7 @@ VIOSerialEvtDeviceD0Entry(
         status = VIOSerialInitAllQueues(Device);
         if (NT_SUCCESS(status) && pContext->isHostMultiport)
         {
-            status = VIOSerialFillQueue(pContext->c_ivq, pContext->CVqLock);
+            status = VIOSerialFillQueue(pContext->c_ivq, pContext->CInVqLock);
         }
 
         if (!NT_SUCCESS(status))

--- a/vioserial/sys/vioser.h
+++ b/vioserial/sys/vioser.h
@@ -55,8 +55,6 @@ EVT_WDF_INTERRUPT_DISABLE                       VIOSerialInterruptDisable;
 #define VIRTIO_CONSOLE_PORT_OPEN        6
 #define VIRTIO_CONSOLE_PORT_NAME        7
 
-#define RETRY_THRESHOLD                 400
-
 // This is the value of the IOCTL_GET_INFORMATION macro used by older versions
 // of the driver. We still respond to it for backward compatibility. New clients
 // should use the new value declared in public.h.
@@ -98,7 +96,8 @@ typedef struct _tagPortDevice
     CONSOLE_CONFIG      consoleConfig;
     struct virtqueue    *c_ivq, *c_ovq;
     struct virtqueue    **in_vqs, **out_vqs;
-    WDFSPINLOCK         CVqLock;
+    WDFSPINLOCK         CInVqLock;
+    WDFWAITLOCK         COutVqLock;
 
     BOOLEAN             DeviceOK;
     UINT                DeviceId;
@@ -268,6 +267,7 @@ VIOSerialRemovePort(
 
 VOID
 VIOSerialInitPortConsole(
+    IN WDFDEVICE Device,
     IN PVIOSERIAL_PORT port
 );
 


### PR DESCRIPTION
This patch is a fix for very annoying problem in the production. It was
very hard to understand what is going on and why. From the user point
of view the situation looks like

	dev: virtserialport, id "channel0"
	chardev = "charchannel0"
	nr = 1 (0x1)
	name = "org.qemu.guest_agent.0"
	port 1, guest off, host off, throttle off

and the device comes into this state under unknown circumstances.

We've found out that this problem is caused by a breakdown in the
control channel. The host has stopped responding to the control messages
at some moment. Sometimes channel could be fixed after qemu-qa service
restart, sometimes not. From the technical point of view there is the
following problem:

The amount of virtqueue_get_buf calls from VIOSerialSendCtrlMsg is
limited to RETRY_THRESHOLD times(400). Usually this is more than enough.
The amount of retries in the common case in 1-2. But unfortunately
sometimes host needs MUCH more time to handle message. Thus there is
a probability that the polling counter will exceeds RETRY_THRESHOLD.
In our production and load testing this probability fires 1-2 times
a week. Thus here loop ends, but the queue still contains the element
with the address on VIOSerialSendCtrlMsg stack. This buffer will become
invalid after the return from the function. Obviously QEMU will see the
garbage once it will get a chance to process such orphaned message.
It ignores it without guest notification and thus the vioserial is
stuck in some intermediate state.

We can't just remove RETRY_THRESHOLD limit. In this case there is a
risk of getting DPC_WATCHDOG bugcheck due to long spin wait on
DPC_LEVEL.

This patch splits in/out queues lock CVqLock on two, with WaitLock
COutVqLock being used for c_ovq. In this case virtqueue_get_buf poll
loop is executed on PASSIVE_LEVEL. The restriction to the amount of
retries is removed accordingly. WorkItem is used to low the current
IRQL where necessary.

Spinlock is better solution to synchronize such a small and fast code
and was rightfully used to lock c_ivq and c_ovq access. Thus it is kept
for CInVqLock to lock c_ivq. Using WaitLock for c_ovq leads to
insignificant decrease of the control message sending rate due to
walking through dispatcher every time on lock acquire/free and a possible
thread preemtion while running locked code, but reliability is more
important than control channel speed.

Signed-off-by: Ilya Rudakov <irudakov@virtuozzo.com>
Signed-off-by: Denis V. Lunev <den@openvz.org>