### PR TITLE
vioserial: Send VIRTIO_CONSOLE_PORT_OPEN (0) on port D0 exit

### DIFF
--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1450,6 +1450,12 @@ VIOSerialPortEvtDeviceD0Exit(
 
     VIOSerialDisableInterruptQueue(GetInQueue(Port));
 
+    if (Port->GuestConnected)
+    {
+        VIOSerialSendCtrlMsg(Port->BusDevice,
+            Port->PortId, VIRTIO_CONSOLE_PORT_OPEN, 0);
+    }
+
     WdfSpinLockAcquire(Port->InBufLock);
     VIOSerialDiscardPortDataLocked(Port);
     Port->InBuf = NULL;


### PR DESCRIPTION
Virtio serial ports receive the D0 exit callback before the parent driver.
This is expected in this driver architecture of a parent bus driver and
ports modeled as children. It however causes issues because ports own their
respective queues and try to clean them up while VirtIO as a whole, to be
shut down by the master D0 exit callback, is still running.

As a result, D0 exit (caused by resource rebalance on CPU hot-plug for
example), may crash QEMU with errors similar to:

  Looped descriptor

or

  Guest moved used index from 253 to 176

because port D0 exits race with QEMU still pushing data to the queues.

This patch fixes it by sending the VIRTIO_CONSOLE_PORT_OPEN control message
with open=0, i.e. signaling to the host that the port is closed and should
not be receiving more traffic.

It would be nicer to address this on the VirtIO level but VirtIO 1.0
explicitly forbids the driver from shutting down individual queues:

  4.1.4.3.2 Driver Requirements: Common configuration structure layout
  [...]
  The driver MUST NOT write a 0 to queue_enable.

Alternatively, the driver might be refactored so that all queues are owned
by the parent bus driver which would then be in charge of cleaning them up
following the correct protocol, i.e. only after the VirtIO device has been
reset. This would be a bigger and riskier change.

Link: https://github.com/virtio-win/kvm-guest-drivers-windows/issues/195
Signed-off-by: Ladi Prosek <lprosek@redhat.com>