### PR TITLE
ivshmem: Don't delete WDFINTERRUPTs

### DIFF
--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -220,8 +220,7 @@ NTSTATUS IVSHMEMEvtDeviceReleaseHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
 
     if (deviceContext->interrupts)
     {
-        for (int i = 0; i < deviceContext->interruptsUsed; ++i)
-            WdfObjectDelete(deviceContext->interrupts[i]);
+        // WDFINTERRUPT objects are deleted by the framework
 
         ExFreePoolWithTag(deviceContext->interrupts, 'sQRI');
 


### PR DESCRIPTION
WDFINTERRUPT objects are deleted by the framework. Explicitly calling
WdfObjectDelete results in an assert/BSOD when running with Driver
Verifier enabled.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>

---

Note that the **Creating an Interrupt Object** MSDN article at https://docs.microsoft.com/en-us/windows-hardware/drivers/wdf/creating-an-interrupt-object is wrong. WdfObjectDelete must not be called on interrupts:

https://github.com/Microsoft/Windows-Driver-Frameworks/blob/master/src/framework/shared/irphandlers/pnp/interruptobject.cpp#L234

cc @gnif