### PR TITLE
Cleanup of IVSHMEM and add ability to specify cache type

### DIFF
--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -87,17 +87,17 @@ NTSTATUS IVSHMEMEvtDevicePrepareHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
             ++deviceContext->interruptCount;
     }
 
-	if (deviceContext->interruptCount > 0)
-	{
-		deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolWithTag(NonPagedPool,
-			sizeof(WDFINTERRUPT) * deviceContext->interruptCount, 'sQRI');
+	  if (deviceContext->interruptCount > 0)
+	  {
+		  deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolWithTag(NonPagedPool,
+			  sizeof(WDFINTERRUPT) * deviceContext->interruptCount, 'sQRI');
 
-		if (!deviceContext->interrupts)
-		{
-			DEBUG_ERROR("Failed to allocate space for %d interrupts", deviceContext->interrupts);
-			return STATUS_INSUFFICIENT_RESOURCES;
-		}
-	}
+		  if (!deviceContext->interrupts)
+		  {
+			  DEBUG_ERROR("Failed to allocate space for %d interrupts", deviceContext->interrupts);
+			  return STATUS_INSUFFICIENT_RESOURCES;
+		  }
+	  }
 
     for (ULONG i = 0; i < resCount; ++i)
     {

--- a/ivshmem/Public.h
+++ b/ivshmem/Public.h
@@ -7,6 +7,19 @@ DEFINE_GUID (GUID_DEVINTERFACE_IVSHMEM,
 typedef UINT16 IVSHMEM_PEERID;
 typedef UINT64 IVSHMEM_SIZE;
 
+#define IVSHMEM_CACHE_NONCACHED     0
+#define IVSHMEM_CACHE_CACHED        1
+#define IVSHMEM_CACHE_WRITECOMBINED 2
+
+/*
+    This structure is for use with the IOCTL_IVSHMEM_REQUEST_MMAP IOCTL
+*/
+typedef struct IVSHMEM_MMAP_CONFIG
+{
+    UINT8 cacheMode; // the caching mode of the mapping, see IVSHMEM_CACHE_* for options
+}
+IVSHMEM_MMAP_CONFIG, *PIVSHMEM_MMAP_CONFIG;
+
 /*
     This structure is for use with the IOCTL_IVSHMEM_REQUEST_MMAP IOCTL
 */

--- a/ivshmem/Queue.c
+++ b/ivshmem/Queue.c
@@ -18,45 +18,45 @@ IVSHMEM_MMAP32, *PIVSHMEM_MMAP32;
 
 // Forwards
 static NTSTATUS ioctl_request_peerid(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 static NTSTATUS ioctl_request_size(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 static NTSTATUS ioctl_request_mmap(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 static NTSTATUS ioctl_release_mmap(
-  const PDEVICE_CONTEXT DeviceContext,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 static NTSTATUS ioctl_ring_doorbell(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 static NTSTATUS ioctl_register_event(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 );
 
 NTSTATUS IVSHMEMQueueInitialize(_In_ WDFDEVICE Device)
@@ -100,28 +100,28 @@ IVSHMEMEvtIoDeviceControl(
     switch (IoControlCode)
     {
         case IOCTL_IVSHMEM_REQUEST_PEERID:
-          status = ioctl_request_peerid(deviceContext, OutputBufferLength, Request, &bytesReturned);
-          break;
-
+            status = ioctl_request_peerid(deviceContext, OutputBufferLength, Request, &bytesReturned);
+            break;
+  
         case IOCTL_IVSHMEM_REQUEST_SIZE:
-          status = ioctl_request_size(deviceContext, OutputBufferLength, Request, &bytesReturned);
-          break;
+            status = ioctl_request_size(deviceContext, OutputBufferLength, Request, &bytesReturned);
+            break;
 
         case IOCTL_IVSHMEM_REQUEST_MMAP:
-          status = ioctl_request_mmap(deviceContext, InputBufferLength, OutputBufferLength, Request, &bytesReturned);
-          break;
+            status = ioctl_request_mmap(deviceContext, InputBufferLength, OutputBufferLength, Request, &bytesReturned);
+            break;
 
         case IOCTL_IVSHMEM_RELEASE_MMAP:
-          status = ioctl_release_mmap(deviceContext, Request, &bytesReturned);
-          break;
+            status = ioctl_release_mmap(deviceContext, Request, &bytesReturned);
+            break;
 
         case IOCTL_IVSHMEM_RING_DOORBELL:
-          status = ioctl_ring_doorbell(deviceContext, InputBufferLength, Request, &bytesReturned);
-          break;
+            status = ioctl_ring_doorbell(deviceContext, InputBufferLength, Request, &bytesReturned);
+            break;
 
         case IOCTL_IVSHMEM_REGISTER_EVENT:
-          status = ioctl_register_event(deviceContext, InputBufferLength, Request, &bytesReturned);
-          break;
+            status = ioctl_register_event(deviceContext, InputBufferLength, Request, &bytesReturned);
+            break;
     }
 
     WdfRequestCompleteWithInformation(Request, status, bytesReturned);
@@ -134,8 +134,8 @@ IVSHMEMEvtIoStop(
     _In_ ULONG ActionFlags
 )
 {
-	UNREFERENCED_PARAMETER(Queue);
-	UNREFERENCED_PARAMETER(ActionFlags);
+    UNREFERENCED_PARAMETER(Queue);
+    UNREFERENCED_PARAMETER(ActionFlags);
     WdfRequestStopAcknowledge(Request, TRUE);
     return;
 }
@@ -181,315 +181,315 @@ VOID IVSHMEMEvtDeviceFileCleanup(_In_ WDFFILEOBJECT FileObject)
 }
 
 static NTSTATUS ioctl_request_peerid(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  if (OutputBufferLength != sizeof(IVSHMEM_PEERID))
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_PEERID: Invalid size, expected %u but got %u", sizeof(IVSHMEM_PEERID), OutputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  IVSHMEM_PEERID *out = NULL;
-  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_PEERID: Failed to retrieve the output buffer");
-    return STATUS_INVALID_USER_BUFFER;
-  }
-
-  *out           = (IVSHMEM_PEERID)DeviceContext->devRegisters->ivProvision;
-  *BytesReturned = sizeof(IVSHMEM_PEERID);
-  return STATUS_SUCCESS;
+    if (OutputBufferLength != sizeof(IVSHMEM_PEERID))
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_PEERID: Invalid size, expected %u but got %u", sizeof(IVSHMEM_PEERID), OutputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    IVSHMEM_PEERID *out = NULL;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_PEERID: Failed to retrieve the output buffer");
+        return STATUS_INVALID_USER_BUFFER;
+    }
+  
+    *out           = (IVSHMEM_PEERID)DeviceContext->devRegisters->ivProvision;
+    *BytesReturned = sizeof(IVSHMEM_PEERID);
+    return STATUS_SUCCESS;
 }
 
 static NTSTATUS ioctl_request_size(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  if (OutputBufferLength != sizeof(IVSHMEM_SIZE))
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_SIZE: Invalid size, expected %u but got %u", sizeof(IVSHMEM_SIZE), OutputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  IVSHMEM_SIZE *out = NULL;
-  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_SIZE: Failed to retrieve the output buffer");
-    return STATUS_INVALID_USER_BUFFER;
-  }
-
-  *out           = DeviceContext->shmemAddr.NumberOfBytes;
-  *BytesReturned = sizeof(IVSHMEM_SIZE);
-  return STATUS_SUCCESS;
+    if (OutputBufferLength != sizeof(IVSHMEM_SIZE))
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_SIZE: Invalid size, expected %u but got %u", sizeof(IVSHMEM_SIZE), OutputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    IVSHMEM_SIZE *out = NULL;
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_SIZE: Failed to retrieve the output buffer");
+        return STATUS_INVALID_USER_BUFFER;
+    }
+  
+    *out           = DeviceContext->shmemAddr.NumberOfBytes;
+    *BytesReturned = sizeof(IVSHMEM_SIZE);
+    return STATUS_SUCCESS;
 }
 
 static NTSTATUS ioctl_request_mmap(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const size_t          OutputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const size_t          OutputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  // only one mapping at a time is allowed
-  if (DeviceContext->shmemMap)
-    return STATUS_DEVICE_ALREADY_ATTACHED;
-
-  if (InputBufferLength != sizeof(IVSHMEM_MMAP_CONFIG))
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_MMAP: Invalid input size, expected %u but got %u", sizeof(IVSHMEM_MMAP_CONFIG), InputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  PIVSHMEM_MMAP_CONFIG in;
-  if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_MMAP: Failed to retrieve the input buffer");
-    return STATUS_INVALID_USER_BUFFER;
-  }
-
-  MEMORY_CACHING_TYPE cacheType;
-  switch (in->cacheMode)
-  {
-    case IVSHMEM_CACHE_NONCACHED    : cacheType = MmNonCached    ; break;
-    case IVSHMEM_CACHE_CACHED       : cacheType = MmCached       ; break;
-    case IVSHMEM_CACHE_WRITECOMBINED: cacheType = MmWriteCombined; break;
-    default:
-      DEBUG_ERROR("IOCTL_IVSHMEM_MMAP: Invalid cache mode: %u", in->cacheMode);
-      return STATUS_INVALID_PARAMETER;
-  }
-
-#ifdef _WIN64
-  PIRP  irp = WdfRequestWdmGetIrp(Request);
-  const BOOLEAN is32Bit = IoIs32bitProcess(irp);
-  const size_t  bufferLen = is32Bit ? sizeof(IVSHMEM_MMAP32) : sizeof(IVSHMEM_MMAP);
-#else
-  const size_t  bufferLen = sizeof(IVSHMEM_MMAP);
-#endif
-  PVOID buffer;
-
-  if (OutputBufferLength != bufferLen)
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_MMAP: Invalid size, expected %u but got %u", bufferLen, OutputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, bufferLen, (PVOID *)&buffer, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Failed to retrieve the output buffer");
-    return STATUS_INVALID_USER_BUFFER;
-  }
-
-  __try
-  {
-    DeviceContext->shmemMap = MmMapLockedPagesSpecifyCache(
-      DeviceContext->shmemMDL,
-      UserMode,
-      cacheType,
-      NULL,
-      FALSE,
-      NormalPagePriority | MdlMappingNoExecute
-    );
-  }
-  __except (EXCEPTION_EXECUTE_HANDLER)
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Exception trying to map pages");
-    return STATUS_DRIVER_INTERNAL_ERROR;
-  }
-
-  if (!DeviceContext->shmemMap)
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: shmemMap is NULL");
-    return STATUS_DRIVER_INTERNAL_ERROR;
-  }
-
-  DeviceContext->owner = WdfRequestGetFileObject(Request);
-#ifdef _WIN64
-  if (is32Bit)
-  {
-    PIVSHMEM_MMAP32 out = (PIVSHMEM_MMAP32)buffer;
-    out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
-    out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
-    out->ptr     = PtrToUint(DeviceContext->shmemMap);
-    out->vectors = DeviceContext->interruptsUsed;
-  }
-  else
-#endif
-  {
-    PIVSHMEM_MMAP out = (PIVSHMEM_MMAP)buffer;
-    out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
-    out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
-    out->ptr     = DeviceContext->shmemMap;
-    out->vectors = DeviceContext->interruptsUsed;
-  }
+    // only one mapping at a time is allowed
+    if (DeviceContext->shmemMap)
+        return STATUS_DEVICE_ALREADY_ATTACHED;
   
