### PR TITLE
Build: Balloon build fixed

### DIFF
--- a/Balloon/sys/memstat.c
+++ b/Balloon/sys/memstat.c
@@ -32,6 +32,10 @@
 
 #include "precomp.h"
 
+#if defined(EVENT_TRACING)
+#include "memstat.tmh"
+#endif
+
 #ifndef USE_BALLOON_SERVICE
 
 #include "ntddkex.h"


### PR DESCRIPTION
Balloon.sys build failed, when USE_BALLOON_SERVICE is not defined, because of
include <memstat.tmh> missing.

Signed-off-by: Ilya Rudakov <irudakov@virtuozzo.com>