### PR TITLE
build: Debug config support for PackOne

### DIFF
--- a/Tools/Driver.PackOne.targets
+++ b/Tools/Driver.PackOne.targets
@@ -143,9 +143,14 @@ Related features:
   </PropertyGroup>
 
   <!-- $(PackOne_SourcePath) and $(PackOne_DestinationPath) -->
-  <PropertyGroup>
-    <PackOne_SourcePath>objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
-    <PackOne_DestinationPath>$(PackOne_DestinationPrefix)Install\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
+  <PropertyGroup Condition="$(Configuration.EndsWith('Debug'))"> 
+    <PackOne_SourcePath Condition="$(PackOne_SourcePath)==''">objchk_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
+    <PackOne_DestinationPath Condition="$(PackOne_DestinationPath)==''">$(PackOne_DestinationPrefix)Install_Debug\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="!$(Configuration.EndsWith('Debug'))"> 
+    <PackOne_SourcePath Condition="$(PackOne_SourcePath)==''">objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
+    <PackOne_DestinationPath Condition="$(PackOne_DestinationPath)==''">$(PackOne_DestinationPrefix)Install\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
   </PropertyGroup>
 
   <!-- $(PackOne_CopyWdf) and $(PackOne_WdfCoinstaller) -->

--- a/Tools/Driver.PackOne.targets
+++ b/Tools/Driver.PackOne.targets
@@ -149,8 +149,8 @@ Related features:
   </PropertyGroup>
   
   <PropertyGroup Condition="!$(Configuration.EndsWith('Debug'))"> 
-    <PackOne_SourcePath Condition="$(PackOne_SourcePath)==''">objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
-    <PackOne_DestinationPath Condition="$(PackOne_DestinationPath)==''">$(PackOne_DestinationPrefix)Install\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
+    <PackOne_SourcePath Condition="'$(PackOne_SourcePath)'==''">objfre_$(TargetOS)_$(TargetArch)\$(PackOne_SourcePathArch)</PackOne_SourcePath>
+    <PackOne_DestinationPath Condition="'$(PackOne_DestinationPath)'==''">$(PackOne_DestinationPrefix)Install\$(TargetOS)\$(TargetArch)</PackOne_DestinationPath>
   </PropertyGroup>
 
   <!-- $(PackOne_CopyWdf) and $(PackOne_WdfCoinstaller) -->


### PR DESCRIPTION
Now PackOne takes files from objchk_* and copy them to Install_Debug when project configuration name ends with "Debug". It's required for NDIS5 driver build.
Also, PackOne source and dest can be overrided in the project configuration.
