### PR TITLE
Minor balloon fixes

### DIFF
--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -289,6 +289,7 @@ BalloonTellHost(
     if (virtqueue_add_buf(vq, &sg, 1, 0, devCtx, NULL, 0) < 0)
     {
         TraceEvents(TRACE_LEVEL_ERROR, DBG_HW_ACCESS, "<-> %s :: Cannot add buffer\n", __FUNCTION__);
+        WdfSpinLockRelease(devCtx->InfDefQueueLock);
         return;
     }
     do_notify = virtqueue_kick_prepare(vq);


### PR DESCRIPTION
Patch 1 addresses a concern that the driver may be spending more time in the DPC than necessary due to contention on the queue spin locks (https://bugzilla.redhat.com/show_bug.cgi?id=1453090).

Patch 2 fixes a potential deadlock found while working on patch 1.