### PR TITLE
netkvm: Driver should not indicate MQ support when RSS isn't supported

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -752,16 +752,20 @@ NDIS_STATUS ParaNdis_InitializeContext(
     if (pContext->ulPriorityVlanSetting)
         pContext->MaxPacketSize.nMaxFullSizeHwTx = pContext->MaxPacketSize.nMaxFullSizeOS + ETH_PRIORITY_HEADER_SIZE;
 
+#if PARANDIS_SUPPORT_RSS
     pContext->bMultiQueue = pContext->bControlQueueSupported && AckFeature(pContext, VIRTIO_NET_F_MQ);
     if (pContext->bMultiQueue)
     {
         virtio_get_config(&pContext->IODevice, ETH_ALEN + sizeof(USHORT), &pContext->nHardwareQueues,
-            sizeof(pContext->nHardwareQueues));
+        sizeof(pContext->nHardwareQueues));
     }
     else
     {
         pContext->nHardwareQueues = 1;
     }
+#else
+    pContext->nHardwareQueues = 1;
+#endif
 
     dependentOptions = osbT4TcpChecksum | osbT4UdpChecksum | osbT4TcpOptionsChecksum |
         osbT6TcpChecksum | osbT6UdpChecksum | osbT6TcpOptionsChecksum | osbT6IpExtChecksum;


### PR DESCRIPTION
The bug was caused by a bug in the backend where the driver allocates more
than one hardqueue and doesn't enable all of them which leads the backend
crashing. When RSS is not enabled in compilation the driver uses one queue
only, this commit drops MQ support when the driver has RSS disabled which
prevents these unnecessary allocations.

Closes 230

Signed-off-by: jackli <1744764178@qq.com>
Signed-off-by: Sameeh Jubran <sameeh@daynix.com>