### PR TITLE
NetKVM: LockFreeQueue: Fix Peek method

### DIFF
--- a/NetKVM/ParaNdis_LockFreeQueue.h
+++ b/NetKVM/ParaNdis_LockFreeQueue.h
@@ -139,7 +139,7 @@ public:
 
     TEntryType *Peek()
     {
-        if (m_ConsumerHead == m_ProducerHead)
+        if (m_ConsumerHead == m_ProducerTail)
         {
             return nullptr;
         }


### PR DESCRIPTION
We should compare the consumer's head to the producer's tail.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>