### PR TITLE
NetKVM to support ACK of VIRTIO_F_IOMMU_PLATFORM

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -779,6 +779,11 @@ NDIS_STATUS ParaNdis_InitializeContext(
         pContext->u64HostFeatures = virtio_get_features(&pContext->IODevice);
         DumpVirtIOFeatures(pContext);
 
+        // Enable VIRTIO_F_IOMMU_PLATFORM feature on Windows 10 and Windows Server 2016
+#if (WINVER == 0x0A00)
+        AckFeature(pContext, VIRTIO_F_IOMMU_PLATFORM);
+#endif
+
         pContext->bLinkDetectSupported = AckFeature(pContext, VIRTIO_NET_F_STATUS);
         if(pContext->bLinkDetectSupported) {
             virtio_get_config(&pContext->IODevice, ETH_ALEN, &linkStatus, sizeof(linkStatus));

--- a/VirtIO/linux/virtio_config.h
+++ b/VirtIO/linux/virtio_config.h
@@ -60,6 +60,8 @@
 /* v1.0 compliant. */
 #define VIRTIO_F_VERSION_1              32
 
+#define VIRTIO_F_IOMMU_PLATFORM         33
+
 // if this number is not equal to desc size, queue creation fails
 #define SIZE_OF_SINGLE_INDIRECT_DESC    16
 


### PR DESCRIPTION
Background: https://issues.oasis-open.org/browse/VIRTIO-154 , we want that virtio-win drivers will use only DMA API for shared memory allocation (where possible, the balloon might be an exception).

This is the first set of patches adding VIRTIO_F_IOMMU_PLATFORM flag and acking the flag in NetKVM.
More changes for other drivers to follow.

