### PR TITLE
NetKVM: Use Ndis DPC level spinlock functions

### DIFF
--- a/NetKVM/Common/ParaNdis-AbstractPath.h
+++ b/NetKVM/Common/ParaNdis-AbstractPath.h
@@ -80,7 +80,7 @@ public:
 
     void Shutdown()
     {
-        TSpinLocker LockedContext(m_Lock);
+        TPassiveSpinLocker LockedContext(m_Lock);
         m_VirtQueue.Shutdown();
     }
 

--- a/NetKVM/Common/ParaNdis-RX.cpp
+++ b/NetKVM/Common/ParaNdis-RX.cpp
@@ -203,7 +203,7 @@ VOID CParaNdisRX::ProcessRxRing(CCHAR nCurrCpuReceiveQueue)
     UNREFERENCED_PARAMETER(nCurrCpuReceiveQueue);
 #endif
 
-    CLockedContext<CNdisSpinLock> autoLock(m_Lock);
+    TDPCSpinLocker autoLock(m_Lock);
 
     while (NULL != (pBufferDescriptor = (pRxNetDescriptor)m_VirtQueue.GetBuf(&nFullLength)))
     {
@@ -216,6 +216,7 @@ VOID CParaNdisRX::ProcessRxRing(CCHAR nCurrCpuReceiveQueue)
 #if PARANDIS_SUPPORT_RSS
             &m_Context->RSSParameters,
 #endif
+
             &pBufferDescriptor->PacketInfo,
             pBufferDescriptor->PhysicalPages[PARANDIS_FIRST_RX_DATA_PAGE].Virtual,
             nFullLength - m_Context->nVirtioHeaderSize);
@@ -262,7 +263,7 @@ VOID CParaNdisRX::ProcessRxRing(CCHAR nCurrCpuReceiveQueue)
 void CParaNdisRX::PopulateQueue()
 {
     LIST_ENTRY TempList;
-    CLockedContext<CNdisSpinLock> autoLock(m_Lock);
+    TPassiveSpinLocker autoLock(m_Lock);
 
 
     InitializeListHead(&TempList);

--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -17,7 +17,7 @@ public:
 
     void ReuseReceiveBuffer(pRxNetDescriptor pBuffersDescriptor)
     {
-        CLockedContext<CNdisSpinLock> autoLock(m_Lock);
+        TPassiveSpinLocker autoLock(m_Lock);
 
         ReuseReceiveBufferNoLock(pBuffersDescriptor);
     }
@@ -28,7 +28,7 @@ public:
 
     void Shutdown()
     {
-        CLockedContext<CNdisSpinLock> autoLock(m_Lock);
+        TPassiveSpinLocker autoLock(m_Lock);
 
         m_VirtQueue.Shutdown();
         m_Reinsert = false;

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -78,7 +78,7 @@ public:
 private:
     void CompleteStopping()
     {
-        TSpinLocker lock(m_CompleteStoppingLock);
+        TPassiveSpinLocker lock(m_CompleteStoppingLock);
         if (m_State == FlowState::Stopping)
         {
             m_State = FlowState::Stopped;

--- a/NetKVM/Common/ParaNdis-TX.cpp
+++ b/NetKVM/Common/ParaNdis-TX.cpp
@@ -266,7 +266,7 @@ void CNBL::OnLastReferenceGone()
 CParaNdisTX::~CParaNdisTX()
 {
 
-    TSpinLocker LockedContext(m_Lock);
+    TPassiveSpinLocker LockedContext(m_Lock);
     CNBL* NBL = nullptr;
 
     NBL = m_SendQueue.Dequeue();
@@ -393,7 +393,7 @@ void CParaNdisTX::NBLMappingDone(CNBL *NBLHolder)
     {
         if (!m_SendQueueFullListIsEmpty || !m_SendQueue.Enqueue(NBLHolder))
         {
-            TSpinLocker LockedContext(m_SendQueueFullListLock);
+            TDPCSpinLocker LockedContext(m_SendQueueFullListLock);
             m_SendQueueFullList.PushBack(NBLHolder);
             InterlockedExchange(&m_SendQueueFullListIsEmpty, m_SendQueueFullList.IsEmpty());
         }
@@ -464,7 +464,7 @@ PNET_BUFFER_LIST CParaNdisTX::ProcessWaitingList(CRawCNBLList& completed)
 
     // locked part under waiting list lock
     {
-        TSpinLocker LockedContext(m_WaitingListLock);
+        TDPCSpinLocker LockedContext(m_WaitingListLock);
 
         completed.ForEachDetachedIf([](CNBL* NBL) { return !NBL->IsSendDone(); },
             [&](CNBL* NBL)
@@ -502,7 +502,7 @@ PNET_BUFFER_LIST CParaNdisTX::ProcessWaitingList(CRawCNBLList& completed)
 PNET_BUFFER_LIST CParaNdisTX::BuildCancelList(PVOID CancelId)
 {
     PNET_BUFFER_LIST CanceledNBLs = nullptr;
-    TSpinLocker LockedContext(m_Lock);
+    TPassiveSpinLocker LockedContext(m_Lock);
     CNBL* NBL = nullptr;
 
     NBL = PopMappedNBL();
@@ -627,7 +627,7 @@ bool CParaNdisTX::FillQueue()
 
     if (!m_SendQueueFullListIsEmpty)
     {
-        TSpinLocker LockedContext(m_SendQueueFullListLock);
+        TDPCSpinLocker LockedContext(m_SendQueueFullListLock);
         do
         {
             nbl = m_SendQueueFullList.Pop();

--- a/NetKVM/Common/ParaNdis-TX.h
+++ b/NetKVM/Common/ParaNdis-TX.h
@@ -218,7 +218,7 @@ public:
     template <typename TFunctor>
     void DoWithTXLock(TFunctor Functor)
     {
-        TSpinLocker LockedContext(m_Lock);
+        TDPCSpinLocker LockedContext(m_Lock);
         Functor();
     }
 


### PR DESCRIPTION
The NdisDprAcquireSpinLock and NdisDprReleaseSpinLock are an optimized
version of the Ndis Acquire and Release functions that should be called
only at Dispatch level.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>