-  *BytesReturned = bufferLen;
-  return STATUS_SUCCESS;
+    if (InputBufferLength != sizeof(IVSHMEM_MMAP_CONFIG))
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_MMAP: Invalid input size, expected %u but got %u", sizeof(IVSHMEM_MMAP_CONFIG), InputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    PIVSHMEM_MMAP_CONFIG in;
+    if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_MMAP: Failed to retrieve the input buffer");
+        return STATUS_INVALID_USER_BUFFER;
+    }
+  
+    MEMORY_CACHING_TYPE cacheType;
+    switch (in->cacheMode)
+    {
+        case IVSHMEM_CACHE_NONCACHED    : cacheType = MmNonCached    ; break;
+        case IVSHMEM_CACHE_CACHED       : cacheType = MmCached       ; break;
+        case IVSHMEM_CACHE_WRITECOMBINED: cacheType = MmWriteCombined; break;
+        default:
+          DEBUG_ERROR("IOCTL_IVSHMEM_MMAP: Invalid cache mode: %u", in->cacheMode);
+          return STATUS_INVALID_PARAMETER;
+    }
+  
+  #ifdef _WIN64
+    PIRP  irp = WdfRequestWdmGetIrp(Request);
+    const BOOLEAN is32Bit = IoIs32bitProcess(irp);
+    const size_t  bufferLen = is32Bit ? sizeof(IVSHMEM_MMAP32) : sizeof(IVSHMEM_MMAP);
+  #else
+    const size_t  bufferLen = sizeof(IVSHMEM_MMAP);
+  #endif
+    PVOID buffer;
+  
+    if (OutputBufferLength != bufferLen)
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_MMAP: Invalid size, expected %u but got %u", bufferLen, OutputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, bufferLen, (PVOID *)&buffer, NULL)))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Failed to retrieve the output buffer");
+        return STATUS_INVALID_USER_BUFFER;
+    }
+  
+    __try
+    {
+        DeviceContext->shmemMap = MmMapLockedPagesSpecifyCache(
+          DeviceContext->shmemMDL,
+          UserMode,
+          cacheType,
+          NULL,
+          FALSE,
+          NormalPagePriority | MdlMappingNoExecute
+        );
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Exception trying to map pages");
+        return STATUS_DRIVER_INTERNAL_ERROR;
+    }
+  
+    if (!DeviceContext->shmemMap)
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: shmemMap is NULL");
+        return STATUS_DRIVER_INTERNAL_ERROR;
+    }
+  
+    DeviceContext->owner = WdfRequestGetFileObject(Request);
+  #ifdef _WIN64
+    if (is32Bit)
+    {
+        PIVSHMEM_MMAP32 out = (PIVSHMEM_MMAP32)buffer;
+        out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
+        out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
+        out->ptr     = PtrToUint(DeviceContext->shmemMap);
+        out->vectors = DeviceContext->interruptsUsed;
+    }
+    else
+  #endif
+    {
+        PIVSHMEM_MMAP out = (PIVSHMEM_MMAP)buffer;
+        out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
+        out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
+        out->ptr     = DeviceContext->shmemMap;
+        out->vectors = DeviceContext->interruptsUsed;
+    }
+    
+    *BytesReturned = bufferLen;
+    return STATUS_SUCCESS;
 }
 
 static NTSTATUS ioctl_release_mmap(
-  const PDEVICE_CONTEXT DeviceContext,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  // ensure the mapping exists
-  if (!DeviceContext->shmemMap)
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: not mapped");
-    return STATUS_INVALID_DEVICE_REQUEST;
-  }
-
-  // ensure someone else other then the owner doesn't attempt to release the mapping
-  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: Invalid owner");
-    return STATUS_INVALID_HANDLE;
-  }
-
-  MmUnmapLockedPages(DeviceContext->shmemMap, DeviceContext->shmemMDL);
-  DeviceContext->shmemMap = NULL;
-  DeviceContext->owner    = NULL;
-  *BytesReturned = 0;
-  return STATUS_SUCCESS;
+    // ensure the mapping exists
+    if (!DeviceContext->shmemMap)
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: not mapped");
+        return STATUS_INVALID_DEVICE_REQUEST;
+    }
+  
+    // ensure someone else other then the owner doesn't attempt to release the mapping
+    if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: Invalid owner");
+        return STATUS_INVALID_HANDLE;
+    }
+  
+    MmUnmapLockedPages(DeviceContext->shmemMap, DeviceContext->shmemMDL);
+    DeviceContext->shmemMap = NULL;
+    DeviceContext->owner    = NULL;
+    *BytesReturned = 0;
+    return STATUS_SUCCESS;
 }
 
 static NTSTATUS ioctl_ring_doorbell(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  // ensure someone else other then the owner doesn't attempt to trigger IRQs
-  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Invalid owner");
-    return STATUS_INVALID_HANDLE;
-  }
-
-  if (InputBufferLength != sizeof(IVSHMEM_RING))
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_RING_DOORBELL: Invalid size, expected %u but got %u", sizeof(IVSHMEM_RING), InputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  PIVSHMEM_RING in;
-  if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Failed to retrieve the input buffer");
-    return STATUS_INVALID_USER_BUFFER;   
-  }
-
-  WRITE_REGISTER_ULONG(
-    &DeviceContext->devRegisters->doorbell,
-    (ULONG)in->vector | ((ULONG)in->peerID << 16));
-
-  *BytesReturned = 0;
-  return STATUS_SUCCESS;
+    // ensure someone else other then the owner doesn't attempt to trigger IRQs
+    if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Invalid owner");
+        return STATUS_INVALID_HANDLE;
+    }
+  
+    if (InputBufferLength != sizeof(IVSHMEM_RING))
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_RING_DOORBELL: Invalid size, expected %u but got %u", sizeof(IVSHMEM_RING), InputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    PIVSHMEM_RING in;
+    if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Failed to retrieve the input buffer");
+        return STATUS_INVALID_USER_BUFFER;   
+    }
+  
+    WRITE_REGISTER_ULONG(
+      &DeviceContext->devRegisters->doorbell,
+      (ULONG)in->vector | ((ULONG)in->peerID << 16));
+  
+    *BytesReturned = 0;
+    return STATUS_SUCCESS;
 }
 
 static NTSTATUS ioctl_register_event(
-  const PDEVICE_CONTEXT DeviceContext,
-  const size_t          InputBufferLength,
-  const WDFREQUEST      Request,
-  size_t              * BytesReturned
+    const PDEVICE_CONTEXT DeviceContext,
+    const size_t          InputBufferLength,
+    const WDFREQUEST      Request,
+    size_t              * BytesReturned
 )
 {
-  // ensure someone else other then the owner isn't attempting to register events
-  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Invalid owner");
-    return STATUS_INVALID_HANDLE;
-  }
-
-  if (InputBufferLength != sizeof(IVSHMEM_EVENT))
-  {
-    DEBUG_ERROR("IOCTL_IVSHMEM_REGISTER_EVENT: Invalid size, expected %u but got %u", sizeof(PIVSHMEM_EVENT), InputBufferLength);
-    return STATUS_INVALID_BUFFER_SIZE;
-  }
-
-  // early non locked quick check to see if we are out of event space
-  if (DeviceContext->eventBufferUsed == MAX_EVENTS)
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
-    return STATUS_INSUFFICIENT_RESOURCES;
-  }
-
-  PIVSHMEM_EVENT in;
-  if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
-  {
-    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Failed to retrieve the input buffer");
-    return STATUS_INVALID_USER_BUFFER;
-  }
-
-  PRKEVENT hObject;
-  if (!NT_SUCCESS(ObReferenceObjectByHandle(
-    in->event,
-    SYNCHRONIZE | EVENT_MODIFY_STATE,
-    *ExEventObjectType,
-    UserMode,
-    &hObject,
-    NULL)))
-  {
-    DEBUG_ERROR("%s", "Unable to reference user-mode event object");
-    return STATUS_INVALID_HANDLE;
-  }
-
-  // clear the event in case the caller didn't think to
-  KeClearEvent(hObject);
-
-  // lock the event list so we can push the new entry into it
-  KIRQL oldIRQL;
-  KeAcquireSpinLock(&DeviceContext->eventListLock, &oldIRQL);
-  {
-    // check again if there is space before we search as we now hold the lock
+    // ensure someone else other then the owner isn't attempting to register events
+    if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+    {
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Invalid owner");
+        return STATUS_INVALID_HANDLE;
+    }
+  
+    if (InputBufferLength != sizeof(IVSHMEM_EVENT))
+    {
+        DEBUG_ERROR("IOCTL_IVSHMEM_REGISTER_EVENT: Invalid size, expected %u but got %u", sizeof(PIVSHMEM_EVENT), InputBufferLength);
+        return STATUS_INVALID_BUFFER_SIZE;
+    }
+  
+    // early non locked quick check to see if we are out of event space
     if (DeviceContext->eventBufferUsed == MAX_EVENTS)
     {
-      KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
-
-      DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
-      ObDereferenceObject(hObject);
-      return STATUS_INSUFFICIENT_RESOURCES;      
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
+        return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    // look for a free slot
-    BOOLEAN done = FALSE;
-    for (UINT16 i = 0; i < MAX_EVENTS; ++i)
+  
+    PIVSHMEM_EVENT in;
+    if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
     {
-      PIVSHMEMEventListEntry event = &DeviceContext->eventBuffer[i];
-      if (event->event != NULL)
-        continue;
-
-      // found one, assign the event to it and add it to the list
-      event->owner = WdfRequestGetFileObject(Request);
-      event->event = hObject;
-      event->vector = in->vector;
-      event->singleShot = in->singleShot;
-      ++DeviceContext->eventBufferUsed;
-      InsertTailList(&DeviceContext->eventList, &event->ListEntry);
-      done = TRUE;
-      break;
+        DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Failed to retrieve the input buffer");
+        return STATUS_INVALID_USER_BUFFER;
     }
-
-    // this should never occur, if it does it indicates memory corruption
-    if (!done)
+  
+    PRKEVENT hObject;
+    if (!NT_SUCCESS(ObReferenceObjectByHandle(
+        in->event,
+        SYNCHRONIZE | EVENT_MODIFY_STATE,
+        *ExEventObjectType,
+        UserMode,
+        &hObject,
+        NULL)))
     {
-      DEBUG_ERROR(
-        "IOCTL_IVSHMEM_REGISTER_EVENT: deviceContext->eventBufferUsed (%u) < MAX_EVENTS (%u) but no slots found!",
-        DeviceContext->eventBufferUsed, MAX_EVENTS);
-      KeBugCheckEx(CRITICAL_STRUCTURE_CORRUPTION, 0, 0, 0, 0x1C);
+        DEBUG_ERROR("%s", "Unable to reference user-mode event object");
+        return STATUS_INVALID_HANDLE;
     }
-  }
-  KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
-
-  *BytesReturned = 0;
-  return STATUS_SUCCESS;
+  
+    // clear the event in case the caller didn't think to
+    KeClearEvent(hObject);
+  
+    // lock the event list so we can push the new entry into it
+    KIRQL oldIRQL;
+    KeAcquireSpinLock(&DeviceContext->eventListLock, &oldIRQL);
+    {
+        // check again if there is space before we search as we now hold the lock
+        if (DeviceContext->eventBufferUsed == MAX_EVENTS)
+        {
+            KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
+      
+            DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
+            ObDereferenceObject(hObject);
+            return STATUS_INSUFFICIENT_RESOURCES;      
+        }
+    
+        // look for a free slot
+        BOOLEAN done = FALSE;
+        for (UINT16 i = 0; i < MAX_EVENTS; ++i)
+        {
+            PIVSHMEMEventListEntry event = &DeviceContext->eventBuffer[i];
+            if (event->event != NULL)
+                continue;
+      
+            // found one, assign the event to it and add it to the list
+            event->owner = WdfRequestGetFileObject(Request);
+            event->event = hObject;
+            event->vector = in->vector;
+            event->singleShot = in->singleShot;
+            ++DeviceContext->eventBufferUsed;
+            InsertTailList(&DeviceContext->eventList, &event->ListEntry);
+            done = TRUE;
+            break;
+        }
+    
+        // this should never occur, if it does it indicates memory corruption
+        if (!done)
+        {
+            DEBUG_ERROR(
+              "IOCTL_IVSHMEM_REGISTER_EVENT: deviceContext->eventBufferUsed (%u) < MAX_EVENTS (%u) but no slots found!",
+              DeviceContext->eventBufferUsed, MAX_EVENTS);
+            KeBugCheckEx(CRITICAL_STRUCTURE_CORRUPTION, 0, 0, 0, 0x1C);
+        }
+    }
+    KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
+  
+    *BytesReturned = 0;
+    return STATUS_SUCCESS;
 }

