### PR TITLE
pvpanic, vioinput, viorng, virtiolib, netkvm: Static analysis fixes and tweaks

### DIFF
--- a/NetKVM/CoInstaller/NetKVMnetsh.cpp
+++ b/NetKVM/CoInstaller/NetKVMnetsh.cpp
@@ -59,10 +59,11 @@ static bool _NetKVMGetDeviceClassGuids(vector<GUID>& GUIDs)
             NETCO_DEBUG_PRINT(TEXT("SetupDiClassGuidsFromNameEx failed with code ") << dwErr);
             return false;
         }
+
+        GUIDs.insert(GUIDs.end(), &pguidDevClassPtr[0], &pguidDevClassPtr[dwNumGuids]);
+        delete[] pguidDevClassPtr;
     }
 
-    GUIDs.insert(GUIDs.end(), &pguidDevClassPtr[0], &pguidDevClassPtr[dwNumGuids]);
-    delete [] pguidDevClassPtr;
     return true;
 }
 

--- a/VirtIO/WDF/PCI.c
+++ b/VirtIO/WDF/PCI.c
@@ -41,7 +41,7 @@ NTSTATUS PCIAllocBars(WDFCMRESLIST ResourcesTranslated,
     int nListSize = WdfCmResourceListGetCount(ResourcesTranslated);
     int i;
     PVIRTIO_WDF_BAR pBar;
-    PCI_COMMON_HEADER PCIHeader;
+    PCI_COMMON_HEADER PCIHeader = { 0 };
 
     /* read the PCI config header */
     if (pWdfDriver->PCIBus.GetBusData(

--- a/pvpanic/pvpanic/power.c
+++ b/pvpanic/pvpanic/power.c
@@ -69,8 +69,13 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
 
                 if (context->MappedPort)
                 {
+#if defined(NTDDI_WINTHRESHOLD) && (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
+                    context->IoBaseAddress = MmMapIoSpaceEx(desc->u.Port.Start,
+                        desc->u.Port.Length, PAGE_READWRITE | PAGE_NOCACHE);
+#else
                     context->IoBaseAddress = MmMapIoSpace(desc->u.Port.Start,
                         desc->u.Port.Length, MmNonCached);
+#endif
                 }
                 else
                 {

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -34,7 +34,6 @@
 #pragma alloc_text(INIT, DriverEntry)
 #pragma alloc_text(PAGE, PVPanicEvtDeviceAdd)
 #pragma alloc_text(PAGE, PVPanicEvtDriverContextCleanup)
-#pragma alloc_text(PAGE, PVPanicEvtQueueDeviceControl)
 #endif
 
 NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject,
@@ -163,7 +162,7 @@ VOID PVPanicEvtDriverContextCleanup(IN WDFOBJECT DriverObject)
     PAGED_CODE();
 
     // Stop WPP tracing.
-    WPP_CLEANUP(WdfDriverWdmGetDriverObject(DriverObject));
+    WPP_CLEANUP(WdfDriverWdmGetDriverObject((WDFDRIVER)DriverObject));
 }
 
 VOID PVPanicEvtDeviceFileCreate(IN WDFDEVICE Device,
@@ -186,8 +185,6 @@ VOID PVPanicEvtQueueDeviceControl(IN WDFQUEUE Queue,
     ULONG    length = 0;
     PVOID    buffer;
     size_t   buffer_length;
-
-    PAGED_CODE();
 
     UNREFERENCED_PARAMETER(Queue);
     UNREFERENCED_PARAMETER(InputBufferLength);

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -64,6 +64,10 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 // Referenced in MSDN but not declared in SDK/WDK headers.
 #define DUMP_TYPE_FULL 1
 
+#ifndef _IRQL_requires_
+#define _IRQL_requires_(level)
+#endif
+
 //
 // Bug check callback registration functions.
 //
@@ -77,7 +81,11 @@ BOOLEAN PVPanicDeregisterBugCheckCallback();
 
 DRIVER_INITIALIZE DriverEntry;
 EVT_WDF_DRIVER_DEVICE_ADD PVPanicEvtDeviceAdd;
-EVT_WDF_OBJECT_CONTEXT_CLEANUP PVPanicEvtDriverContextCleanup;
+
+// Context cleanup callbacks generally run at IRQL <= DISPATCH_LEVEL but
+// WDFDRIVER context cleanup is guaranteed to run at PASSIVE_LEVEL.
+// Annotate the prototype to make static analysis happy.
+EVT_WDF_OBJECT_CONTEXT_CLEANUP _IRQL_requires_(PASSIVE_LEVEL) PVPanicEvtDriverContextCleanup;
 
 EVT_WDF_DEVICE_PREPARE_HARDWARE PVPanicEvtDevicePrepareHardware;
 EVT_WDF_DEVICE_RELEASE_HARDWARE PVPanicEvtDeviceReleaseHardware;

--- a/vioinput/hidpassthrough/hidpassthrough.c
+++ b/vioinput/hidpassthrough/hidpassthrough.c
@@ -79,6 +79,7 @@ HidPassthroughDispatchPower(_In_    PDEVICE_OBJECT  DeviceObject,
     return PoCallDriver(ext->NextDeviceObject, Irp);
 }
 
+_Dispatch_type_(IRP_MJ_INTERNAL_DEVICE_CONTROL)
 static NTSTATUS
 HidPassthroughDispatchIoctl(_In_    PDEVICE_OBJECT  DeviceObject,
                             _Inout_ PIRP            Irp)

--- a/vioinput/sys/Device.c
+++ b/vioinput/sys/Device.c
@@ -283,6 +283,8 @@ VIOInputCreateChildPdo(
     DECLARE_CONST_UNICODE_STRING(deviceId, L"VIOINPUT\\REV_01");
     DECLARE_UNICODE_STRING_SIZE(buffer, 32);
 
+    PAGED_CODE();
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "--> %s\n", __FUNCTION__);
 
     pDeviceInit = WdfPdoInitAllocate(hDevice);

--- a/vioinput/sys/Driver.c
+++ b/vioinput/sys/Driver.c
@@ -35,7 +35,11 @@
 #endif
 
 DRIVER_INITIALIZE DriverEntry;
-EVT_WDF_OBJECT_CONTEXT_CLEANUP VIOInputEvtDriverContextCleanup;
+
+// Context cleanup callbacks generally run at IRQL <= DISPATCH_LEVEL but
+// WDFDRIVER context cleanup is guaranteed to run at PASSIVE_LEVEL.
+// Annotate the prototype to make static analysis happy.
+EVT_WDF_OBJECT_CONTEXT_CLEANUP _IRQL_requires_(PASSIVE_LEVEL) VIOInputEvtDriverContextCleanup;
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (INIT, DriverEntry)
@@ -86,11 +90,11 @@ DriverEntry(
 
 VOID
 VIOInputEvtDriverContextCleanup(
-    IN WDFDRIVER Driver)
+    IN WDFOBJECT Driver)
 {
     PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<--> %s\n", __FUNCTION__);
 
-    WPP_CLEANUP(WdfDriverWdmGetDriverObject(Driver));
+    WPP_CLEANUP(WdfDriverWdmGetDriverObject((WDFDRIVER)Driver));
 }

--- a/vioinput/sys/HidKeyboard.c
+++ b/vioinput/sys/HidKeyboard.c
@@ -159,7 +159,10 @@ HIDKeyboardEventKeyToReportKey(
         else if (pKeyboardDesc->nKeysPressed == HID_KEYBOARD_KEY_SLOTS + 1)
         {
             // we just got into the "rolled over" state
-            RtlFillMemory(pKeyArray, HID_USAGE_KEYBOARD_ROLLOVER, HID_KEYBOARD_KEY_SLOTS);
+#pragma warning (push)
+#pragma warning (disable:28625) // C28625 heuristic triggered by "key" in the variable name
+            RtlFillMemory(pKeyArray, HID_KEYBOARD_KEY_SLOTS, HID_USAGE_KEYBOARD_ROLLOVER);
+#pragma warning (pop)
         }
     }
     else if (bReleased)

--- a/vioinput/sys/KeyMap.c
+++ b/vioinput/sys/KeyMap.c
@@ -655,7 +655,7 @@ ULONG
 HIDKeyboardEventCodeToUsageCode(
     USHORT uEventCode)
 {
-    if (uEventCode < sizeof(ReportCodeToUsageCodeTable))
+    if (uEventCode < (sizeof(ReportCodeToUsageCodeTable) / sizeof(ReportCodeToUsageCodeTable[0])))
     {
         return ReportCodeToUsageCodeTable[uEventCode];
     }

--- a/viorng/viorng/viorng.h
+++ b/viorng/viorng/viorng.h
@@ -72,6 +72,10 @@ typedef struct _DEVICE_CONTEXT {
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 
+#ifndef _IRQL_requires_
+#define _IRQL_requires_(level)
+#endif
+
 //
 // WDFDRIVER Events
 //
@@ -79,7 +83,11 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 DRIVER_INITIALIZE DriverEntry;
 EVT_WDF_DRIVER_DEVICE_ADD VirtRngEvtDeviceAdd;
 EVT_WDF_OBJECT_CONTEXT_CLEANUP VirtRngEvtDeviceContextCleanup;
-EVT_WDF_OBJECT_CONTEXT_CLEANUP VirtRngEvtDriverContextCleanup;
+
+// Context cleanup callbacks generally run at IRQL <= DISPATCH_LEVEL but
+// WDFDRIVER context cleanup is guaranteed to run at PASSIVE_LEVEL.
+// Annotate the prototype to make static analysis happy.
+EVT_WDF_OBJECT_CONTEXT_CLEANUP _IRQL_requires_(PASSIVE_LEVEL) VirtRngEvtDriverContextCleanup;
 
 EVT_WDF_DEVICE_PREPARE_HARDWARE VirtRngEvtDevicePrepareHardware;
 EVT_WDF_DEVICE_RELEASE_HARDWARE VirtRngEvtDeviceReleaseHardware;


### PR DESCRIPTION
Fixes an assortment of issues found by running the static analysis build.

It uncovered two bugs in vioinput and several places where we allocated executable memory. The rest is mostly tweaks.

With this and the other two static analysis pull requests all included, the remaining list of issues is small and mostly non-actionable:

```
     1>c:\program files (x86)\windows kits\10\include\10.0.10240.0\ucrt\string.h(130): warning C28252: Inconsistent annotation for 'strcpy': _Param_(1) has 'SAL_writableTo(elementCount(_String_length_(__formal(1,parameter1))+1))' on the prior instance. See <no file>(0). 
     1>c:\program files (x86)\windows kits\10\include\10.0.10240.0\ucrt\string.h(130): warning C28253: Inconsistent annotation for 'strcpy': _Param_(1) has 'SAL_writableTo(elementCount(_String_length_(_Source)+1))' on this instance. See <no file>(0). 
     1>c:\kvm-guest-drivers-windows\viorng\coinstaller\viorngci.c(124): warning C6387: '_Param_(2)' could be '0':  this does not adhere to the specification for the function 'BCryptAddContextFunctionProvider'. 
     1>c:\kvm-guest-drivers-windows\viorng\coinstaller\viorngci.c(144): warning C6387: '_Param_(2)' could be '0':  this does not adhere to the specification for the function 'BCryptRemoveContextFunctionProvider'. 

     1>c:\program files (x86)\windows kits\10\include\10.0.10240.0\ucrt\string.h(130): warning C28252: Inconsistent annotation for 'strcpy': _Param_(1) has 'SAL_writableTo(elementCount(_String_length_(__formal(1,parameter1))+1))' on the prior instance. See <no file>(0). 
     1>c:\program files (x86)\windows kits\10\include\10.0.10240.0\ucrt\string.h(130): warning C28253: Inconsistent annotation for 'strcpy': _Param_(1) has 'SAL_writableTo(elementCount(_String_length_(_Source)+1))' on this instance. See <no file>(0). 
     1>c:\kvm-guest-drivers-windows\viorng\cng\um\viorngum.c(85): warning C28251: Inconsistent annotation for 'GetRngInterface': this instance has no annotations. See c:\program files (x86)\windows kits\8.0\cryptographic provider development kit\include\bcrypt_provider.h(491). 

     1>c:\kvm-guest-drivers-windows\pvpanic\pvpanic\pvpanic.tmh(2779): warning C28182: Dereferencing NULL pointer. 'TraceCb' contains the same NULL value as 'CallbackContext' did. 
     1>c:\kvm-guest-drivers-windows\pvpanic\pvpanic\pvpanic.tmh(2904): warning C6387: 'DevObject' could be '0':  this does not adhere to the specification for the function 'WdfDriverRegisterTraceInfo'. 
     1>c:\kvm-guest-drivers-windows\pvpanic\pvpanic\pvpanic.tmh(3038): warning C28118: The current function is permitted to run at an IRQ level above the maximum permitted for '__PREfastPagedCode' (1). Prior function calls or annotation are inconsistent with use of that function:  The current function may need _IRQL_requires_max_, or it may be that the limit is set by some prior call. Maximum legal IRQL was last set to 2 at line 3030.

     1>c:\kvm-guest-drivers-windows\viorng\viorng\viorng.tmh(2848): warning C28182: Dereferencing NULL pointer. 'TraceCb' contains the same NULL value as 'CallbackContext' did. 
     1>c:\kvm-guest-drivers-windows\viorng\viorng\viorng.tmh(2973): warning C6387: 'DevObject' could be '0':  this does not adhere to the specification for the function 'WdfDriverRegisterTraceInfo'. 
     1>c:\kvm-guest-drivers-windows\viorng\viorng\viorng.tmh(3107): warning C28118: The current function is permitted to run at an IRQ level above the maximum permitted for '__PREfastPagedCode' (1). Prior function calls or annotation are inconsistent with use of that function:  The current function may need _IRQL_requires_max_, or it may be that the limit is set by some prior call. Maximum legal IRQL was last set to 2 at line 3099.

     1>c:\kvm-guest-drivers-windows\balloon\app\device.cpp(190): warning C6258: Using TerminateThread does not allow proper thread clean up.
     1>c:\kvm-guest-drivers-windows\balloon\app\utils.cpp(178): warning C28159: Consider using 'GetTickCount64' instead of 'GetTickCount'. Reason: GetTickCount overflows roughly every 49 days.  Code that does not take that into account can loop indefinitely.  GetTickCount64 operates on 64 bit values and does not have that problem
     1>c:\kvm-guest-drivers-windows\balloon\app\utils.cpp(197): warning C28159: Consider using 'GetTickCount64' instead of 'GetTickCount'. Reason: GetTickCount overflows roughly every 49 days.  Code that does not take that into account can loop indefinitely.  GetTickCount64 operates on 64 bit values and does not have that problem
     1>c:\kvm-guest-drivers-windows\balloon\app\utils.cpp(200): warning C28159: Consider using 'GetTickCount64' instead of 'GetTickCount'. Reason: GetTickCount overflows roughly every 49 days.  Code that does not take that into account can loop indefinitely.  GetTickCount64 operates on 64 bit values and does not have that problem

17>C:\kvm-guest-drivers-windows\viorng\viorng\viorng.inf(98-98): warning 1304: Found legacy AddReg operation defining co-installers (CoInstallers32).

```