### PR TITLE
[ivshmem] fixed infiniate loop bug

### DIFF
--- a/ivshmem/Queue.c
+++ b/ivshmem/Queue.c
@@ -371,10 +371,13 @@ VOID IVSHMEMEvtDeviceFileCleanup(_In_ WDFFILEOBJECT FileObject)
     while (entry != &deviceContext->eventList)
     {
         PIVSHMEMEventListEntry event = CONTAINING_RECORD(entry, IVSHMEMEventListEntry, ListEntry);
-        PLIST_ENTRY next = entry->Flink;
         if (event->owner != FileObject)
+        {
+            entry = entry->Flink;
             continue;
+        }
 
+        PLIST_ENTRY next = entry->Flink;
         RemoveEntryList(entry);
         ObDereferenceObject(_Notnull_ event->event);
         event->owner = NULL;


### PR DESCRIPTION
If a second application opens and then closes the device handle the cleanup will enter an infinite loop. This patch fixes this.