### PR TITLE
VirtIO: Change vp_notify debug print to a higher level

### DIFF
--- a/VirtIO/VirtIOPCICommon.c
+++ b/VirtIO/VirtIOPCICommon.c
@@ -391,7 +391,7 @@ bool vp_notify(struct virtqueue *vq)
     /* we write the queue's selector into the notification register to
      * signal the other end */
     iowrite16(vq->vdev, (unsigned short)vq->index, vq->notification_addr);
-    DPrintf(0, ("virtio: vp_notify vq->index = %x\n", vq->index));
+    DPrintf(6, ("virtio: vp_notify vq->index = %x\n", vq->index));
     return true;
 }
 


### PR DESCRIPTION
Currently the DPrintf inside vp_notify is called at level 0,
the vp_notify is usually called many many times during normal
execution of the code, this debug print shouldn't be printed
during typical run as it may cause performance issues.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>