### PR TITLE
viostor, vioscsi: Ack the VIRTIO_RING_F_INDIRECT_DESC feature

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -619,6 +619,9 @@ ENTER_FN();
     if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_EVENT_IDX)) {
         guestFeatures |= (1ULL << VIRTIO_RING_F_EVENT_IDX);
     }
+    if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_INDIRECT_DESC)) {
+        guestFeatures |= (1ULL << VIRTIO_RING_F_INDIRECT_DESC);
+    }
     if (CHECKBIT(adaptExt->features, VIRTIO_SCSI_F_CHANGE)) {
         guestFeatures |= (1ULL << VIRTIO_SCSI_F_CHANGE);
     }

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -106,8 +106,6 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_SCSI_S_HEAD                     2
 #define VIRTIO_SCSI_S_ACA                      3
 
-#define VIRTIO_RING_F_INDIRECT_DESC            28
-
 #define VIRTIO_SCSI_CONTROL_QUEUE              0
 #define VIRTIO_SCSI_EVENTS_QUEUE               1
 #define VIRTIO_SCSI_REQUEST_QUEUE_0            2

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -587,6 +587,10 @@ VirtIoHwInitialize(
         guestFeatures |= (1ULL << VIRTIO_RING_F_EVENT_IDX);
     }
 
+    if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_INDIRECT_DESC)) {
+        guestFeatures |= (1ULL << VIRTIO_RING_F_INDIRECT_DESC);
+    }
+
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH)) {
         guestFeatures |= (1ULL << VIRTIO_BLK_F_FLUSH);
     }

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -76,8 +76,6 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 
 #define VIRTIO_BLK_MSIX_CONFIG_VECTOR   0
 
-#define VIRTIO_RING_F_INDIRECT_DESC     28
-
 #define BLOCK_SERIAL_STRLEN     20
 
 #define MAX_PHYS_SEGMENTS       64


### PR DESCRIPTION
The drivers were using indirect virtqueue buffers if the feature was offered by the device but they never acked it which is a spec violation.

The VIRTIO_RING_F_INDIRECT_DESC macro is already defined in virtio_ring.h, the commits also delete extra copies.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>