### PR TITLE
All driver for Windows 10 will be built for "Universal" target platform.

### DIFF
--- a/Balloon/app/blnsvr.props
+++ b/Balloon/app/blnsvr.props
@@ -10,4 +10,8 @@ Enabling and customizing virtio build features
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
     <CopyrightStrings>BalloonCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
+	<DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
 </Project>

--- a/Balloon/app/blnsvr.vcxproj
+++ b/Balloon/app/blnsvr.vcxproj
@@ -194,8 +194,8 @@
     <TargetVersion>Windows7</TargetVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <Import Project="$(MSBuildProjectDirectory)\blnsvr.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
+  <Import Project="$(MSBuildProjectDirectory)\blnsvr.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">

--- a/NetKVM/CoInstaller/netkvmco-vs2015.vcxproj
+++ b/NetKVM/CoInstaller/netkvmco-vs2015.vcxproj
@@ -115,6 +115,7 @@
     <TargetVersion>Windows7</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|Win32'">
     <TargetVersion>Windows7</TargetVersion>
@@ -135,6 +136,7 @@
     <TargetVersion>Windows7</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">
     <TargetVersion>Windows7</TargetVersion>
@@ -165,6 +167,7 @@
     <TargetVersion>Windows7</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|x64'">
     <TargetVersion>Windows7</TargetVersion>
@@ -185,6 +188,7 @@
     <TargetVersion>Windows7</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <TargetVersion>Windows7</TargetVersion>

--- a/Tools/Driver.Common.props
+++ b/Tools/Driver.Common.props
@@ -32,6 +32,7 @@ Common property definitions used by all drivers:
   <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
     <_NT_TARGET_MAJ>100</_NT_TARGET_MAJ>
     <TargetOS>Win10</TargetOS>
+	<DriverTargetPlatform>Universal</DriverTargetPlatform>
     <InfArch>$(TargetArch).10.0</InfArch>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Win8.1 Release' OR '$(Configuration)'=='Win8.1 Debug'">

--- a/viorng/VirtRNG Package/VirtRNG Package.vcxproj
+++ b/viorng/VirtRNG Package/VirtRNG Package.vcxproj
@@ -150,8 +150,8 @@
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <Import Project="$(MSBuildProjectDirectory)\viorng_pack.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
+  <Import Project="$(MSBuildProjectDirectory)\viorng_pack.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">

--- a/viorng/VirtRNG Package/viorng_pack.props
+++ b/viorng/VirtRNG Package/viorng_pack.props
@@ -11,4 +11,8 @@ Enabling and customizing virtio build features
     <Feature_AdjustInf>true</Feature_AdjustInf>
     <CopyrightStrings>VioRNGCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
+	<DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
 </Project>

--- a/vioserial/app/vioser-test.props
+++ b/vioserial/app/vioser-test.props
@@ -1,0 +1,12 @@
+<!--
+***********************************************************************************************
+viser-test.props
+Enabling and customizing virtio build features
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
+	<DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
+</Project>

--- a/vioserial/app/vioser-test.vcxproj
+++ b/vioserial/app/vioser-test.vcxproj
@@ -197,6 +197,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.props" />
+  <Import Project="$(MSBuildProjectDirectory)\vioser-test.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets">


### PR DESCRIPTION
All driver for Windows 10 will be built for "Universal" target platform.

Exceptions:
* viorng - currently coninstaller is used to register user mode components for viorng. The usage of coinstallers is not allowed with "Universal" platform.

* Balloon service - still uses non-universal API.

* netsh plugin that is provided with NetKVM  - still uses non-universal API.
