### PR TITLE
[viostor] Fix for bug 1549455 - Event ID: 158 is logged on Win10/WS2016 when …

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -169,7 +169,7 @@ typedef struct _ADAPTER_EXTENSION {
     };
     VIRTIO_BAR            pci_bars[PCI_TYPE0_ADDRESSES];
     ULONG                 system_io_bus_number;
-
+    ULONG                 slot_number;
     ULONG                 perfFlags;
     PSTOR_DPC             dpc;
     BOOLEAN               dpc_ok;


### PR DESCRIPTION
Fix for https://github.com/virtio-win/kvm-guest-drivers-windows/issues/171
(Bug 1549455 - Event ID: 158 is logged on Win10/WS2016 whentwo or more virtio-blk disks attached to VM). 
Win10/WS2016 are logging Event Id 158 if  viostor driver fails to report unique identifier through
Device Identification VPD page (page number: 0x83)