### PR TITLE
NetKVM: Use NdisGetSharedDataAlignment to align miniport's adapter context

### DIFF
--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -478,6 +478,9 @@ typedef struct _tagPARANDIS_ADAPTER
     } RSC;
 #endif
 
+    PVOID                   UnalignedAdapterContext;
+    ULONG                   UnalignedAdapterContextSize;
+
     _tagPARANDIS_ADAPTER(const _tagPARANDIS_ADAPTER&) = delete;
     _tagPARANDIS_ADAPTER& operator= (const _tagPARANDIS_ADAPTER&) = delete;
 }PARANDIS_ADAPTER, *PPARANDIS_ADAPTER;


### PR DESCRIPTION
Aligning shared data can affect performance as it might reduce cache
misses which result in performance gain.

According to msdn documentation NdisGetSharedDataAlignment returns boundary
value, in bytes, on which drivers should align structures that can be shared
by more than one processor.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>