### PR TITLE
CParaNdisCX: SendControlMessage: Make sure the buffer is returned

### DIFF
--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -89,16 +89,14 @@ BOOLEAN CParaNdisCX::SendControlMessage(
         if (0 <= m_VirtQueue.AddBuf(sg, nOut, 1, (PVOID)1, NULL, 0))
         {
             UINT len;
-            void *p;
-            /* Control messages are processed synchronously in QEMU, so upon kick_buf return, the response message
-              has been already inserted in the queue */
+
             m_VirtQueue.Kick();
-            p = m_VirtQueue.GetBuf(&len);
-            if (!p)
+            while (!m_VirtQueue.GetBuf(&len))
             {
-                DPrintf(0, ("%s - ERROR: get_buf failed\n", __FUNCTION__));
+                UINT interval = 1;
+                NdisStallExecution(interval);
             }
-            else if (len != sizeof(virtio_net_ctrl_ack))
+            if (len != sizeof(virtio_net_ctrl_ack))
             {
                 DPrintf(0, ("%s - ERROR: wrong len %d\n", __FUNCTION__, len));
             }

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1365,6 +1365,7 @@ VOID ParaNdis_CleanupContext(PARANDIS_ADAPTER *pContext)
 
     pContext->RSSParameters.rwLock.~CNdisRWLock();
 #endif
+    pContext->m_StateMachine.NotifyHalted();
 
     if (pContext->bCXPathAllocated)
     {

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -2,18 +2,21 @@
 
 #include "ParaNdis-Util.h"
 
-class CDataFlowStateMachine : public CPlacementAllocatable
+class CFlowStateMachine : public CPlacementAllocatable
 {
 public:
-    void Start()
+    virtual void Start()
     {
-        NETKVM_ASSERT(m_State == FlowState::Stopped);
+        if (m_State != FlowState::Stopped)
+        {
+            return;
+        }
         m_Counter.AddRef();
         m_State = FlowState::Running;
         m_Counter.ClearMask(StoppedMask);
     }
 
-    void Stop(NDIS_STATUS Reason = NDIS_STATUS_PAUSED)
+    virtual void Stop(NDIS_STATUS Reason = NDIS_STATUS_PAUSED)
     {
         NETKVM_ASSERT(m_State == FlowState::Running);
         m_State = FlowState::Stopping;
@@ -24,8 +27,8 @@ public:
         m_NoOutstandingItems.Wait();
     }
 
-    bool RegisterOutstandingItems(ULONG NumItems,
-                                  NDIS_STATUS *FailureReason = nullptr)
+    virtual bool RegisterOutstandingItems(ULONG NumItems,
+        NDIS_STATUS *FailureReason = nullptr)
     {
         auto value = m_Counter.AddRef(NumItems);
         if (value & StoppedMask)
@@ -44,7 +47,7 @@ public:
         return true;
     }
 
-    void UnregisterOutstandingItems(ULONG NumItems)
+    virtual void UnregisterOutstandingItems(ULONG NumItems)
     {
         NETKVM_ASSERT(m_State != FlowState::Stopped);
         LONG value = m_Counter.Release(NumItems);
@@ -64,19 +67,23 @@ public:
         }
     }
 
-    bool RegisterOutstandingItem()
-    { return RegisterOutstandingItems(1); }
+    virtual bool RegisterOutstandingItem()
+    {
+        return RegisterOutstandingItems(1);
+    }
 
-    void UnregisterOutstandingItem()
-    { UnregisterOutstandingItems(1); }
+    virtual void UnregisterOutstandingItem()
+    {
+        UnregisterOutstandingItems(1);
+    }
 
-    CDataFlowStateMachine() { m_Counter.SetMask(StoppedMask); }
-    ~CDataFlowStateMachine() = default;
-    CDataFlowStateMachine(const CDataFlowStateMachine&) = delete;
-    CDataFlowStateMachine& operator= (const CDataFlowStateMachine&) = delete;
+    CFlowStateMachine() { m_Counter.SetMask(StoppedMask); }
+    ~CFlowStateMachine() = default;
+    CFlowStateMachine(const CFlowStateMachine&) = delete;
+    CFlowStateMachine& operator= (const CFlowStateMachine&) = delete;
 
-private:
-    void CompleteStopping()
+protected:
+    virtual void CompleteStopping()
     {
         TSpinLocker lock(m_CompleteStoppingLock);
         if (m_State == FlowState::Stopping)
@@ -100,21 +107,56 @@ private:
     CNdisSpinLock m_CompleteStoppingLock;
     CNdisEvent m_NoOutstandingItems;
     NDIS_STATUS m_StopReason = NDIS_STATUS_PAUSED;
+};
 
+class CDataFlowStateMachine : public CFlowStateMachine
+{
+public:
+
+
+    CDataFlowStateMachine() { }
+    ~CDataFlowStateMachine() = default;
+    CDataFlowStateMachine(const CDataFlowStateMachine&) = delete;
+    CDataFlowStateMachine& operator= (const CDataFlowStateMachine&) = delete;
+
+private:
     DECLARE_CNDISLIST_ENTRY(CDataFlowStateMachine);
+};
+
+class CConfigFlowStateMachine : public CFlowStateMachine
+{
+public:
+
+
+    CConfigFlowStateMachine() { }
+    ~CConfigFlowStateMachine() = default;
+    CConfigFlowStateMachine(const CConfigFlowStateMachine&) = delete;
+    CConfigFlowStateMachine& operator= (const CConfigFlowStateMachine&) = delete;
+
+private:
+    DECLARE_CNDISLIST_ENTRY(CConfigFlowStateMachine);
 };
 
 class CMiniportStateMachine : public CPlacementAllocatable
 {
 public:
         void RegisterFlow(CDataFlowStateMachine &Flow)
-        { m_Flows.PushBack(&Flow); }
+        { m_DataFlows.PushBack(&Flow); }
 
         void UnregisterFlow(CDataFlowStateMachine &Flow)
-        { m_Flows.Remove(&Flow); }
+        { m_DataFlows.Remove(&Flow); }
+
+        void RegisterFlow(CConfigFlowStateMachine &Flow)
+        { m_ConfigFlows.PushBack(&Flow); }
+
+        void UnregisterFlow(CConfigFlowStateMachine &Flow)
+        { m_ConfigFlows.Remove(&Flow); }
 
         void NotifyInitialized()
-        { ChangeState(MiniportState::Paused, MiniportState::Halted); }
+        {
+            StartConfigFlows();
+            ChangeState(MiniportState::Paused, MiniportState::Halted);
+        }
 
         void NotifyShutdown()
         { ChangeState(MiniportState::Shutdown,
@@ -160,6 +202,10 @@ public:
             }
         }
 
+        void NotifyHalted()
+        {
+            StopConfigFlows(NDIS_STATUS_PAUSED); }
+
         CMiniportStateMachine() = default;
         ~CMiniportStateMachine() = default;
         CMiniportStateMachine(const CMiniportStateMachine&) = delete;
@@ -196,11 +242,18 @@ private:
     }
 
     void StartFlows()
-    { m_Flows.ForEach([](CDataFlowStateMachine* Flow) { Flow->Start(); }); }
+    { m_DataFlows.ForEach([](CDataFlowStateMachine* Flow) { Flow->Start(); }); }
 
     void StopFlows(NDIS_STATUS Reason)
-    { m_Flows.ForEach([Reason](CDataFlowStateMachine* Flow) { Flow->Stop(Reason); }); }
+    { m_DataFlows.ForEach([Reason](CDataFlowStateMachine* Flow) { Flow->Stop(Reason); }); }
+
+    void StartConfigFlows()
+    { m_ConfigFlows.ForEach([](CConfigFlowStateMachine* Flow) { Flow->Start(); }); }
+
+    void StopConfigFlows(NDIS_STATUS Reason)
+    { m_ConfigFlows.ForEach([Reason](CConfigFlowStateMachine* Flow) { Flow->Stop(Reason); }); }
 
     MiniportState m_State = MiniportState::Halted;
-    CNdisList<CDataFlowStateMachine, CRawAccess, CNonCountingObject> m_Flows;
+    CNdisList<CDataFlowStateMachine, CRawAccess, CNonCountingObject> m_DataFlows;
+    CNdisList<CConfigFlowStateMachine, CRawAccess, CNonCountingObject> m_ConfigFlows;
 };

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -397,6 +397,8 @@ typedef struct _tagPARANDIS_ADAPTER
 
     CMiniportStateMachine   m_StateMachine;
     CDataFlowStateMachine   m_RxStateMachine;
+    CConfigFlowStateMachine m_CxStateMachine;
+
 
     CGuestAnnouncePackets    guestAnnouncePackets;
 

--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -183,8 +183,11 @@ static NDIS_STATUS ParaNdis6_Initialize(
 
         new (&pContext->m_StateMachine) CMiniportStateMachine;
         new (&pContext->m_RxStateMachine) CDataFlowStateMachine;
+        new (&pContext->m_CxStateMachine) CConfigFlowStateMachine;
 
         pContext->m_StateMachine.RegisterFlow(pContext->m_RxStateMachine);
+        pContext->m_StateMachine.RegisterFlow(pContext->m_CxStateMachine);
+
 
         NdisZeroMemory(&miniportAttributes, sizeof(miniportAttributes));
         miniportAttributes.RegistrationAttributes.Header.Type = NDIS_OBJECT_TYPE_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES;
@@ -335,7 +338,10 @@ static NDIS_STATUS ParaNdis6_Initialize(
 #endif
 
         pContext->m_StateMachine.UnregisterFlow(pContext->m_RxStateMachine);
+        pContext->m_StateMachine.UnregisterFlow(pContext->m_CxStateMachine);
+        pContext->m_StateMachine.NotifyHalted();
 
+        pContext->m_CxStateMachine.~CConfigFlowStateMachine();
         pContext->m_RxStateMachine.~CDataFlowStateMachine();
         pContext->m_StateMachine.~CMiniportStateMachine();
 


### PR DESCRIPTION
The following assumption in CParaNdisCX::SendControlMessage:

"Control messages are processed synchronously in QEMU, so upon kick_buf
return, the response message has been already inserted in the queue"

Is not true, so we need to wait until the buffer is
returned by the virtqueue.

Prior to this patch the debug build of NetKVM would flood the logs
on startup of the device with the message:

"CParaNdisCX::SendControlMessage - ERROR: add_buf failed"

The driver would fill the virtqueue by not waiting for the buffers to
return due to the misleading assumption above which lead the queue to
become overflawed that caused failure in adding buffers to the queue.

This assumption seems to be true with vhost=on as this doesn't reproduce
with vhost=on.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>