### PR TITLE
fwcfg64: add decoded KdDebuggerDataBlock exposure

### DIFF
--- a/fwcfg64/driver.h
+++ b/fwcfg64/driver.h
@@ -13,7 +13,10 @@
 #define DUMP_TYPE_FULL          1
 #define VMCOREINFO_FORMAT_ELF   0x1
 #ifdef _AMD64_
-    #define DUMP_HDR_SIZE       (PAGE_SIZE * 2)
+    #define DUMP_HDR_SIZE                   (PAGE_SIZE * 2)
+    #define MINIDUMP_OFFSET_KDBG_OFFSET     (DUMP_HDR_SIZE + 0x70)
+    #define MINIDUMP_OFFSET_KDBG_SIZE       (DUMP_HDR_SIZE + 0x74)
+    #define DUMP_HDR_OFFSET_BUGCHECK_PARAM1 0x40
 #endif
 
 #define ROUND_UP(x, n) (((x) + (n) - 1) & (-(n)))
@@ -59,7 +62,17 @@ typedef struct DEVICE_CONTEXT {
     VMCI_DATA           vmci_data;
     FWCfgDmaAccess      *dma_access;
     LONGLONG            dma_access_pa;
+    PUCHAR              kdbg;
 } DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+ULONG NTAPI KeCapturePersistentThreadState(PCONTEXT Context,
+                                           PKTHREAD Thread,
+                                           ULONG BugCheckCode,
+                                           ULONG BugCheckParameter1,
+                                           ULONG BugCheckParameter2,
+                                           ULONG BugCheckParameter3,
+                                           ULONG BugCheckParameter4,
+                                           PVOID VirtualAddress);
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 
@@ -73,4 +86,5 @@ EVT_WDF_DEVICE_RELEASE_HARDWARE FwCfgEvtDeviceReleaseHardware;
 EVT_WDF_DEVICE_D0_ENTRY FwCfgEvtDeviceD0Entry;
 EVT_WDF_DEVICE_D0_EXIT FwCfgEvtDeviceD0Exit;
 
-NTSTATUS VMCoreInfoFillAndSend(PDEVICE_CONTEXT ctx);
+NTSTATUS VMCoreInfoFill(PDEVICE_CONTEXT ctx);
+NTSTATUS VMCoreInfoSend(PDEVICE_CONTEXT ctx);

--- a/fwcfg64/power.c
+++ b/fwcfg64/power.c
@@ -49,7 +49,13 @@ NTSTATUS FwCfgEvtDeviceD0Entry(IN WDFDEVICE Device,
     pVmci->paddr = ctx->vmci_data.note_pa;
     pVmci->size = sizeof(VMCI_ELF64_NOTE);
 
-    status = VMCoreInfoFillAndSend(ctx);
+    status = VMCoreInfoFill(ctx);
+    if (!NT_SUCCESS(status))
+    {
+        return status;
+    }
+
+    status = VMCoreInfoSend(ctx);
 
     return status;
 }


### PR DESCRIPTION
After this patch driver can expose crashdump header with pointer to
decoded KdDebuggerDataBlock. In addition to producing crashdump at BSOD time,
QEMU using this structure can create valid live system dump.

Signed-off-by: Viktor Prutyanov <viktor.prutyanov@virtuozzo.com>