### PR TITLE
NetKVM: BZ#1537430 Import LinkSpeed/Duplex configs from the hypervisor

### DIFF
--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -150,8 +150,7 @@ struct CPUPathBundle : public CPlacementAllocatable {
 
 #define PARANDIS_MULTICAST_LIST_SIZE        32
 #define PARANDIS_MEMORY_TAG                 '5muQ'
-#define PARANDIS_FORMAL_LINK_SPEED          (pContext->ulFormalLinkSpeed)
-#define PARANDIS_MAXIMUM_RECEIVE_SPEED      PARANDIS_FORMAL_LINK_SPEED
+#define PARANDIS_MAXIMUM_LINK_SPEED         10000000000 // 10Gbps link speed
 #define PARANDIS_MIN_LSO_SEGMENTS           2
 // reported
 #define PARANDIS_MAX_LSO_SIZE               0xF800
@@ -271,6 +270,12 @@ typedef struct _tagMaxPacketSize
     UINT nMaxFullSizeOsRx;
 }tMaxPacketSize;
 
+typedef struct _tagLinkProperties
+{
+    ULONGLONG Speed;
+    NET_IF_MEDIA_DUPLEX_STATE DuplexState;
+}tLinkProperties;
+
 #define MAX_HW_RX_PACKET_SIZE (MAX_IP4_DATAGRAM_SIZE + ETH_HEADER_SIZE + ETH_PRIORITY_HEADER_SIZE)
 #define MAX_OS_RX_PACKET_SIZE (MAX_IP4_DATAGRAM_SIZE + ETH_HEADER_SIZE)
 
@@ -364,6 +369,7 @@ typedef struct _tagPARANDIS_ADAPTER
     BOOLEAN                 bLinkDetectSupported;
     BOOLEAN                 bGuestAnnounceSupported;
     BOOLEAN                 bMaxMTUConfigSupported;
+    BOOLEAN                 bLinkPropertiesConfigSupported;
     BOOLEAN                 bGuestChecksumSupported;
     BOOLEAN                 bControlQueueSupported;
     BOOLEAN                 bUseMergedBuffers;
@@ -384,9 +390,9 @@ typedef struct _tagPARANDIS_ADAPTER
     LONG                    counterDPCInside;
     ULONG                   ulPriorityVlanSetting;
     ULONG                   VlanId;
-    ULONGLONG               ulFormalLinkSpeed;
     ULONG                   ulEnableWakeup;
     tMaxPacketSize          MaxPacketSize;
+    tLinkProperties         LinkProperties;
     ULONG                   ulUniqueID;
     UCHAR                   PermanentMacAddress[ETH_ALEN];
     UCHAR                   CurrentMacAddress[ETH_ALEN];

--- a/NetKVM/Common/osdep.h
+++ b/NetKVM/Common/osdep.h
@@ -41,6 +41,12 @@
 #if ((OSVERSION_MASK & NTDDI_VERSION) == NTDDI_VISTA)
 #define NDIS_PROTOCOL_ID_IP6            0x03
 
