### PR TITLE
Fix asserts in VirtioLib and NetKVM

### DIFF
--- a/NetKVM/Common/ParaNdis-VirtIO.cpp
+++ b/NetKVM/Common/ParaNdis-VirtIO.cpp
@@ -90,6 +90,7 @@ void CPciBar::Unmap(NDIS_HANDLE DrvHandle)
                 m_BaseVA,
                 m_uSize);
         }
+        m_BaseVA = nullptr;
     }
 }
 

--- a/VirtIO/VirtIORing.c
+++ b/VirtIO/VirtIORing.c
@@ -41,7 +41,7 @@
 static inline u16 get_unused_desc(struct virtqueue *vq)
 {
     u16 idx = vq->first_unused;
-    ASSERT(vq->vring.desc[idx].flags & VIRTQ_DESC_F_NEXT);
+    ASSERT(vq->num_unused > 0);
 
     vq->first_unused = vq->vring.desc[idx].next;
     vq->num_unused--;


### PR DESCRIPTION
Fixes two asserts that fire when a debug build of NetKVM is started.