### PR TITLE
virtiolib: Don't read vring avail flags

### DIFF
--- a/VirtIO/VirtIORing.c
+++ b/VirtIO/VirtIORing.c
@@ -219,7 +219,7 @@ bool virtqueue_enable_cb(struct virtqueue *vq)
         vq->master_vring_avail.flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
         if (!vq->vdev->event_suppression_enabled)
         {
-            vq->vring.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
+            vq->vring.avail->flags = vq->master_vring_avail.flags;
         }
     }
 
@@ -238,7 +238,7 @@ bool virtqueue_enable_cb_delayed(struct virtqueue *vq)
         vq->master_vring_avail.flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
         if (!vq->vdev->event_suppression_enabled)
         {
-            vq->vring.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
+            vq->vring.avail->flags = vq->master_vring_avail.flags;
         }
     }
 
@@ -256,7 +256,7 @@ void virtqueue_disable_cb(struct virtqueue *vq)
         vq->master_vring_avail.flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
         if (!vq->vdev->event_suppression_enabled)
         {
-            vq->vring.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+            vq->vring.avail->flags = vq->master_vring_avail.flags;
         }
     }
 }


### PR DESCRIPTION
A small tweak to VirtioLib to make the available ring flags write-
only, as originally intended.

Fixes:
  commit 71405a229ef98ddcb7937953b063dfd163bfaea1
  Author: Ladi Prosek <lprosek@redhat.com>
  Date:   Tue Aug 1 08:51:58 2017 +0200

      virtiolib: Rewrite VirtIORing.c

Signed-off-by: Ladi Prosek <lprosek@redhat.com>