--- a/ivshmem/Queue.c
+++ b/ivshmem/Queue.c
@@ -16,6 +16,48 @@ typedef struct IVSHMEM_MMAP32
 IVSHMEM_MMAP32, *PIVSHMEM_MMAP32;
 #endif
 
+// Forwards
+static NTSTATUS ioctl_request_peerid(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
+static NTSTATUS ioctl_request_size(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
+static NTSTATUS ioctl_request_mmap(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
+static NTSTATUS ioctl_release_mmap(
+  const PDEVICE_CONTEXT DeviceContext,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
+static NTSTATUS ioctl_ring_doorbell(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          InputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
+static NTSTATUS ioctl_register_event(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          InputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+);
+
 NTSTATUS IVSHMEMQueueInitialize(_In_ WDFDEVICE Device)
 {
     WDFQUEUE queue;
@@ -57,291 +99,28 @@ IVSHMEMEvtIoDeviceControl(
     switch (IoControlCode)
     {
         case IOCTL_IVSHMEM_REQUEST_PEERID:
-        {
-            if (OutputBufferLength != sizeof(IVSHMEM_PEERID))
-            {
-                DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_PEERID: Invalid size, expected %u but got %u", sizeof(IVSHMEM_PEERID), OutputBufferLength);
-                status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            IVSHMEM_PEERID *out = NULL;
-            if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_PEERID: Failed to retrieve the output buffer");
-                status = STATUS_INVALID_USER_BUFFER;
-                break;
-            }
-
-            *out = (IVSHMEM_PEERID)deviceContext->devRegisters->ivProvision;
-            status = STATUS_SUCCESS;
-            bytesReturned = sizeof(IVSHMEM_PEERID);
-            break;
-        }
+          status = ioctl_request_peerid(deviceContext, OutputBufferLength, Request, &bytesReturned);
+          break;
 
         case IOCTL_IVSHMEM_REQUEST_SIZE:
-        {
-            if (OutputBufferLength != sizeof(IVSHMEM_SIZE))
-            {
-                DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_SIZE: Invalid size, expected %u but got %u", sizeof(IVSHMEM_SIZE), OutputBufferLength);
-                status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            IVSHMEM_SIZE *out = NULL;
-            if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_SIZE: Failed to retrieve the output buffer");
-                status = STATUS_INVALID_USER_BUFFER;
-                break;
-            }
-
-            *out = deviceContext->shmemAddr.NumberOfBytes;
-            status = STATUS_SUCCESS;
-            bytesReturned = sizeof(IVSHMEM_SIZE);
-            break;
-        }
+          status = ioctl_request_size(deviceContext, OutputBufferLength, Request, &bytesReturned);
+          break;
 
         case IOCTL_IVSHMEM_REQUEST_MMAP:
-        {
-            // only one mapping at a time is allowed
-            if (deviceContext->shmemMap)
-            {
-                status = STATUS_DEVICE_ALREADY_ATTACHED;
-                break;
-            }
-
-#ifdef _WIN64
-            PIRP  irp = WdfRequestWdmGetIrp(Request);
-            const BOOLEAN is32Bit   = IoIs32bitProcess(irp);
-            const size_t  bufferLen = is32Bit ? sizeof(IVSHMEM_MMAP32) : sizeof(IVSHMEM_MMAP);
-#else
-            const size_t  bufferLen = sizeof(IVSHMEM_MMAP);
-#endif
-            PVOID buffer;
-
-            if (OutputBufferLength != bufferLen)
-            {
-                DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_MMAP: Invalid size, expected %u but got %u", bufferLen, OutputBufferLength);
-                status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, bufferLen, (PVOID *)&buffer, NULL)))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Failed to retrieve the output buffer");
-                status = STATUS_INVALID_USER_BUFFER;
-                break;
-            }
-
-            __try
-            {
-                deviceContext->shmemMap = MmMapLockedPagesSpecifyCache(
-                    deviceContext->shmemMDL,
-                    UserMode,
-                    MmWriteCombined,
-                    NULL,
-                    FALSE,
-                    NormalPagePriority | MdlMappingNoExecute
-                );
-            }
-            __except(EXCEPTION_EXECUTE_HANDLER)
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Exception trying to map pages");
-                status = STATUS_DRIVER_INTERNAL_ERROR;
-                break;
-            }
-
-            if (!deviceContext->shmemMap)
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: shmemMap is NULL");
-                status = STATUS_DRIVER_INTERNAL_ERROR;
-                break;
-            }
-
-            deviceContext->owner = WdfRequestGetFileObject(Request);
-#ifdef _WIN64
-            if (is32Bit)
-            {
-                PIVSHMEM_MMAP32 out = (PIVSHMEM_MMAP32)buffer;
-                out->peerID  = (UINT16)deviceContext->devRegisters->ivProvision;
-                out->size    = (UINT64)deviceContext->shmemAddr.NumberOfBytes;
-                out->ptr     = PtrToUint(deviceContext->shmemMap);
-                out->vectors = deviceContext->interruptsUsed;
-            }
-            else
-#endif
-            {
-                PIVSHMEM_MMAP out = (PIVSHMEM_MMAP)buffer;
-                out->peerID   = (UINT16)deviceContext->devRegisters->ivProvision;
-                out->size     = (UINT64)deviceContext->shmemAddr.NumberOfBytes;
-                out->ptr      = deviceContext->shmemMap;
-                out->vectors  = deviceContext->interruptsUsed;
-            }
-            status = STATUS_SUCCESS;
-            bytesReturned = bufferLen;
-            break;
-        }
+          status = ioctl_request_mmap(deviceContext, OutputBufferLength, Request, &bytesReturned);
+          break;
 
         case IOCTL_IVSHMEM_RELEASE_MMAP:
-        {
-            // ensure the mapping exists
-            if (!deviceContext->shmemMap)
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: not mapped");
-                status = STATUS_INVALID_DEVICE_REQUEST;
-                break;
-            }
-
-            // ensure someone else other then the owner doesn't attempt to release the mapping
-            if (deviceContext->owner != WdfRequestGetFileObject(Request))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: Invalid owner");
-                status = STATUS_INVALID_HANDLE;
-                break;
-            }
-
-            MmUnmapLockedPages(deviceContext->shmemMap, deviceContext->shmemMDL);
-            deviceContext->shmemMap = NULL;
-            deviceContext->owner    = NULL;
-            status = STATUS_SUCCESS;
-            bytesReturned = 0;
-            break;
-        }
+          status = ioctl_release_mmap(deviceContext, Request, &bytesReturned);
+          break;
 
         case IOCTL_IVSHMEM_RING_DOORBELL:
-        {
-            // ensure someone else other then the owner doesn't attempt to trigger IRQs
-            if (deviceContext->owner != WdfRequestGetFileObject(Request))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Invalid owner");
-                status = STATUS_INVALID_HANDLE;
-                break;
-            }
-
-            if (InputBufferLength != sizeof(IVSHMEM_RING))
-            {
-                DEBUG_ERROR("IOCTL_IVSHMEM_RING_DOORBELL: Invalid size, expected %u but got %u", sizeof(IVSHMEM_RING), InputBufferLength);
-                status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            PIVSHMEM_RING in;
-            if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Failed to retrieve the input buffer");
-                status = STATUS_INVALID_USER_BUFFER;
-                break;
-            }
-
-            WRITE_REGISTER_ULONG(
-                &deviceContext->devRegisters->doorbell,
-                (ULONG)in->vector | ((ULONG)in->peerID << 16));
-
-            status = STATUS_SUCCESS;
-            bytesReturned = 0;
-            break;
-        }
+          status = ioctl_ring_doorbell(deviceContext, InputBufferLength, Request, &bytesReturned);
+          break;
 
         case IOCTL_IVSHMEM_REGISTER_EVENT:
