### PR TITLE
NetKVM: Fix a bug where driver won't load with 2 msi vectors

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1222,7 +1222,7 @@ NDIS_STATUS ParaNdis_FinishInitialization(PARANDIS_ADAPTER *pContext)
     if (status == NDIS_STATUS_SUCCESS && pContext->bUsingMSIX)
     {
         status = ParaNdis_ConfigureMSIXVectors(pContext);
-        DPrintf(0, ("[%s] ParaNdis_VirtIONetInit passed, status = %d\n", __FUNCTION__, status));
+        DPrintf(0, ("[%s] ParaNdis_ConfigureMSIXVectors passed, status = %d\n", __FUNCTION__, status));
     }
 
     if (status == NDIS_STATUS_SUCCESS)

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -853,7 +853,7 @@ static USHORT DetermineQueueNumber(PARANDIS_ADAPTER *pContext)
 
     /* In virtio the type of the queue index is "short", thus this type casting */
     USHORT nBundles = USHORT(((pContext->pMSIXInfoTable->MessageCount - 1) / 2)  & 0xFFFF);
-    if (!nBundles && pContext->pMSIXInfoTable->MessageCount == 1)
+    if (!nBundles && (pContext->pMSIXInfoTable->MessageCount == 1 || pContext->pMSIXInfoTable->MessageCount == 2))
     {
         DPrintf(0, ("[%s] WARNING: Single MSIx interrupt allocated, performance will be reduced\n", __FUNCTION__));
         nBundles = 1;

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -855,7 +855,7 @@ static USHORT DetermineQueueNumber(PARANDIS_ADAPTER *pContext)
     USHORT nBundles = USHORT(((pContext->pMSIXInfoTable->MessageCount - 1) / 2)  & 0xFFFF);
     if (!nBundles && pContext->pMSIXInfoTable->MessageCount == 1)
     {
-        DPrintf(0, ("[%s] WARNING: Single MSIx interrupt allocated, performance will be reduced\n", __FUNCTION__, pContext->pMSIXInfoTable->MessageCount));
+        DPrintf(0, ("[%s] WARNING: Single MSIx interrupt allocated, performance will be reduced\n", __FUNCTION__));
         nBundles = 1;
     }
 

--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -487,6 +487,7 @@ NDIS_STATUS ParaNdis_ConfigureMSIXVectors(PARANDIS_ADAPTER *pContext)
     UINT i;
     PIO_INTERRUPT_MESSAGE_INFO pTable = pContext->pMSIXInfoTable;
     bool bSingleVector = pContext->pMSIXInfoTable->MessageCount == 1;
+    bool bDoubleVectors = pContext->pMSIXInfoTable->MessageCount == 2;
     if (pTable && pTable->MessageCount)
     {
         status = NDIS_STATUS_SUCCESS;
@@ -505,7 +506,7 @@ NDIS_STATUS ParaNdis_ConfigureMSIXVectors(PARANDIS_ADAPTER *pContext)
             status = pContext->pPathBundles[j].txPath.SetupMessageIndex(vector);
             if (status == NDIS_STATUS_SUCCESS)
             {
-                if (!bSingleVector) vector++;
+                if (!bSingleVector && !bDoubleVectors) vector++;
                 status = pContext->pPathBundles[j].rxPath.SetupMessageIndex(vector);
             }
             DPrintf(0, ("[%s] Using messages %u/%u for RX/TX queue %u\n", __FUNCTION__,
@@ -523,6 +524,10 @@ NDIS_STATUS ParaNdis_ConfigureMSIXVectors(PARANDIS_ADAPTER *pContext)
             if (bSingleVector)
             {
                 status = pContext->CXPath.SetupMessageIndex(0);
+            }
+            else if (bDoubleVectors)
+            {
+                status = pContext->CXPath.SetupMessageIndex(1);
             }
             else
             {


### PR DESCRIPTION
Even though I don't see why anyone would use 2 msi vectors for the device, the driver should handle this successfully.