### PR TITLE
virtiolib: fix compilation error

### DIFF
--- a/VirtIO/linux/virtio_types.h
+++ b/VirtIO/linux/virtio_types.h
@@ -31,7 +31,8 @@
 * Copyright (C) 2014 Red Hat, Inc.
 * Author: Michael S. Tsirkin <mst@redhat.com>
 */
-#include <linux/types.h>
+
+#include "linux/types.h"
 
 /*
 * __virtio{16,32,64} have the following meaning:

--- a/VirtIO/virtio_pci.h
+++ b/VirtIO/virtio_pci.h
@@ -39,8 +39,8 @@
 #ifndef _LINUX_VIRTIO_PCI_H
 #define _LINUX_VIRTIO_PCI_H
 
-#include <linux/types.h>
-#include <linux/virtio_config.h>
+#include "linux/types.h"
+#include "linux/virtio_config.h"
 
 #ifndef VIRTIO_PCI_NO_LEGACY
 

--- a/VirtIO/virtio_ring.h
+++ b/VirtIO/virtio_ring.h
@@ -31,8 +31,9 @@
 * SUCH DAMAGE.
 *
 * Copyright Rusty Russell IBM Corporation 2007. */
-#include <linux/types.h>
-#include <linux/virtio_types.h>
+
+#include "linux/types.h"
+#include "linux/virtio_types.h"
 
 #pragma warning (push)
 #pragma warning (disable:4200)


### PR DESCRIPTION
Search for the Linux imported header files in the local directory and not in the global Include files one.

Signed-off-by: Gal Hammer <ghammer@redhat.com>