### PR TITLE
adding a certificate sign script to all drivers

### DIFF
--- a/Tools/signAll.bat
+++ b/Tools/signAll.bat
@@ -1,0 +1,5 @@
+@echo off
+SET "SignToolDir=C:\Program Files (x86)\Windows Kits\8.1\bin\x64"
+for /r "%~dp0\..\" %%i in (*.sys) do "%SignToolDir%\signtool.exe" sign /f %~dp0\VirtIOTestCert.pfx %%i
+for /r "%~dp0\..\" %%i in (*.cat) do "%SignToolDir%\signtool.exe" sign /f %~dp0\VirtIOTestCert.pfx %%i
+


### PR DESCRIPTION
this script will sign all drivers with the certificate found at VirtIOTestCert.pfx.
this is used to practice a CI workflow automating microsoft HCK/HLK tests.
Signed-off-by: 20lives <lior@dotcore.co.il>