### PR TITLE
Inf2cat: Use /uselocaltime when compiling

### DIFF
--- a/NetKVM/NDIS5/tools/signing.cmd
+++ b/NetKVM/NDIS5/tools/signing.cmd
@@ -33,5 +33,5 @@ echo INF file %2
 echo VERSION file %3
 echo Target OS mask %_OSMASK_% 
 call :_stampinf %2 %3 %4
-inf2cat /driver:%~dp2 /os:%_OSMASK_%
+inf2cat /driver:%~dp2 /os:%_OSMASK_% /uselocaltime
 goto :eof

--- a/NetKVM/NetKVM-VS2015.vcxproj
+++ b/NetKVM/NetKVM-VS2015.vcxproj
@@ -92,6 +92,7 @@
     <RootNamespace>NetKVM_Win10</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <SignMode>Off</SignMode>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'" Label="Configuration">
@@ -412,7 +413,7 @@
     </Link>
     <PostBuildEvent>
       <Command>
-        inf2cat /driver:$(OutDir) /os:Vista_X86
+        inf2cat /driver:$(OutDir) /os:Vista_X86 /uselocaltime
         %(Command)
       </Command>
     </PostBuildEvent>
@@ -468,7 +469,7 @@
     </Link>
     <PostBuildEvent>
       <Command>
-        inf2cat /driver:$(OutDir) /os:Vista_X86
+        inf2cat /driver:$(OutDir) /os:Vista_X86 /uselocaltime
         %(Command)
       </Command>
     </PostBuildEvent>
@@ -518,7 +519,7 @@
     </Link>
     <PostBuildEvent>
       <Command>
-        inf2cat /driver:$(OutDir) /os:Vista_X64
+        inf2cat /driver:$(OutDir) /os:Vista_X64 /uselocaltime
         %(Command)
       </Command>
     </PostBuildEvent>
@@ -586,7 +587,7 @@
     </Link>
     <PostBuildEvent>
       <Command>
-        inf2cat /driver:$(OutDir) /os:Vista_X64
+        inf2cat /driver:$(OutDir) /os:Vista_X64 /uselocaltime
         %(Command)
       </Command>
     </PostBuildEvent>

--- a/Q35/buildAll.bat
+++ b/Q35/buildAll.bat
@@ -7,6 +7,6 @@ call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 mkdir Install
 
 copy smbus\smbus.* .\Install\
-inf2cat /driver:Install /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+inf2cat /driver:Install /uselocaltime /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
 
 endlocal

--- a/Tools/Driver.PackOne.targets
+++ b/Tools/Driver.PackOne.targets
@@ -177,7 +177,7 @@ Related features:
     <Copy SourceFiles="@(PackOne_Files)"
           DestinationFolder="$(PackOne_DestinationPath)"/>
     <Message Text="Setting OS mask for: $(TargetOS) $(TargetArch) to $(PackOne_OsMask)" Importance="high"/>
-    <Exec Command="inf2cat /driver:$(PackOne_DestinationPath) /os:$(PackOne_OsMask)" />
+    <Exec Command="inf2cat /uselocaltime /driver:$(PackOne_DestinationPath) /os:$(PackOne_OsMask)" />
   </Target>
 
 </Project>

--- a/fwcfg/buildAll.bat
+++ b/fwcfg/buildAll.bat
@@ -4,7 +4,7 @@ rem call ..\Tools\SetVsEnv 14 x64
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 
-inf2cat /driver:. /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+inf2cat /uselocaltime /driver:. /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
 
 mkdir Install
 copy qemufwcfg.* .\Install\

--- a/pciserial/buildAll.bat
+++ b/pciserial/buildAll.bat
@@ -7,9 +7,9 @@ call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 mkdir Install\rhel
 
 copy qemupciserial.* .\Install\
-inf2cat /driver:Install /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+inf2cat /driver:Install /uselocaltime /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
 
 copy rhel\qemupciserial.* .\Install\rhel
-inf2cat /driver:Install\rhel /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
+inf2cat /driver:Install\rhel /uselocaltime /os:XP_X86,Server2003_X86,XP_X64,Server2003_X64,Vista_X86,Server2008_X86,Vista_X64,Server2008_X64,7_X86,7_X64,Server2008R2_X64,8_X86,8_X64,Server8_X64,6_3_X86,6_3_X64,Server6_3_X64,10_X86,10_X64,Server10_X64
 
 endlocal


### PR DESCRIPTION
The inf2cat tool uses the UTC timezone by default for timestamp comparison,
this can cause the following error when there is a mismatch between time on
the build machine is and the one in UTC timezone. Using /uselocaltime
parameter solves this issue.

Inf2cat error:

* DriverVer set to incorrect date (postdated DriverVer not allowed) in
\netkvm.inf. The current date (UTC) is 01/01/2017.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>