### PR TITLE
Simplify event suppression

### DIFF
--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -54,15 +54,12 @@ BalloonInit(
     WdfObjectAcquireLock(WdfDevice);
 
     // inflate
-    params[0].bEnableInterruptSuppression = false;
     params[0].Interrupt = devCtx->WdfInterrupt;
 
     // deflate
-    params[1].bEnableInterruptSuppression = false;
     params[1].Interrupt = devCtx->WdfInterrupt;
 
     // stats
-    params[2].bEnableInterruptSuppression = false;
     params[2].Interrupt = devCtx->WdfInterrupt;
 
     u64HostFeatures = VirtIOWdfGetDeviceFeatures(&devCtx->VDevice);

--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -30,8 +30,7 @@ bool CParaNdisCX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
 
     return m_VirtQueue.Create(DeviceQueueIndex,
         &m_Context->IODevice,
-        m_Context->MiniportHandle,
-        m_Context->bDoPublishIndices ? true : false);
+        m_Context->MiniportHandle);
 }
 
 BOOLEAN CParaNdisCX::SendControlMessage(

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -88,7 +88,6 @@ typedef struct _tagConfigurationEntries
     tConfigurationEntry stdLsoV2ip6;
     tConfigurationEntry PriorityVlanTagging;
     tConfigurationEntry VlanId;
-    tConfigurationEntry PublishIndices;
     tConfigurationEntry MTU;
     tConfigurationEntry NumberOfHandledRXPacketsInDPC;
 #if PARANDIS_SUPPORT_RSS
@@ -122,7 +121,6 @@ static const tConfigurationEntries defaultConfiguration =
     { "*LsoV2IPv6", 1, 0, 1 },
     { "*PriorityVLANTag", 3, 0, 3},
     { "VlanId", 0, 0, MAX_VLAN_ID},
-    { "PublishIndices", 1, 0, 1},
     { "MTU", 1500, 576, 65500},
     { "NumberOfHandledRXPacketsInDPC", MAX_RX_LOOPS, 1, 10000},
 #if PARANDIS_SUPPORT_RSS
@@ -252,7 +250,6 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             GetConfigurationEntry(cfg, &pConfiguration->stdLsoV2ip6);
             GetConfigurationEntry(cfg, &pConfiguration->PriorityVlanTagging);
             GetConfigurationEntry(cfg, &pConfiguration->VlanId);
-            GetConfigurationEntry(cfg, &pConfiguration->PublishIndices);
             GetConfigurationEntry(cfg, &pConfiguration->MTU);
             GetConfigurationEntry(cfg, &pConfiguration->NumberOfHandledRXPacketsInDPC);
 #if PARANDIS_SUPPORT_RSS
@@ -716,7 +713,7 @@ NDIS_STATUS ParaNdis_InitializeContext(
 
         pContext->bUseMergedBuffers = AckFeature(pContext, VIRTIO_NET_F_MRG_RXBUF);
         pContext->nVirtioHeaderSize = (pContext->bUseMergedBuffers) ? sizeof(virtio_net_hdr_mrg_rxbuf) : sizeof(virtio_net_hdr);
-        pContext->bDoPublishIndices = AckFeature(pContext, VIRTIO_RING_F_EVENT_IDX);
+        AckFeature(pContext, VIRTIO_RING_F_EVENT_IDX);
     }
     else
     {

--- a/NetKVM/Common/ParaNdis-RX.cpp
+++ b/NetKVM/Common/ParaNdis-RX.cpp
@@ -22,8 +22,7 @@ bool CParaNdisRX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
 
     if (!m_VirtQueue.Create(DeviceQueueIndex,
         &m_Context->IODevice,
-        m_Context->MiniportHandle,
-        m_Context->bDoPublishIndices ? true : false))
+        m_Context->MiniportHandle))
     {
         DPrintf(0, ("CParaNdisRX::Create - virtqueue creation failed\n"));
         return false;

--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -302,7 +302,6 @@ bool CParaNdisTX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
     return m_VirtQueue.Create(DeviceQueueIndex,
         &m_Context->IODevice,
         m_Context->MiniportHandle,
-        m_Context->bDoPublishIndices ? true : false,
         m_Context->maxFreeTxDescriptors,
         m_Context->nVirtioHeaderSize,
         m_Context) &&

--- a/NetKVM/Common/ParaNdis-VirtQueue.cpp
+++ b/NetKVM/Common/ParaNdis-VirtQueue.cpp
@@ -33,11 +33,7 @@ void CVirtQueue::Renew()
         &m_VirtQueue);
     pContext->pPageAllocator = nullptr;
 
