### PR TITLE
NetKVM: Fix hang in release

### DIFF
--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -577,7 +577,11 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList& toWaitingList)
                     // if this NBL finished?
                     if (!NBLHolder->HaveMappedBuffers())
                     {
-                        ASSERT(NBLHolder == PopMappedToSendNBL());
+                        /* We use PeekMappedToSendNBL method to get the current NBL
+                         * that should be processed from the queue, when we finish
+                         * sending all it's NBs, we should pop it from the queue.
+                         */
+                        PopMappedToSendNBL();
                         toWaitingList.Push(NBLHolder);
                     }
                     else


### PR DESCRIPTION
The ASSERT macro is defined as ((void) 0) and thus whatever inside it
doesn't get executed when compiling release.

For the reason explained above, NBLs from the lock free queue weren't
poped from the queue after performing peek operation, this caused
the driver to hang in an infinite loop when running release.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>