### PR TITLE
WPP Tracing: Set wppmodulename as project name

### DIFF
--- a/Tools/Driver.Common.props
+++ b/Tools/Driver.Common.props
@@ -153,6 +153,13 @@ Common property definitions used by all drivers:
     </Link>
   </ItemDefinitionGroup>
 
+  <!-- WPP settings -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WppModuleName>$(TargetFileName)</WppModuleName>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
   <!-- Import vendor specific properties -->
   <Import Project="Driver.Vendor.props" />
 


### PR DESCRIPTION
The wppmodulename is the friendly name of the message GUID. The
friendly name of the message GUID appears, by default, in the trace
message prefix.

By default, the friendly name of the message GUID is the name of
the directory in which the trace provider was built, this causes
some drivers as "sys". This commit overrides the default value
by setting the wppmodulename to be project name.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>