### PR TITLE
serial: Minor corrections according to ladipro comments

### DIFF
--- a/vioserial/sys/Control.c
+++ b/vioserial/sys/Control.c
@@ -49,7 +49,8 @@ VIOSerialSendCtrlMsg(
         virtqueue_kick(vq);
         while(!virtqueue_get_buf(vq, &len))
         {
-           KeStallExecutionProcessor(50);
+            LARGE_INTEGER interval = {0};
+            KeDelayExecutionThread(KernelMode, FALSE, &interval);
         }
     }
     WdfWaitLockRelease(pContext->COutVqLock);

--- a/vioserial/sys/Control.c
+++ b/vioserial/sys/Control.c
@@ -26,7 +26,7 @@ VIOSerialSendCtrlMsg(
     UINT len;
     PPORTS_DEVICE pContext = GetPortsDevice(Device);
     VIRTIO_CONSOLE_CONTROL cpkt;
-    int cnt = 0;
+
     if (!pContext->isHostMultiport)
     {
         return;

--- a/vioserial/sys/Control.c
+++ b/vioserial/sys/Control.c
@@ -49,7 +49,8 @@ VIOSerialSendCtrlMsg(
         virtqueue_kick(vq);
         while(!virtqueue_get_buf(vq, &len))
         {
-            LARGE_INTEGER interval = {0};
+            LARGE_INTEGER interval;
+            interval.QuadPart = -1;
             KeDelayExecutionThread(KernelMode, FALSE, &interval);
         }
     }


### PR DESCRIPTION
1. Counter variable (int cnt) is now unused and should be deleted.

2. Using KeDelayExecutionThread with zero timeout interval cause current thread
to relinquish the remainder of its time slice to other thread in most cases.
This allows to make small delay on PASSIVE_LEVEL and optimize CPU usage.
It looks slightly more efficient then using KeDelayExecutionThread which is
actually a busy loop.