### PR TITLE
vioinput: Reset device before detaching unused buffers

### DIFF
--- a/vioinput/sys/Device.c
+++ b/vioinput/sys/Device.c
@@ -570,6 +570,10 @@ VIOInputEvtDeviceD0Exit(
 
     PAGED_CODE();
 
+    // reset the device to make sure it's not processing the event queue anymore
+    virtio_device_reset(&pContext->VDevice.VIODevice);
+
+    // now with the queue stopped, free the buffers we've pushed to it
     if (pContext->EventQ)
     {
         while (buf = (PVIRTIO_INPUT_EVENT)virtqueue_detach_unused_buf(pContext->EventQ))


### PR DESCRIPTION
The virtio-input driver has the same bug as virtio-serial, see
https://bugzilla.redhat.com/show_bug.cgi?id=1520352.

It's much harder to hit it with virtio-input because of its much lower
data rate and, to a smaller extend, also a smaller number of "receive"
buffers that can be pushed on the event queue (64 vs. 128 in virtio-
serial).

The fix here is simply to reset the device before touching the event
queue with virtqueue_detach_unused_buf() so it doesn't race with the
device processing it. With virtio 1.0, the reset is synchronous (the
driver waits for the reset to be acknowledged by the device) and
virtio-input is exposed as a virtio 1.0-only device.

Long-term it may be nicer to eliminate the virtqueue_detach_unused_buf()
API altogether and have the drivers track what's been pushed with a
simple linked list or similar.

Signed-off-by: Ladi Prosek <lprosek@redhat.com>