### PR TITLE
Dealing with white spaces in files path on cert sign script

### DIFF
--- a/Tools/signAll.bat
+++ b/Tools/signAll.bat
@@ -1,5 +1,5 @@
 @echo off
 SET "SignToolDir=C:\Program Files (x86)\Windows Kits\8.1\bin\x64"
-for /r "%~dp0\..\" %%i in (*.sys) do "%SignToolDir%\signtool.exe" sign /f %~dp0\VirtIOTestCert.pfx %%i
-for /r "%~dp0\..\" %%i in (*.cat) do "%SignToolDir%\signtool.exe" sign /f %~dp0\VirtIOTestCert.pfx %%i
+for /r "%~dp0\..\" %%i in (*.sys) do "%SignToolDir%\signtool.exe" sign /f "%~dp0\VirtIOTestCert.pfx" "%%i"
+for /r "%~dp0\..\" %%i in (*.cat) do "%SignToolDir%\signtool.exe" sign /f "%~dp0\VirtIOTestCert.pfx" "%%i"
 


### PR DESCRIPTION
files and folders with spaces got messed up, this fixes the issue.
Signed-off-by: 20lives <lior@dotcore.co.il>