### PR TITLE
netkvm: driver should fail initialization if PCI resources init failed

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -722,8 +722,8 @@ NDIS_STATUS ParaNdis_InitializeContext(
     else
     {
         DPrintf(0, "[%s] Error: Incomplete resources\n", __FUNCTION__);
-        /* avoid deregistering if failed */
         status = NDIS_STATUS_RESOURCE_CONFLICT;
+        return status;
     }
 
     pContext->MaxPacketSize.nMaxFullSizeOS = pContext->MaxPacketSize.nMaxDataSize + ETH_HEADER_SIZE;


### PR DESCRIPTION
This bug caused by historical refactoring done in
ParaNdis_InitializeContext function. If PCI resource initialization failed
driver should not continue execution of ParaNdis_InitializeContext
function.

Signed-off-by: Yan Vugenfirer <yvugenfi@redhat.com>