### PR TITLE
viostor and vioscsi to support ACK of VIRTIO_F_IOMMU_PLATFORM

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -649,6 +649,11 @@ ENTER_FN();
     if (CHECKBIT(adaptExt->features, VIRTIO_F_ANY_LAYOUT)) {
         guestFeatures |= (1ULL << VIRTIO_F_ANY_LAYOUT);
     }
+#if (WINVER == 0x0A00)
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_IOMMU_PLATFORM)) {
+        guestFeatures |= (1ULL << VIRTIO_F_IOMMU_PLATFORM);
+    }
+#endif
     if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_EVENT_IDX)) {
         guestFeatures |= (1ULL << VIRTIO_RING_F_EVENT_IDX);
     }

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -573,6 +573,12 @@ VirtIoHwInitialize(
         guestFeatures |= (1ULL << VIRTIO_F_VERSION_1);
     }
 
+#if (WINVER == 0x0A00)
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_IOMMU_PLATFORM)) {
+        guestFeatures |= (1ULL << VIRTIO_F_IOMMU_PLATFORM);
+    }
+#endif
+
     if (CHECKBIT(adaptExt->features, VIRTIO_F_ANY_LAYOUT)) {
         guestFeatures |= (1ULL << VIRTIO_F_ANY_LAYOUT);
     }


### PR DESCRIPTION
Background: https://issues.oasis-open.org/browse/VIRTIO-154 , we want that virtio-win drivers will use only DMA API for shared memory allocation (where possible, the balloon might be an exception).

This is the second set of patches adding VIRTIO_F_IOMMU_PLATFORM flag and acking the flag in storage related drivers.