+#ifdef  _WIN64
+#define offsetof(s,f)   ((size_t)((ptrdiff_t)&(((s *)0)->f)))
+#else
+#define offsetof(s,f)   ((size_t)&(((s *)0)->f))
+#endif
+
 typedef struct _NETWORK_ADDRESS_IP6 {
     USHORT      sin6_port;
     ULONG       sin6_flowinfo;

--- a/NetKVM/Common/virtio_net.h
+++ b/NetKVM/Common/virtio_net.h
@@ -59,6 +59,8 @@
 #define VIRTIO_NET_F_GUEST_RSC4 41	/* Guest can handle coalesced IPv4 tcp packets. */
 #define VIRTIO_NET_F_GUEST_RSC6 42	/* Guest can handle coalesced IPv6 tcp packets. */
 
+#define VIRTIO_NET_F_SPEED_DUPLEX 63	/* Device set linkspeed and duplex */
+
 #ifndef VIRTIO_NET_NO_LEGACY
 #define VIRTIO_NET_F_GSO	6	/* Host handles pkts w/ any GSO type */
 #endif /* VIRTIO_NET_NO_LEGACY */
@@ -78,7 +80,23 @@ struct virtio_net_config {
 	__u16 max_virtqueue_pairs;
 	/* Default maximum transmit unit advice */
 	__u16 mtu;
+	/*
+	* speed, in units of 1Mb. All values 0 to INT_MAX are legal.
+	* Any other value stands for unknown.
+	*/
+	__u32 speed;
+	/*
+	* 0x00 - half duplex
+	* 0x01 - full duplex
+	* Any other value stands for unknown.
+	*/
+	__u8 duplex;
 } __attribute__((packed));
+
+#define VIRTIO_NET_DUPLEX_UNKNOWN                      0xff
+#define VIRTIO_NET_DUPLEX_HALF                         0x00
+#define VIRTIO_NET_DUPLEX_FULL                         0x01
+#define VIRTIO_NET_SPEED_UNKNOWN                       -1
 
 /*
  * This header comes first in the scatter-gather list.  If you don't

--- a/NetKVM/netkvm.inx
+++ b/NetKVM/netkvm.inx
@@ -88,15 +88,7 @@ HKR, Ndi\params\*RscIPv6,             Optional,            0, "0"
 HKR, Ndi\params\*RscIPv6\enum,        "0",                 0, "Disabled"
 HKR, Ndi\params\*RscIPv6\enum,        "1",                 0, "Enabled"
 
-[Parameters] 
- 
-HKR, Ndi\Params\ConnectRate,        ParamDesc,  0,          %ConnectRate% 
-HKR, Ndi\Params\ConnectRate,        Default,    0,          "10000" 
-HKR, Ndi\Params\ConnectRate,        type,       0,          "enum" 
-HKR, Ndi\Params\ConnectRate\enum,   "10",       0,          %10M% 
-HKR, Ndi\Params\ConnectRate\enum,   "100",      0,          %100M% 
-HKR, Ndi\Params\ConnectRate\enum,   "1000",     0,          %1G% 
-HKR, Ndi\Params\ConnectRate\enum,   "10000",    0,          %10G% 
+[Parameters]
  
 HKR, Ndi\Params\Priority,           ParamDesc,  0,          %Priority% 
 HKR, Ndi\Params\Priority,           Default,    0,          "1" 
@@ -286,8 +278,7 @@ VENDOR = "INX_COMPANY"
 kvmnet6.DeviceDesc        = "INX_PREFIX_VENDORVirtIO Ethernet Adapter"
 kvmnet6.Service.DispName    = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Service"
 DiskId1 = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Driver Disk #1"
-NetworkAddress = "Assign MAC" 
-ConnectRate = "Init.ConnectionRate(Mb)" 
+NetworkAddress = "Assign MAC"
 Priority = "Init.Do802.1PQ" 
 MTU = "Init.MTUSize" 
 TxCapacity = "Init.MaxTxBuffers" 

--- a/NetKVM/netkvm_no_RSC.inx
+++ b/NetKVM/netkvm_no_RSC.inx
@@ -75,15 +75,7 @@ HKR, Ndi\params\*NumRssQueues,          max,        0,          "16"
 HKR, Ndi\params\*NumRssQueues,          step,       0,          "1" 
 
 
-[Parameters] 
- 
-HKR, Ndi\Params\ConnectRate,        ParamDesc,  0,          %ConnectRate% 
-HKR, Ndi\Params\ConnectRate,        Default,    0,          "10000" 
-HKR, Ndi\Params\ConnectRate,        type,       0,          "enum" 
-HKR, Ndi\Params\ConnectRate\enum,   "10",       0,          %10M% 
-HKR, Ndi\Params\ConnectRate\enum,   "100",      0,          %100M% 
-HKR, Ndi\Params\ConnectRate\enum,   "1000",     0,          %1G% 
-HKR, Ndi\Params\ConnectRate\enum,   "10000",    0,          %10G% 
+[Parameters]
  
 HKR, Ndi\Params\Priority,           ParamDesc,  0,          %Priority% 
 HKR, Ndi\Params\Priority,           Default,    0,          "1" 
@@ -273,8 +265,7 @@ VENDOR = "INX_COMPANY"
 kvmnet6.DeviceDesc        = "INX_PREFIX_VENDORVirtIO Ethernet Adapter"
 kvmnet6.Service.DispName    = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Service"
 DiskId1 = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Driver Disk #1"
-NetworkAddress = "Assign MAC" 
-ConnectRate = "Init.ConnectionRate(Mb)" 
+NetworkAddress = "Assign MAC"
 Priority = "Init.Do802.1PQ" 
 MTU = "Init.MTUSize" 
 TxCapacity = "Init.MaxTxBuffers" 

--- a/NetKVM/netkvm_no_RSS.inx
+++ b/NetKVM/netkvm_no_RSS.inx
@@ -60,15 +60,7 @@ HKR, Ndi,                         Service,             0, "netkvm"
 HKR, Ndi\Interfaces,              UpperRange,          0, "ndis5" 
 HKR, Ndi\Interfaces,              LowerRange,          0, "ethernet" 
 
-[Parameters] 
- 
-HKR, Ndi\Params\ConnectRate,        ParamDesc,  0,          %ConnectRate% 
-HKR, Ndi\Params\ConnectRate,        Default,    0,          "10000" 
-HKR, Ndi\Params\ConnectRate,        type,       0,          "enum" 
-HKR, Ndi\Params\ConnectRate\enum,   "10",       0,          %10M% 
-HKR, Ndi\Params\ConnectRate\enum,   "100",      0,          %100M% 
-HKR, Ndi\Params\ConnectRate\enum,   "1000",     0,          %1G% 
-HKR, Ndi\Params\ConnectRate\enum,   "10000",    0,          %10G% 
+[Parameters]
  
 HKR, Ndi\Params\Priority,           ParamDesc,  0,          %Priority% 
 HKR, Ndi\Params\Priority,           Default,    0,          "1" 
@@ -258,8 +250,7 @@ VENDOR = "INX_COMPANY"
 kvmnet6.DeviceDesc        = "INX_PREFIX_VENDORVirtIO Ethernet Adapter"
 kvmnet6.Service.DispName    = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Service"
 DiskId1 = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Driver Disk #1"
-NetworkAddress = "Assign MAC" 
-ConnectRate = "Init.ConnectionRate(Mb)" 
+NetworkAddress = "Assign MAC"
 Priority = "Init.Do802.1PQ" 
 MTU = "Init.MTUSize" 
 TxCapacity = "Init.MaxTxBuffers" 

--- a/NetKVM/wlh/ParaNdis6-Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6-Oid.cpp
@@ -444,14 +444,14 @@ static NDIS_STATUS ParaNdis_OidQuery(PARANDIS_ADAPTER *pContext, tOidDesc *pOid)
         case OID_GEN_LINK_SPEED:
             {
                 /* units are 100 bps */
-                ul64LinkSpeed = PARANDIS_FORMAL_LINK_SPEED / 100;
+                ul64LinkSpeed = PARANDIS_MAXIMUM_LINK_SPEED / 100;
                 pInfo = &ul64LinkSpeed;
                 ulSize = sizeof(ul64LinkSpeed);
             }
             break;
         case OID_GEN_LINK_SPEED_EX:
             {
-                ULONG64 speed = pContext->bConnected ? PARANDIS_FORMAL_LINK_SPEED : NDIS_LINK_SPEED_UNKNOWN;
+                ULONG64 speed = pContext->bConnected ? pContext->LinkProperties.Speed : NDIS_LINK_SPEED_UNKNOWN;
                 u.LinkSpeed.RcvLinkSpeed = speed;
                 u.LinkSpeed.XmitLinkSpeed = speed;
                 pInfo = &u.LinkSpeed;


### PR DESCRIPTION
Changes following the introduction of virtio's flag, VIRTIO_NET_F_SPEED_DUPLEX,
which allows the host to set the LinkSpeed/Duplex values.

Up until this stage the configurations of LinkSpeed/Duplex used were hardcoded,
with default LinkSpeed=10Gbits/s, Duplex=full.
But uppon the introduction of VIRTIO_NET_F_SPEED_DUPLEX, it'll be more useful to
import them from the host and apply them if the VIRTIO_NET_F_SPEED_DUPLEX is on,
or, use the default configurations if it is off:
(LinkSpeed=10Gbits/s, Duplex=full).

Changes also includes removing the ConnectRate parameter from the inf file as we
never saw that it was used.

Qemu patches:

  1. [v4,2/3] qemu: virtio-net: use 64-bit values for feature flags:
     https://patchwork.ozlabs.org/patch/856266/
  2. [v4,3/3] qemu: add linkspeed and duplex settings to virtio-net:
     https://patchwork.ozlabs.org/patch/856226/

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>