### PR TITLE
netkvm: If the driver doesn't support RSS, it should not ACK virtio multi-queue feature

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -752,16 +752,20 @@ NDIS_STATUS ParaNdis_InitializeContext(
     if (pContext->ulPriorityVlanSetting)
         pContext->MaxPacketSize.nMaxFullSizeHwTx = pContext->MaxPacketSize.nMaxFullSizeOS + ETH_PRIORITY_HEADER_SIZE;
 
+#if PARANDIS_SUPPORT_RSS
     pContext->bMultiQueue = pContext->bControlQueueSupported && AckFeature(pContext, VIRTIO_NET_F_MQ);
-    if (pContext->bMultiQueue)
-    {
-        virtio_get_config(&pContext->IODevice, ETH_ALEN + sizeof(USHORT), &pContext->nHardwareQueues,
-            sizeof(pContext->nHardwareQueues));
-    }
-    else
-    {
-        pContext->nHardwareQueues = 1;
-    }
+	if (pContext->bMultiQueue)
+	{
+		virtio_get_config(&pContext->IODevice, ETH_ALEN + sizeof(USHORT), &pContext->nHardwareQueues,
+			sizeof(pContext->nHardwareQueues));
+	}
+	else
+	{
+		pContext->nHardwareQueues = 1;
+	}
+#else
+	pContext->nHardwareQueues = 1;
+#endif
 
     dependentOptions = osbT4TcpChecksum | osbT4UdpChecksum | osbT4TcpOptionsChecksum |
         osbT6TcpChecksum | osbT6UdpChecksum | osbT6TcpOptionsChecksum | osbT6IpExtChecksum;


### PR DESCRIPTION
…rt RSS

This bug caused by when frontend notify qemu support multi queue, but in face not support, just one hardqueue, qemu alloc max queue(large then one), but just enable one queue;
dpdk do hot upgrade, save all the queue value , then recover,  crash.
this change to when frontend not support multi queue, not to notify qemu support, avoid qemu to alloc more than one queue.

Signed-off-by: jackli <1744764178@qq.com>