### PR TITLE
ivshmem: Fix integer width warnings in ivshmem-test

### DIFF
--- a/ivshmem/test/ivshmem-test.cpp
+++ b/ivshmem/test/ivshmem-test.cpp
@@ -95,7 +95,7 @@ int main()
 		}
 		TEST_PASS();
 
-		printf("Size: %u\n", size);
+		printf("Size: %I64u\n", size);
 
 		TEST_START("IOCTL_IVSHMEM_REQUEST_MMAP");
 		IVSHMEM_MMAP map;
@@ -177,7 +177,7 @@ int main()
 		TEST_PASS();
 
 		TEST_START("Shared memory actually works");
-		memset(map.ptr, 0xAA, map.size);
+		memset(map.ptr, 0xAA, (size_t)map.size);
 		CloseHandle(devHandle);
 		devHandle = CreateFile(infData->DevicePath, 0, 0, NULL, OPEN_EXISTING, 0, 0);
 		if (devHandle == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
ivshmem-test.cpp(180): warning C4244: 'argument': conversion from 'IVSHMEM_SIZE' to 'std::size_t', possible loss of data

ivshmem-test.cpp(98): warning C4477: 'printf' : format string '%u' requires an argument of type 'unsigned int', but variadic argument 1 has type 'IVSHMEM_SIZE'
         ivshmem-test.cpp(98): note: consider using '%llu' in the format string
         ivshmem-test.cpp(98): note: consider using '%I64u' in the format string1

Signed-off-by: Ladi Prosek <lprosek@redhat.com>

CC @gnif