-    if (NT_SUCCESS(status))
-    {
-        virtio_set_queue_event_suppression(m_VirtQueue, m_UsePublishedIndices);
-    }
-    else
+    if (!NT_SUCCESS(status))
     {
         DPrintf(0, ("[%s] - queue setup failed for index %u with error %x\n", __FUNCTION__, m_Index, status));
         m_VirtQueue = nullptr;
@@ -46,8 +42,7 @@ void CVirtQueue::Renew()
 
 bool CVirtQueue::Create(UINT Index,
     VirtIODevice *IODevice,
-    NDIS_HANDLE DrvHandle,
-    bool UsePublishedIndices)
+    NDIS_HANDLE DrvHandle)
 {
     m_DrvHandle = DrvHandle;
     m_Index = Index;
@@ -57,8 +52,6 @@ bool CVirtQueue::Create(UINT Index,
         DPrintf(0, ("[%s] - shared memory creation failed\n", __FUNCTION__));
         return false;
     }
-
-    m_UsePublishedIndices = UsePublishedIndices;
 
     NETKVM_ASSERT(m_VirtQueue == nullptr);
 
@@ -131,12 +124,11 @@ void CTXVirtQueue::FreeBuffers()
 bool CTXVirtQueue::Create(UINT Index,
     VirtIODevice *IODevice,
     NDIS_HANDLE DrvHandle,
-    bool UsePublishedIndices,
     ULONG MaxBuffers,
     ULONG HeaderSize,
     PPARANDIS_ADAPTER Context)
 {
-    if (!CVirtQueue::Create(Index, IODevice, DrvHandle, UsePublishedIndices)) {
+    if (!CVirtQueue::Create(Index, IODevice, DrvHandle)) {
         return false;
     }
 

--- a/NetKVM/Common/ParaNdis-VirtQueue.h
+++ b/NetKVM/Common/ParaNdis-VirtQueue.h
@@ -152,7 +152,6 @@ public:
         : m_DrvHandle(NULL)
         , m_Index(0xFFFFFFFF)
         , m_IODevice(NULL)
-        , m_UsePublishedIndices(false)
     {}
 
     virtual ~CVirtQueue()
@@ -162,8 +161,7 @@ public:
 
     bool Create(UINT Index,
         VirtIODevice *IODevice,
-        NDIS_HANDLE DrvHandle,
-        bool UsePublishedIndices);
+        NDIS_HANDLE DrvHandle);
 
     ULONG GetRingSize()
     { return virtio_get_queue_size(m_VirtQueue); }
@@ -232,7 +230,6 @@ private:
     VirtIODevice *m_IODevice;
 
     CNdisSharedMemory m_SharedMemory;
-    bool m_UsePublishedIndices;
     struct virtqueue *m_VirtQueue = nullptr;
 
     CVirtQueue(const CVirtQueue&) = delete;
@@ -252,7 +249,6 @@ public:
     bool Create(UINT Index,
         VirtIODevice *IODevice,
         NDIS_HANDLE DrvHandle,
-        bool UsePublishedIndices,
         ULONG MaxBuffers,
         ULONG HeaderSize,
         PPARANDIS_ADAPTER Context);

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -367,7 +367,6 @@ typedef struct _tagPARANDIS_ADAPTER
     BOOLEAN                 bGuestChecksumSupported;
     BOOLEAN                 bControlQueueSupported;
     BOOLEAN                 bUseMergedBuffers;
-    BOOLEAN                 bDoPublishIndices;
     BOOLEAN                 bSurprizeRemoved;
     BOOLEAN                 bUsingMSIX;
     BOOLEAN                 bUseIndirect;

--- a/NetKVM/NDIS5/Common/ParaNdis-Common.c
+++ b/NetKVM/NDIS5/Common/ParaNdis-Common.c
@@ -1106,7 +1106,7 @@ static int PrepareReceiveBuffers(PARANDIS_ADAPTER *pContext)
 static NDIS_STATUS FindNetQueues(PARANDIS_ADAPTER *pContext)
 {
     struct virtqueue *queues[3];
-    unsigned i, nvqs = pContext->bHasControlQueue ? 3 : 2;
+    unsigned nvqs = pContext->bHasControlQueue ? 3 : 2;
     NTSTATUS status;
 
     // We work with two or three virtqueues, 0 - receive, 1 - send, 2 - control
@@ -1117,13 +1117,6 @@ static NDIS_STATUS FindNetQueues(PARANDIS_ADAPTER *pContext)
     if (!NT_SUCCESS(status)) {
        DPrintf(0, ("[%s] virtio_find_queues failed with %x\n", __FUNCTION__, status));
        return NTStatusToNdisStatus(status);
-    }
-
-    // set interrupt suppression flags
-    for (i = 0; i < nvqs; i++) {
-        virtio_set_queue_event_suppression(
-          queues[i],
-          pContext->bDoPublishIndices);
     }
 
     pContext->NetReceiveQueue = queues[0];

--- a/NetKVM/NDIS5/Common/ndis56common.h
+++ b/NetKVM/NDIS5/Common/ndis56common.h
@@ -374,7 +374,6 @@ typedef struct _tagPARANDIS_ADAPTER
     BOOLEAN                 bDoIPCheckTx;
     BOOLEAN                 bDoIPCheckRx;
     BOOLEAN                 bUseMergedBuffers;
-    BOOLEAN                 bDoPublishIndices;
     BOOLEAN                 bDoKickOnNoBuffer;
     BOOLEAN                 bSurprizeRemoved;
     BOOLEAN                 bUsingMSIX;

--- a/NetKVM/NDIS5/wxp/netkvm.inx
+++ b/NetKVM/NDIS5/wxp/netkvm.inx
@@ -130,12 +130,6 @@ HKR, Ndi\Params\MergeableBuf,       type,       0,          "enum"
 HKR, Ndi\Params\MergeableBuf\enum,  "1",        0,          %Enable%
 HKR, Ndi\Params\MergeableBuf\enum,  "0",        0,          %Disable%
 
-HKR, Ndi\Params\PublishIndices,     ParamDesc,  0,          %PublishIndices%
-HKR, Ndi\Params\PublishIndices,     Default,    0,          "1"
-HKR, Ndi\Params\PublishIndices,     type,       0,          "enum"
-HKR, Ndi\Params\PublishIndices\enum,    "1",        0,          %Enable%
-HKR, Ndi\Params\PublishIndices\enum,    "0",        0,          %Disable%
-
 HKR, Ndi\params\NetworkAddress,     ParamDesc,  0,          %NetworkAddress%
 HKR, Ndi\params\NetworkAddress,     type,       0,          "edit"
 HKR, Ndi\params\NetworkAddress,     Optional,   0,          "1"
@@ -284,7 +278,6 @@ NetworkAddress = "Assign MAC"
 ConnectRate = "Init.ConnectionRate(Mb)"
 Priority = "Init.Do802.1PQ"
 MergeableBuf = "Init.UseMergedBuffers"
-PublishIndices = "Init.UsePublishEvents"
 MTU = "Init.MTUSize"
 Indirect = "Init.IndirectTx"
 TxCapacity = "Init.MaxTxBuffers"

--- a/VirtIO/VirtIO.h
+++ b/VirtIO/VirtIO.h
@@ -25,7 +25,6 @@ struct virtqueue {
     unsigned int num_added_since_kick;
     u16 first_unused;
     u16 last_used;
-    bool event_suppression_enabled;
     void *notification_addr;
     void (*notification_cb)(struct virtqueue *vq);
     void *opaque[];

--- a/VirtIO/VirtIOPCICommon.c
+++ b/VirtIO/VirtIOPCICommon.c
@@ -119,8 +119,11 @@ u64 virtio_get_features(VirtIODevice *vdev)
 NTSTATUS virtio_set_features(VirtIODevice *vdev, u64 features)
 {
     unsigned char dev_status;
-    NTSTATUS status = vdev->device->set_features(vdev, features);
+    NTSTATUS status;
 
+    vdev->event_suppression_enabled = virtio_is_feature_enabled(features, VIRTIO_RING_F_EVENT_IDX);
+
+    status = vdev->device->set_features(vdev, features);
     if (!NT_SUCCESS(status)) {
         return status;
     }

--- a/VirtIO/WDF/VirtIOWdf.c
+++ b/VirtIO/WDF/VirtIOWdf.c
@@ -158,14 +158,6 @@ NTSTATUS VirtIOWdfInitQueues(PVIRTIO_WDF_DRIVER pWdfDriver,
         pQueues);
     pWdfDriver->pQueueParams = NULL;
 
-    if (NT_SUCCESS(status)) {
-        /* set interrupt suppression flags */
-        for (i = 0; i < nQueues; i++) {
-            virtio_set_queue_event_suppression(
-                pQueues[i],
-                pQueueParams[i].bEnableInterruptSuppression);
-        }
-    }
     return status;
 }
 
@@ -207,8 +199,7 @@ NTSTATUS VirtIOWdfInitQueuesCB(PVIRTIO_WDF_DRIVER pWdfDriver,
             break;
         }
 
-        /* set the desired queue vector and suppression flag */
-        QueueParam.bEnableInterruptSuppression = false;
+        /* set the desired queue vector */
         QueueParam.Interrupt = NULL;
 
         pQueueParamFunc(pWdfDriver, i, &QueueParam);
@@ -225,10 +216,6 @@ NTSTATUS VirtIOWdfInitQueuesCB(PVIRTIO_WDF_DRIVER pWdfDriver,
                 break;
             }
         }
-
-        virtio_set_queue_event_suppression(
-            vq,
-            QueueParam.bEnableInterruptSuppression);
 
         /* pass the virtqueue pointer to the caller */
         pSetQueueFunc(pWdfDriver, i, vq);

--- a/VirtIO/WDF/VirtIOWdf.h
+++ b/VirtIO/WDF/VirtIOWdf.h
@@ -39,7 +39,7 @@ typedef struct virtio_wdf_queue_param {
     /* interrupt associated with the queue */
     WDFINTERRUPT            Interrupt;
 
-    /* old-style interrupt suppression, see virtio 1.0 spec § 2.4.7 */
+    /* will be removed */
     bool                    bEnableInterruptSuppression;
 } VIRTIO_WDF_QUEUE_PARAM , *PVIRTIO_WDF_QUEUE_PARAM;
 

--- a/VirtIO/WDF/VirtIOWdf.h
+++ b/VirtIO/WDF/VirtIOWdf.h
@@ -38,9 +38,6 @@
 typedef struct virtio_wdf_queue_param {
     /* interrupt associated with the queue */
     WDFINTERRUPT            Interrupt;
-
-    /* will be removed */
-    bool                    bEnableInterruptSuppression;
 } VIRTIO_WDF_QUEUE_PARAM , *PVIRTIO_WDF_QUEUE_PARAM;
 
 /* Data associated with a WDF virtio driver, usually declared as

--- a/VirtIO/virtio_pci.h
+++ b/VirtIO/virtio_pci.h
@@ -241,6 +241,9 @@ struct virtio_device
     // true if the device uses MSI interrupts
     bool msix_used;
 
+    // true if the VIRTIO_RING_F_EVENT_IDX feature flag has been negotiated
+    bool event_suppression_enabled;
+
     // internal device operations, implemented separately for legacy and modern
     const struct virtio_device_ops *device;
 
@@ -349,12 +352,11 @@ void virtio_delete_queue(struct virtqueue *vq);
 void virtio_delete_queues(VirtIODevice *vdev);
 
 /* Driver API: virtqueue query and manipulation
- * virtio_set_queue_event_suppression controls the virtqueue notification logic, see
- * the VIRTIO_RING_F_EVENT_IDX feature bit for more details. virtio_get_queue_descriptor_size
+ * virtio_get_queue_descriptor_size
  * is useful in situations where the driver has to prepare for the memory allocation
  * performed by virtio_reserve_queue_memory beforehand.
  */
-void virtio_set_queue_event_suppression(struct virtqueue *vq, bool enable);
+#define virtio_set_queue_event_suppression(vq, enable) // Will be removed
 
 u32 virtio_get_queue_size(struct virtqueue *vq);
 unsigned long virtio_get_indirect_page_capacity();

--- a/VirtIO/virtio_pci.h
+++ b/VirtIO/virtio_pci.h
@@ -356,7 +356,6 @@ void virtio_delete_queues(VirtIODevice *vdev);
  * is useful in situations where the driver has to prepare for the memory allocation
  * performed by virtio_reserve_queue_memory beforehand.
  */
-#define virtio_set_queue_event_suppression(vq, enable) // Will be removed
 
 u32 virtio_get_queue_size(struct virtqueue *vq);
 unsigned long virtio_get_indirect_page_capacity();

--- a/vioinput/sys/Device.c
+++ b/vioinput/sys/Device.c
@@ -408,11 +408,9 @@ VIOInputInitAllQueues(
     VIRTIO_WDF_QUEUE_PARAM params[2];
 
     // event
-    params[0].bEnableInterruptSuppression = false;
     params[0].Interrupt = pContext->QueuesInterrupt;
 
     // status
-    params[1].bEnableInterruptSuppression = false;
     params[1].Interrupt = pContext->QueuesInterrupt;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "--> %s\n", __FUNCTION__);

--- a/viorng/viorng/power.c
+++ b/viorng/viorng/power.c
@@ -115,7 +115,6 @@ NTSTATUS VirtRngEvtDeviceD0Entry(IN WDFDEVICE Device,
     status = VirtIOWdfSetDriverFeatures(&context->VDevice, u64GuestFeatures);
     if (NT_SUCCESS(status))
     {
-        param.bEnableInterruptSuppression = false;
         param.Interrupt = context->WdfInterrupt;
 
         status = VirtIOWdfInitQueues(&context->VDevice, 1, &context->VirtQueue, &param);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -594,9 +594,7 @@ EXIT_FN();
 
 static BOOLEAN InitializeVirtualQueues(PADAPTER_EXTENSION adaptExt, ULONG numQueues)
 {
-    ULONG index;
     NTSTATUS status;
-    BOOLEAN useEventIndex = CHECKBIT(adaptExt->features, VIRTIO_RING_F_EVENT_IDX);
 
     status = virtio_find_queues(
         &adaptExt->vdev,
@@ -607,11 +605,6 @@ static BOOLEAN InitializeVirtualQueues(PADAPTER_EXTENSION adaptExt, ULONG numQue
         return FALSE;
     }
 
-    for (index = 0; index < numQueues; index++) {
-        virtio_set_queue_event_suppression(
-            adaptExt->vq[index],
-            useEventIndex);
-    }
     return TRUE;
 }
 

--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -374,7 +374,6 @@ VIOSerialGetQueueParamCallback(
 {
     PPORTS_DEVICE pContext = CONTAINING_RECORD(pVDevice, PORTS_DEVICE, VDevice);
 
-    pQueueParam->bEnableInterruptSuppression = false;
     if (uQueueIndex == 2 || uQueueIndex == 3) {
         // control queues
         pQueueParam->Interrupt = pContext->WdfInterrupt;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -534,9 +534,7 @@ VirtIoPassiveInitializeRoutine (
 
 static BOOLEAN InitializeVirtualQueues(PADAPTER_EXTENSION adaptExt)
 {
-    ULONG index;
     NTSTATUS status;
-    BOOLEAN useEventIndex = CHECKBIT(adaptExt->features, VIRTIO_RING_F_EVENT_IDX);
     ULONG numQueues = adaptExt->num_queues;
 
     RhelDbgPrint(TRACE_LEVEL_FATAL, ("InitializeVirtualQueues numQueues %d\n", numQueues));
@@ -549,11 +547,6 @@ static BOOLEAN InitializeVirtualQueues(PADAPTER_EXTENSION adaptExt)
         return FALSE;
     }
 
-    for (index = 0; index < numQueues; index++) {
-        virtio_set_queue_event_suppression(
-            adaptExt->vq[index],
-            useEventIndex);
-    }
     return TRUE;
 }
 


### PR DESCRIPTION
There's no point in telling VirtioLib about the event suppression setting using  virtio_set_queue_event_suppression() or the bEnableInterruptSuppression field. VirtioLib can detect the presence of the VIRTIO_RING_F_EVENT_IDX feature (as acked by the driver) internally.

This series removes the API and all its uses, which simplifies all drivers.