-        {
-            // ensure someone else other then the owner isn't attempting to register events
-            if (deviceContext->owner != WdfRequestGetFileObject(Request))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Invalid owner");
-                status = STATUS_INVALID_HANDLE;
-                break;
-            }
-
-            if (InputBufferLength != sizeof(IVSHMEM_EVENT))
-            {
-                DEBUG_ERROR("IOCTL_IVSHMEM_REGISTER_EVENT: Invalid size, expected %u but got %u", sizeof(PIVSHMEM_EVENT), InputBufferLength);
-                status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            // early non locked quick check to see if we are out of event space
-            if (deviceContext->eventBufferUsed == MAX_EVENTS)
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
-                status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-
-            PIVSHMEM_EVENT in;
-            if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
-            {
-                DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Failed to retrieve the input buffer");
-                status = STATUS_INVALID_USER_BUFFER;
-                break;
-            }
-
-            PRKEVENT hObject;
-            if (!NT_SUCCESS(ObReferenceObjectByHandle(
-                    in->event,
-                    SYNCHRONIZE | EVENT_MODIFY_STATE,
-                    *ExEventObjectType,
-                    UserMode,
-                    &hObject,
-                    NULL)))
-            {
-                DEBUG_ERROR("%s", "Unable to reference user-mode event object");
-                status = STATUS_INVALID_HANDLE;
-                break;
-            }
-
-            // clear the event in case the caller didn't think to
-            KeClearEvent(hObject);
-
-            // lock the event list so we can push the new entry into it
-            KIRQL oldIRQL;
-            KeAcquireSpinLock(&deviceContext->eventListLock, &oldIRQL);
-            {
-                // check again if there is space before we search as we now hold the lock
-                if (deviceContext->eventBufferUsed == MAX_EVENTS)
-                {
-                    KeReleaseSpinLock(&deviceContext->eventListLock, oldIRQL);
-
-                    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
-                    ObDereferenceObject(hObject);
-                    status = STATUS_INSUFFICIENT_RESOURCES;
-                    break;
-                }
-
-                // look for a free slot
-                BOOLEAN done = FALSE;
-                for (UINT16 i = 0; i < MAX_EVENTS; ++i)
-                {
-                    PIVSHMEMEventListEntry event = &deviceContext->eventBuffer[i];
-                    if (event->event != NULL)
-                        continue;
-
-                    // found one, assign the event to it and add it to the list
-                    event->owner      = WdfRequestGetFileObject(Request);
-                    event->event      = hObject;
-                    event->vector     = in->vector;
-                    event->singleShot = in->singleShot;
-                    ++deviceContext->eventBufferUsed;
-                    InsertTailList(&deviceContext->eventList, &event->ListEntry);
-                    done = TRUE;
-                    break;
-                }
-
-                // this should never occur, if it does it indicates memory corruption
-                if (!done)
-                {
-                    DEBUG_ERROR(
-                        "IOCTL_IVSHMEM_REGISTER_EVENT: deviceContext->eventBufferUsed (%u) < MAX_EVENTS (%u) but no slots found!",
-                        deviceContext->eventBufferUsed, MAX_EVENTS);
-                    KeBugCheckEx(CRITICAL_STRUCTURE_CORRUPTION, 0, 0, 0, 0x1C);
-                }
-            }
-            KeReleaseSpinLock(&deviceContext->eventListLock, oldIRQL);
-
-            bytesReturned = 0;
-            status = STATUS_SUCCESS;
-            break;
-        }
+          status = ioctl_register_event(deviceContext, InputBufferLength, Request, &bytesReturned);
+          break;
     }
 
     WdfRequestCompleteWithInformation(Request, status, bytesReturned);
