### PR TITLE
SDV ivshmem fixes

### DIFF
--- a/buildAll.bat
+++ b/buildAll.bat
@@ -9,8 +9,6 @@ call tools\build.bat viostor\viostor.vcxproj "Win8_SDV Win10_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat ivshmem\ivshmem.vcxproj "Win10_SDV" %*
 if errorlevel 1 goto :fail
-call tools\build.bat ivshmem\test\ivshmem-test.vcxproj "Win10_SDV" %*
-if errorlevel 1 goto :fail
 
 for %%D in (pciserial fwcfg packaging Q35) do (
   pushd %%D

--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -237,8 +237,9 @@ NTSTATUS IVSHMEMEvtDeviceReleaseHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
     PLIST_ENTRY entry = deviceContext->eventList.Flink;
     while (entry != &deviceContext->eventList)
     {
+        _Analysis_assume_(entry != NULL);
         PIVSHMEMEventListEntry event = CONTAINING_RECORD(entry, IVSHMEMEventListEntry, ListEntry);
-        ObDereferenceObject(_Notnull_ event->event);
+        ObDereferenceObject(event->event);
         event->owner  = NULL;
         event->event  = NULL;
         event->vector = 0;
@@ -310,11 +311,12 @@ void IVSHMEMInterruptDPC(_In_ WDFINTERRUPT Interrupt, _In_ WDFOBJECT AssociatedO
         PLIST_ENTRY next = entry->Flink;
         if (pending & ((LONG64)1 << event->vector))
         {
-            KeSetEvent(_Notnull_ event->event, 0, FALSE);
+            _Analysis_assume_(event->event != NULL);
+            KeSetEvent(event->event, 0, FALSE);
             if (event->singleShot)
             {
                 RemoveEntryList(entry);
-                ObDereferenceObjectDeferDelete(_Notnull_ event->event);
+                ObDereferenceObjectDeferDelete(event->event);
                 event->owner  = NULL;
                 event->event  = NULL;
                 event->vector = 0;

--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -3,7 +3,6 @@
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (PAGE, IVSHMEMCreateDevice)
 #pragma alloc_text (PAGE, IVSHMEMEvtDevicePrepareHardware)
-#pragma alloc_text (PAGE, IVSHMEMEvtDeviceReleaseHardware)
 #pragma alloc_text (PAGE, IVSHMEMEvtD0Exit)
 #endif
 
@@ -197,7 +196,6 @@ NTSTATUS IVSHMEMEvtDevicePrepareHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
 NTSTATUS IVSHMEMEvtDeviceReleaseHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIST ResourcesTranslated)
 {
     UNREFERENCED_PARAMETER(ResourcesTranslated);
-    PAGED_CODE();
     DEBUG_INFO("%s", __FUNCTION__);
 
     PDEVICE_CONTEXT deviceContext;

--- a/ivshmem/Queue.c
+++ b/ivshmem/Queue.c
@@ -370,13 +370,14 @@ VOID IVSHMEMEvtDeviceFileCleanup(_In_ WDFFILEOBJECT FileObject)
     PLIST_ENTRY entry = deviceContext->eventList.Flink;
     while (entry != &deviceContext->eventList)
     {
+        _Analysis_assume_(entry != NULL);
         PIVSHMEMEventListEntry event = CONTAINING_RECORD(entry, IVSHMEMEventListEntry, ListEntry);
         PLIST_ENTRY next = entry->Flink;
         if (event->owner != FileObject)
             continue;
 
         RemoveEntryList(entry);
-        ObDereferenceObject(_Notnull_ event->event);
+        ObDereferenceObject(event->event);
         event->owner = NULL;
         event->event = NULL;
         event->vector = 0;

--- a/ivshmem/ivshmem.vcxproj
+++ b/ivshmem/ivshmem.vcxproj
@@ -115,6 +115,11 @@
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>POOL_NX_OPTIN=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">
     <ClCompile>
       <WppEnabled>false</WppEnabled>

--- a/ivshmem/ivshmem.vcxproj
+++ b/ivshmem/ivshmem.vcxproj
@@ -19,9 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <None Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="Device.c" />
     <ClCompile Include="Driver.c" />
     <ClCompile Include="Queue.c" />

--- a/ivshmem/ivshmem.vcxproj.filters
+++ b/ivshmem/ivshmem.vcxproj.filters
@@ -19,9 +19,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="Device.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/ivshmem/test/ivshmem-test.vcxproj
+++ b/ivshmem/test/ivshmem-test.vcxproj
@@ -151,9 +151,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>

--- a/ivshmem/test/ivshmem-test.vcxproj.filters
+++ b/ivshmem/test/ivshmem-test.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
A few fixes to try to make the SDV build succeed. It has found real code issues.

I still haven't been able to make SDV generate the DVL file though. Running

`tools\build.bat ivshmem\ivshmem.vcxproj "Win10_SDV"`

fails with

```
"C:\kvm-guest-drivers-windows\ivshmem\ivshmem.vcxproj" (sdv target) (1) ->
(sdv target) ->
  C:\Program Files (x86)\Windows Kits\10\build\windowsdriver.Sdv.targets(132,9): error MSB3073: The command "staticdv /devenv /check" exited with code -1. [C:\kvm-guest-drivers-windows\ivshmem\ivshmem.vcxproj]

    0 Warning(s)
    1 Error(s)

```

and it seems to be caused by one of the tools looking for sdv-harness.c.rawcfgf in ivshmem\sdv\check\purekmdfdriver instead of ivshmem\sdv where another tool puts it. So very likely a WDK bug. @gnif, do you see the same thing? Thanks!
