### PR TITLE
Update README and parameterize PCI subsystem vendor ID

### DIFF
--- a/Balloon/sys/balloon.inx
+++ b/Balloon/sys/balloon.inx
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes: 
-;    Using Devcon: Type "devcon install BALLOON.inf PCI\VEN_1AF4&DEV_1002&SUBSYS_00051AF4&REV_00" or
-;                       "devcon install BALLOON.inf PCI\VEN_1AF4&DEV_1045&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install BALLOON.inf PCI\VEN_1AF4&DEV_1002&SUBSYS_0005_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install BALLOON.inf PCI\VEN_1AF4&DEV_1045&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -44,8 +44,8 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with
 %VENDOR%=Standard,NT$ARCH$
 
 [Standard.NT$ARCH$]
-%BALLOON.DeviceDesc%=BALLOON_Device, PCI\VEN_1AF4&DEV_1002&SUBSYS_00051AF4&REV_00
-%BALLOON.DeviceDesc%=BALLOON_Device, PCI\VEN_1AF4&DEV_1045&SUBSYS_11001AF4&REV_01
+%BALLOON.DeviceDesc%=BALLOON_Device, PCI\VEN_1AF4&DEV_1002&SUBSYS_0005_INX_SUBSYS_VENDOR_ID&REV_00
+%BALLOON.DeviceDesc%=BALLOON_Device, PCI\VEN_1AF4&DEV_1045&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 [BALLOON_Device.NT]
 CopyFiles=Drivers_Dir

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
+# KVM/QEMU Windows guest drivers (virtio-win) #
+
+This repository contains KVM/QEMU Windows guest drivers, for both
+paravirtual and emulated hardware. The code builds and ships as part
+of the virtio-win RPM on Fedora and Red Hat Enterprise Linux, and the
+binaries are also available in the form of distribution-neutral ISO
+and VFD images. If all you want is use virtio-win in your Windows
+virtual machines, go to
+https://fedoraproject.org/wiki/Windows_Virtio_Drivers for information
+on obtaining the binaries.
+
+If you'd like to build virtio-win from sources, clone this repo and
+follow the instructions in
+https://github.com/virtio-win/kvm-guest-drivers-windows/wiki/Building-the-drivers.
+Note that the drivers you build will be either unsigned or test-signed
+with Tools/VirtIOTestCert.cer, which means that Windows will not load
+them by default. See
+https://docs.microsoft.com/en-us/windows-hardware/drivers/install/installing-test-signed-driver-packages
+for more information on test-signing.
+
+If you want to build cross-signed binaries (like the ones that ship in
+the Fedora RPM), you'll need your own code-signing certificate.
+Cross-signed drivers can be used on all versions of Windows except for
+the latest Windows 10 with secure boot enabled. However, systems with
+cross-signed drivers will not receive Microsoft support.
+
+If you want to produce Microsoft-signed binaries (fully supported,
+like the ones that ship in the Red Hat Enterprise Linux RPM), you'll
+need to submit the drivers to Microsoft along with a set of test
+results (so called WHQL process). If you decide to WHQL the drivers,
+make sure to base them on commit eb2996de or newer, since the GPL
+license used prior to this commit is not compatible with WHQL.
+Additionally, we ask that you make a change to the Hardware IDs so
+that your drivers will *not* match devices exposed by the upstream
+versions of KVM/QEMU. This is especially important if you plan to
+distribute the drivers with Windows Update, see
+https://docs.microsoft.com/en-us/windows-hardware/drivers/dashboard/publishing-restrictions
+for more details.
+
+- - - -
+
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/virtio-win/kvm-guest-drivers-windows?branch=master&svg=true)](https://ci.appveyor.com/project/daynix/kvm-guest-drivers-windows)

--- a/Tools/Driver.Common.targets
+++ b/Tools/Driver.Common.targets
@@ -107,6 +107,11 @@ Invoking the task:
     <Exec Condition="'$(Feature_UsingWDF)'=='true'" Command="stampinf -f $(OutDir)$(TargetName).inf -a $(InfArch) -k 1.9 -v $(STAMPINF_VERSION) -d *"/>
   </Target>
 
+  <!-- Subsystem vendor ID validation -->
+  <Target Condition="'$(SUBSYSTEM_VENDOR_ID.ToUpper())'=='1AF4' AND '$(_VENDOR_)'!='RHEL'" Name="ValidateSubsystemVendor" AfterTargets="AdjustInf_WDK;AdjustInf_LegacyDDK">
+    <Warning Text="Subsystem vendor ID $(SUBSYSTEM_VENDOR_ID) is reserved by Red Hat. Please change it by definining SUBSYSTEM_VENDOR_ID in Driver.$(_VENDOR_).props." />
+  </Target>
+
   <!-- Imports -->
   <Import Condition="'$(Feature_PackOne)'=='true'" Project="Driver.PackOne.targets" />
 

--- a/Tools/Driver.RHEL.props
+++ b/Tools/Driver.RHEL.props
@@ -25,6 +25,7 @@ RHEL inf substitutions and versioning used by all drivers.
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioScsiCopyrightStrings'">2012</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioSerialCopyrightStrings'">2010</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioStorCopyrightStrings'">2008</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'IvshmemCopyrightStrings'">2017</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(RHEL_COPYRIGHT_STARTING_YEAR)' == ''">20??</RHEL_COPYRIGHT_STARTING_YEAR>
 
     <!-- RHEL uses a user-mode service to collect memory statistics -->

--- a/Tools/Driver.VZ.props
+++ b/Tools/Driver.VZ.props
@@ -35,6 +35,7 @@ VZ inf substitutions and versioning used by all drivers.
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioScsiCopyrightStrings'">2012</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioSerialCopyrightStrings'">2010</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'VioStorCopyrightStrings'">2008</RHEL_COPYRIGHT_STARTING_YEAR>
+    <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(CopyrightStrings)' == 'IvshmemCopyrightStrings'">2017</RHEL_COPYRIGHT_STARTING_YEAR>
     <RHEL_COPYRIGHT_STARTING_YEAR Condition="'$(RHEL_COPYRIGHT_STARTING_YEAR)' == ''">20??</RHEL_COPYRIGHT_STARTING_YEAR>
     <VZ_COPYRIGHT_STARTING_YEAR>2016</VZ_COPYRIGHT_STARTING_YEAR>
   </PropertyGroup>

--- a/Tools/Driver.Vendor.props
+++ b/Tools/Driver.Vendor.props
@@ -29,6 +29,16 @@ Set $(Feature_AlwaysDefaultVendor) to false and set $(_VENDOR_) to override.
 
   <Import Project="Driver.$(_VENDOR_).props" />
 
+  <!-- Default subsystem vendor ID -->
+  <PropertyGroup>
+    <SUBSYSTEM_VENDOR_ID Condition="'$(SUBSYSTEM_VENDOR_ID)'==''">1AF4</SUBSYSTEM_VENDOR_ID>
+  </PropertyGroup>
+  <ItemGroup>
+    <Substitution Include="_INX_SUBSYS_VENDOR_ID">
+      <ReplaceWith>$(SUBSYSTEM_VENDOR_ID)</ReplaceWith>
+    </Substitution>
+  </ItemGroup>
+
   <!-- Version specs for C preprocessor, resource compiler, and stampinf -->
   <ItemDefinitionGroup>
     <ClCompile>

--- a/ivshmem/ivshmem.inf
+++ b/ivshmem/ivshmem.inf
@@ -1,14 +1,25 @@
+;/*++
 ;
-; IVSHMEM.inf
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
 ;
+;Module Name:
+;    ivshmem.inf
+;
+;Abstract:
+;
+;Installation Notes:
+;    Using Devcon: Type "devcon install ivshmem.inf PCI\VEN_1AF4&DEV_1110&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
+;
+;--*/
 
 [Version]
 Signature="$WINDOWS NT$"
 Class=System
 ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
-Provider=%ManufacturerName%
-CatalogFile=IVSHMEM.cat
-DriverVer= ; TODO: set DriverVer in stampinf property pages
+Provider=%VENDOR%
+CatalogFile=ivshmem.cat
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
 
 [DestinationDirs]
 DefaultDestDir = 12
@@ -28,10 +39,10 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with
 ;*****************************************
 
 [Manufacturer]
-%ManufacturerName%=Standard,NT$ARCH$
+%VENDOR%=Standard,NT$ARCH$
 
 [Standard.NT$ARCH$]
-%IVSHMEM.DeviceDesc%=IVSHMEM_Device, PCI\VEN_1AF4&DEV_1110
+%IVSHMEM.DeviceDesc%=IVSHMEM_Device, PCI\VEN_1AF4&DEV_1110&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 [IVSHMEM_Device.NT]
 CopyFiles=Drivers_Dir
@@ -84,7 +95,7 @@ KmdfLibraryVersion = $KMDFVERSION$
 
 [Strings]
 SPSVCINST_ASSOCSERVICE= 0x00000002
-ManufacturerName="Red Hat, Inc."
-DiskName = "IVSHMEM Installation Disk"
-IVSHMEM.DeviceDesc = "IVSHMEM Device"
-IVSHMEM.SVCDESC = "IVSHMEM Service"
+VENDOR = "INX_COMPANY"
+DiskName = "INX_PREFIX_QEMUIVSHMEM Installation Disk"
+IVSHMEM.DeviceDesc = "INX_PREFIX_QEMUIVSHMEM Device"
+IVSHMEM.SVCDESC = "INX_PREFIX_QEMUIVSHMEM Service"

--- a/ivshmem/ivshmem.props
+++ b/ivshmem/ivshmem.props
@@ -7,10 +7,14 @@ Enabling and customizing virtio build features
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
   <PropertyGroup>
-    <Feature_AlwaysDefaultVendor>true</Feature_AlwaysDefaultVendor>
+    <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
     <Feature_UsingWDF>true</Feature_UsingWDF>
     <Feature_PackOne>true</Feature_PackOne>
-    <Feature_AdjustInf>false</Feature_AdjustInf>
+    <Feature_LegacyStampInf>false</Feature_LegacyStampInf>
+    <Feature_AdjustInfLegacy>false</Feature_AdjustInfLegacy>
+    <Feature_AdjustInf>true</Feature_AdjustInf>
+    <SourceInfFile>ivshmem.inf</SourceInfFile>
+    <CopyrightStrings>IvshmemCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vioinput/sys/vioinput.inx
+++ b/vioinput/sys/vioinput.inx
@@ -9,7 +9,7 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install vioinput.inf PCI\VEN_1AF4&DEV_1052&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install vioinput.inf PCI\VEN_1AF4&DEV_1052&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -54,9 +54,9 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with
 
 [VirtioInput.NT$ARCH$]
 ;
-; Hw Id is PCI\VEN_1AF4&DEV_1052&SUBSYS_11001AF4&CC_090200&REV_01
+; Hw Id is PCI\VEN_1AF4&DEV_1052&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&CC_090200&REV_01
 ;
-%VirtioInput.DeviceDesc%=VirtioInput_Device, PCI\VEN_1AF4&DEV_1052&SUBSYS_11001AF4&REV_01
+%VirtioInput.DeviceDesc%=VirtioInput_Device, PCI\VEN_1AF4&DEV_1052&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 %VirtioInput.ChildDesc%=VirtioInput_Child, VIOINPUT\REV_01
 
 [VirtioInput_Device.NT]

--- a/viorng/viorng/viorng.inf
+++ b/viorng/viorng/viorng.inf
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install viorng.inf PCI\VEN_1AF4&DEV_1005&SUBSYS_00041AF4&REV_00" or
-;                       "devcon install viorng.inf PCI\VEN_1AF4&DEV_1044&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install viorng.inf PCI\VEN_1AF4&DEV_1005&SUBSYS_0004_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install viorng.inf PCI\VEN_1AF4&DEV_1044&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -45,8 +45,8 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll = 1 ; make sure the number matches wi
 %VENDOR% = Standard,NT$ARCH$
 
 [Standard.NT$ARCH$]
-%VirtRng.DeviceDesc% = VirtRng_Device, PCI\VEN_1AF4&DEV_1005&SUBSYS_00041AF4&REV_00
-%VirtRng.DeviceDesc% = VirtRng_Device, PCI\VEN_1AF4&DEV_1044&SUBSYS_11001AF4&REV_01
+%VirtRng.DeviceDesc% = VirtRng_Device, PCI\VEN_1AF4&DEV_1005&SUBSYS_0004_INX_SUBSYS_VENDOR_ID&REV_00
+%VirtRng.DeviceDesc% = VirtRng_Device, PCI\VEN_1AF4&DEV_1044&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 [VirtRng_Device.NT]
 CopyFiles = VirtRng_CopyFiles

--- a/vioscsi/vioscsi.inx
+++ b/vioscsi/vioscsi.inx
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install vioscsi.inf PCI\VEN_1AF4&DEV_1004&SUBSYS_00081AF4&REV_00" or
-;                       "devcon install vioscsi.inf PCI\VEN_1AF4&DEV_1048&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install vioscsi.inf PCI\VEN_1AF4&DEV_1004&SUBSYS_0008_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install vioscsi.inf PCI\VEN_1AF4&DEV_1048&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -49,8 +49,8 @@ vioscsi_Files_Driver = 12
 %VENDOR%   = VirtioScsi,NT$ARCH$
 
 [VirtioScsi.NT$ARCH$]
-%VirtioScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1004&SUBSYS_00081AF4&REV_00
-%VirtioScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1048&SUBSYS_11001AF4&REV_01
+%VirtioScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1004&SUBSYS_0008_INX_SUBSYS_VENDOR_ID&REV_00
+%VirtioScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1048&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 ;
 ; General installation section

--- a/vioserial/sys/vioser.inx
+++ b/vioserial/sys/vioser.inx
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install vioser.inf PCI\VEN_1AF4&DEV_1003&SUBSYS_00031AF4&REV_00" or
-;                       "devcon install vioser.inf PCI\VEN_1AF4&DEV_1043&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install vioser.inf PCI\VEN_1AF4&DEV_1003&SUBSYS_0003_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install vioser.inf PCI\VEN_1AF4&DEV_1043&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -45,11 +45,11 @@ WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with
 
 [VirtioSerial.NT$ARCH$]
 ;
-; Hw Ids are PCI\VEN_1AF4&DEV_1003&SUBSYS_00031AF4&REV_00
-;            PCI\VEN_1AF4&DEV_1043&SUBSYS_11001AF4&REV_01
+; Hw Ids are PCI\VEN_1AF4&DEV_1003&SUBSYS_0003_INX_SUBSYS_VENDOR_ID&REV_00
+;            PCI\VEN_1AF4&DEV_1043&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 ;
-%VirtioSerial.DeviceDesc%=VirtioSerial_Device, PCI\VEN_1AF4&DEV_1003&SUBSYS_00031AF4&REV_00
-%VirtioSerial.DeviceDesc%=VirtioSerial_Device, PCI\VEN_1AF4&DEV_1043&SUBSYS_11001AF4&REV_01
+%VirtioSerial.DeviceDesc%=VirtioSerial_Device, PCI\VEN_1AF4&DEV_1003&SUBSYS_0003_INX_SUBSYS_VENDOR_ID&REV_00
+%VirtioSerial.DeviceDesc%=VirtioSerial_Device, PCI\VEN_1AF4&DEV_1043&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 [VirtioSerial_Device.NT]
 CopyFiles=Drivers_Dir

--- a/viostor/viostor.inx
+++ b/viostor/viostor.inx
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install viostor.inf PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00" or
-;                       "devcon install viostor.inf PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install viostor.inf PCI\VEN_1AF4&DEV_1001&SUBSYS_0002_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install viostor.inf PCI\VEN_1AF4&DEV_1042&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -49,8 +49,8 @@ viostor_Files_Driver = 12
 %VENDOR%   = VioStor,NT$ARCH$
 
 [VioStor.NT$ARCH$]
-%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
-%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
+%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_0002_INX_SUBSYS_VENDOR_ID&REV_00
+%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 ;
 ; General installation section

--- a/viostor/viostor_no_msi.inx
+++ b/viostor/viostor_no_msi.inx
@@ -9,8 +9,8 @@
 ;Abstract:
 ;
 ;Installation Notes:
-;    Using Devcon: Type "devcon install viostor.inf PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00" or
-;                       "devcon install viostor.inf PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01" to install
+;    Using Devcon: Type "devcon install viostor.inf PCI\VEN_1AF4&DEV_1001&SUBSYS_0002_INX_SUBSYS_VENDOR_ID&REV_00" or
+;                       "devcon install viostor.inf PCI\VEN_1AF4&DEV_1042&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01" to install
 ;
 ;--*/
 
@@ -49,8 +49,8 @@ viostor_Files_Driver = 12
 %VENDOR%   = VioStor,NT$ARCH$
 
 [VioStor.NT$ARCH$]
-%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_00021AF4&REV_00
-%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_11001AF4&REV_01
+%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1001&SUBSYS_0002_INX_SUBSYS_VENDOR_ID&REV_00
+%VioStorScsi.DeviceDesc% = scsi_inst, PCI\VEN_1AF4&DEV_1042&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
 
 ;
 ; General installation section


### PR DESCRIPTION
It is important that all parties shipping virtio-win drivers use their
own vendor-specific HW ID to avoid driving somebody else's device.
This is especially critical for WHQL'ed drivers distributed with Windows
Update, as these could be installed without any explicit user action.

A new build warning is introduced to make this requirement more
discoverable (suggested by @dlunev, thanks!)

Note that NetKVM has not been plugged into the new build infrastructure
yet so it is not handled by these commits.