@@ -398,4 +177,293 @@ VOID IVSHMEMEvtDeviceFileCleanup(_In_ WDFFILEOBJECT FileObject)
     MmUnmapLockedPages(deviceContext->shmemMap, deviceContext->shmemMDL);
     deviceContext->shmemMap = NULL;
     deviceContext->owner    = NULL;
+}
+
+static NTSTATUS ioctl_request_peerid(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  if (OutputBufferLength != sizeof(IVSHMEM_PEERID))
+  {
+    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_PEERID: Invalid size, expected %u but got %u", sizeof(IVSHMEM_PEERID), OutputBufferLength);
+    return STATUS_INVALID_BUFFER_SIZE;
+  }
+
+  IVSHMEM_PEERID *out = NULL;
+  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_PEERID: Failed to retrieve the output buffer");
+    return STATUS_INVALID_USER_BUFFER;
+  }
+
+  *out           = (IVSHMEM_PEERID)DeviceContext->devRegisters->ivProvision;
+  *BytesReturned = sizeof(IVSHMEM_PEERID);
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS ioctl_request_size(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  if (OutputBufferLength != sizeof(IVSHMEM_SIZE))
+  {
+    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_SIZE: Invalid size, expected %u but got %u", sizeof(IVSHMEM_SIZE), OutputBufferLength);
+    return STATUS_INVALID_BUFFER_SIZE;
+  }
+
+  IVSHMEM_SIZE *out = NULL;
+  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, OutputBufferLength, (PVOID *)&out, NULL)))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_SIZE: Failed to retrieve the output buffer");
+    return STATUS_INVALID_USER_BUFFER;
+  }
+
+  *out           = DeviceContext->shmemAddr.NumberOfBytes;
+  *BytesReturned = sizeof(IVSHMEM_SIZE);
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS ioctl_request_mmap(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          OutputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  // only one mapping at a time is allowed
+  if (DeviceContext->shmemMap)
+    return STATUS_DEVICE_ALREADY_ATTACHED;
+
+#ifdef _WIN64
+  PIRP  irp = WdfRequestWdmGetIrp(Request);
+  const BOOLEAN is32Bit = IoIs32bitProcess(irp);
+  const size_t  bufferLen = is32Bit ? sizeof(IVSHMEM_MMAP32) : sizeof(IVSHMEM_MMAP);
+#else
+  const size_t  bufferLen = sizeof(IVSHMEM_MMAP);
+#endif
+  PVOID buffer;
+
+  if (OutputBufferLength != bufferLen)
+  {
+    DEBUG_ERROR("IOCTL_IVSHMEM_REQUEST_MMAP: Invalid size, expected %u but got %u", bufferLen, OutputBufferLength);
+    return STATUS_INVALID_BUFFER_SIZE;
+  }
+
+  if (!NT_SUCCESS(WdfRequestRetrieveOutputBuffer(Request, bufferLen, (PVOID *)&buffer, NULL)))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Failed to retrieve the output buffer");
+    return STATUS_INVALID_USER_BUFFER;
+  }
+
+  __try
+  {
+    DeviceContext->shmemMap = MmMapLockedPagesSpecifyCache(
+      DeviceContext->shmemMDL,
+      UserMode,
+      MmWriteCombined,
+      NULL,
+      FALSE,
+      NormalPagePriority | MdlMappingNoExecute
+    );
+  }
+  __except (EXCEPTION_EXECUTE_HANDLER)
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: Exception trying to map pages");
+    return STATUS_DRIVER_INTERNAL_ERROR;
+  }
+
+  if (!DeviceContext->shmemMap)
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REQUEST_MMAP: shmemMap is NULL");
+    return STATUS_DRIVER_INTERNAL_ERROR;
+  }
+
+  DeviceContext->owner = WdfRequestGetFileObject(Request);
+#ifdef _WIN64
+  if (is32Bit)
+  {
+    PIVSHMEM_MMAP32 out = (PIVSHMEM_MMAP32)buffer;
+    out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
+    out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
+    out->ptr     = PtrToUint(DeviceContext->shmemMap);
+    out->vectors = DeviceContext->interruptsUsed;
+  }
+  else
+#endif
+  {
+    PIVSHMEM_MMAP out = (PIVSHMEM_MMAP)buffer;
+    out->peerID  = (UINT16)DeviceContext->devRegisters->ivProvision;
+    out->size    = (UINT64)DeviceContext->shmemAddr.NumberOfBytes;
+    out->ptr     = DeviceContext->shmemMap;
+    out->vectors = DeviceContext->interruptsUsed;
+  }
+  
+  *BytesReturned = bufferLen;
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS ioctl_release_mmap(
+  const PDEVICE_CONTEXT DeviceContext,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  // ensure the mapping exists
+  if (!DeviceContext->shmemMap)
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: not mapped");
+    return STATUS_INVALID_DEVICE_REQUEST;
+  }
+
+  // ensure someone else other then the owner doesn't attempt to release the mapping
+  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RELEASE_MMAP: Invalid owner");
+    return STATUS_INVALID_HANDLE;
+  }
+
+  MmUnmapLockedPages(DeviceContext->shmemMap, DeviceContext->shmemMDL);
+  DeviceContext->shmemMap = NULL;
+  DeviceContext->owner    = NULL;
+  *BytesReturned = 0;
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS ioctl_ring_doorbell(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          InputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  // ensure someone else other then the owner doesn't attempt to trigger IRQs
+  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Invalid owner");
+    return STATUS_INVALID_HANDLE;
+  }
+
+  if (InputBufferLength != sizeof(IVSHMEM_RING))
+  {
+    DEBUG_ERROR("IOCTL_IVSHMEM_RING_DOORBELL: Invalid size, expected %u but got %u", sizeof(IVSHMEM_RING), InputBufferLength);
+    return STATUS_INVALID_BUFFER_SIZE;
+  }
+
+  PIVSHMEM_RING in;
+  if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_RING_DOORBELL: Failed to retrieve the input buffer");
+    return STATUS_INVALID_USER_BUFFER;   
+  }
+
+  WRITE_REGISTER_ULONG(
+    &DeviceContext->devRegisters->doorbell,
+    (ULONG)in->vector | ((ULONG)in->peerID << 16));
+
+  *BytesReturned = 0;
+  return STATUS_SUCCESS;
+}
+
+static NTSTATUS ioctl_register_event(
+  const PDEVICE_CONTEXT DeviceContext,
+  const size_t          InputBufferLength,
+  const WDFREQUEST      Request,
+  size_t              * BytesReturned
+)
+{
+  // ensure someone else other then the owner isn't attempting to register events
+  if (DeviceContext->owner != WdfRequestGetFileObject(Request))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Invalid owner");
+    return STATUS_INVALID_HANDLE;
+  }
+
+  if (InputBufferLength != sizeof(IVSHMEM_EVENT))
+  {
+    DEBUG_ERROR("IOCTL_IVSHMEM_REGISTER_EVENT: Invalid size, expected %u but got %u", sizeof(PIVSHMEM_EVENT), InputBufferLength);
+    return STATUS_INVALID_BUFFER_SIZE;
+  }
+
+  // early non locked quick check to see if we are out of event space
+  if (DeviceContext->eventBufferUsed == MAX_EVENTS)
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
+    return STATUS_INSUFFICIENT_RESOURCES;
+  }
+
+  PIVSHMEM_EVENT in;
+  if (!NT_SUCCESS(WdfRequestRetrieveInputBuffer(Request, InputBufferLength, (PVOID)&in, NULL)))
+  {
+    DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Failed to retrieve the input buffer");
+    return STATUS_INVALID_USER_BUFFER;
+  }
+
+  PRKEVENT hObject;
+  if (!NT_SUCCESS(ObReferenceObjectByHandle(
+    in->event,
+    SYNCHRONIZE | EVENT_MODIFY_STATE,
+    *ExEventObjectType,
+    UserMode,
+    &hObject,
+    NULL)))
+  {
+    DEBUG_ERROR("%s", "Unable to reference user-mode event object");
+    return STATUS_INVALID_HANDLE;
+  }
+
+  // clear the event in case the caller didn't think to
+  KeClearEvent(hObject);
+
+  // lock the event list so we can push the new entry into it
+  KIRQL oldIRQL;
+  KeAcquireSpinLock(&DeviceContext->eventListLock, &oldIRQL);
+  {
+    // check again if there is space before we search as we now hold the lock
+    if (DeviceContext->eventBufferUsed == MAX_EVENTS)
+    {
+      KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
+
+      DEBUG_ERROR("%s", "IOCTL_IVSHMEM_REGISTER_EVENT: Event buffer full");
+      ObDereferenceObject(hObject);
+      return STATUS_INSUFFICIENT_RESOURCES;      
+    }
+
+    // look for a free slot
+    BOOLEAN done = FALSE;
+    for (UINT16 i = 0; i < MAX_EVENTS; ++i)
+    {
+      PIVSHMEMEventListEntry event = &DeviceContext->eventBuffer[i];
+      if (event->event != NULL)
+        continue;
+
+      // found one, assign the event to it and add it to the list
+      event->owner = WdfRequestGetFileObject(Request);
+      event->event = hObject;
+      event->vector = in->vector;
+      event->singleShot = in->singleShot;
+      ++DeviceContext->eventBufferUsed;
+      InsertTailList(&DeviceContext->eventList, &event->ListEntry);
+      done = TRUE;
+      break;
+    }
+
+    // this should never occur, if it does it indicates memory corruption
+    if (!done)
+    {
+      DEBUG_ERROR(
+        "IOCTL_IVSHMEM_REGISTER_EVENT: deviceContext->eventBufferUsed (%u) < MAX_EVENTS (%u) but no slots found!",
+        DeviceContext->eventBufferUsed, MAX_EVENTS);
+      KeBugCheckEx(CRITICAL_STRUCTURE_CORRUPTION, 0, 0, 0, 0x1C);
+    }
+  }
+  KeReleaseSpinLock(&DeviceContext->eventListLock, oldIRQL);
+
+  *BytesReturned = 0;
+  return STATUS_SUCCESS;
 }


### PR DESCRIPTION
This PR performs two things:

* moves ioctl code from the large switch statement into local static functions
* Adds `IVSHMEM_MMAP_CONFIG` to the `IVSHMEM_REQUEST_MMAP` IOCTL which allows specifying the cache type rather then always assuming write combining.