### PR TITLE
Viostor driver update

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1626,6 +1626,7 @@ VioStorCompleteRequest(
     PSRB_EXTENSION      srbExt = NULL;
     LIST_ENTRY          complete_list;
     UCHAR               srbStatus = SRB_STATUS_SUCCESS;
+#ifdef DBG
 #if (NTDDI_VERSION >= NTDDI_WIN7)
     PROCESSOR_NUMBER ProcNumber = { 0 };
     ULONG processor = KeGetCurrentProcessorNumberEx(&ProcNumber);
@@ -1633,7 +1634,7 @@ VioStorCompleteRequest(
 #else
     ULONG cpu = KeGetCurrentProcessorNumber();
 #endif
-
+#endif
     RhelDbgPrint(TRACE_LEVEL_VERBOSE,
                  ("--->%s : MessageID 0x%x\n", __FUNCTION__, MessageID));
 

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1269,6 +1269,7 @@ RhelScsiGetInquiryData(
         IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)IdentificationPage->Descriptors;
         memset(IdentificationDescr, 0, sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + BLOCK_SERIAL_STRLEN);
 
+#if (NTDDI_VERSION > NTDDI_WINBLUE)
         if (!adaptExt->sn_ok || adaptExt->sn[0] == 0) {
            IdentificationDescr->CodeSet = VpdCodeSetBinary;
            IdentificationDescr->IdentifierType = VpdIdentifierTypeEUI64;
@@ -1298,7 +1299,22 @@ RhelScsiGetInquiryData(
         IdentificationPage->PageLength = (UCHAR)(FIELD_OFFSET(VPD_IDENTIFICATION_PAGE, Descriptors) +
                     FIELD_OFFSET(VPD_IDENTIFICATION_DESCRIPTOR, Identifier) +
                     IdentificationDescr->IdentifierLength);
-
+#else
+        IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)IdentificationPage->Descriptors;
+        memset(IdentificationDescr, 0, sizeof(VPD_IDENTIFICATION_DESCRIPTOR));
+        IdentificationDescr->CodeSet = VpdCodeSetBinary;
+        IdentificationDescr->IdentifierType = VpdIdentifierTypeEUI64;
+        IdentificationDescr->IdentifierLength = 8;
+        IdentificationDescr->Identifier[0] = (adaptExt->pci_config.VendorID >> 12) & 0xF;
+        IdentificationDescr->Identifier[1] = (adaptExt->pci_config.VendorID >> 8) & 0xF;
+        IdentificationDescr->Identifier[2] = (adaptExt->pci_config.VendorID >> 4) & 0xF;
+        IdentificationDescr->Identifier[3] = adaptExt->pci_config.VendorID & 0xF;
+        IdentificationDescr->Identifier[4] = (adaptExt->pci_config.DeviceID >> 12) & 0xF;
+        IdentificationDescr->Identifier[5] = (adaptExt->pci_config.DeviceID >> 8) & 0xF;
+        IdentificationDescr->Identifier[6] = (adaptExt->pci_config.DeviceID >> 4) & 0xF;
+        IdentificationDescr->Identifier[7] = adaptExt->pci_config.DeviceID & 0xF;
+        IdentificationPage->PageLength = sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + IdentificationDescr->IdentifierLength;
+#endif
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, len);
     }
     else if (dataLen > sizeof(INQUIRYDATA)) {

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -396,25 +396,22 @@ VioStorVQLock(
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, ("--->%s MessageID = %d\n", __FUNCTION__, MessageID));
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    if (!isr) {
+        if (adaptExt->msix_enabled) {
+            if (adaptExt->num_queues > 1) {
 
-    if (!adaptExt->msix_enabled) {
-        if (!isr) {
-            StorPortAcquireSpinLock(DeviceExtension, InterruptLock, NULL, LockHandle);
-        }
-    }
-    else {
-        if ((adaptExt->num_queues == 1) ||
-            (!CHECKFLAG(adaptExt->perfFlags, STOR_PERF_CONCURRENT_CHANNELS))) {
-            if (!isr) {
+                NT_ASSERT(MessageID > 0);
+                NT_ASSERT(MessageID <= adaptExt->num_queues);
+                StorPortAcquireSpinLock(DeviceExtension, DpcLock, &adaptExt->dpc[MessageID - 1], LockHandle);
+            }
+            else {
                 ULONG oldIrql = 0;
                 StorPortAcquireMSISpinLock(DeviceExtension, (adaptExt->msix_one_vector ? 0 : MessageID), &oldIrql);
                 LockHandle->Context.OldIrql = (KIRQL)oldIrql;
             }
         }
         else {
-            NT_ASSERT(MessageID > 0);
-            NT_ASSERT(MessageID <= adaptExt->num_queues);
-            StorPortAcquireSpinLock(DeviceExtension, StartIoLock, &adaptExt->dpc[MessageID - 1], LockHandle);
+            StorPortAcquireSpinLock(DeviceExtension, InterruptLock, NULL, LockHandle);
         }
     }
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, ("<---%s MessageID = %d\n", __FUNCTION__, MessageID));
@@ -432,22 +429,12 @@ VioStorVQUnlock(
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, ("--->%s MessageID = %d\n", __FUNCTION__, MessageID));
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if (!adaptExt->msix_enabled) {
-        if (!isr) {
+    if (!isr) {
+        if (adaptExt->num_queues > 1) {
             StorPortReleaseSpinLock(DeviceExtension, LockHandle);
-        }
-    }
-    else {
-        if ((adaptExt->num_queues == 1) ||
-            (!CHECKFLAG(adaptExt->perfFlags, STOR_PERF_CONCURRENT_CHANNELS))) {
-            if (!isr) {
-                StorPortReleaseMSISpinLock(DeviceExtension, (adaptExt->msix_one_vector ? 0 : MessageID), LockHandle->Context.OldIrql);
-            }
         }
         else {
-            NT_ASSERT(MessageID > 0);
-            NT_ASSERT(MessageID <= adaptExt->num_queues);
-            StorPortReleaseSpinLock(DeviceExtension, LockHandle);
+            StorPortReleaseMSISpinLock(DeviceExtension, (adaptExt->msix_one_vector ? 0 : MessageID), LockHandle->Context.OldIrql);
         }
     }
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, ("<---%s MessageID = %d\n", __FUNCTION__, MessageID));


### PR DESCRIPTION
Two things in this series:
- redesign vq lock/unlock routines. Same as in virtio-scsi driver, should give some performance improvement on small (4K) block transfers. 
- Bugfix for Bug 1566298 unattended installation failure on upartitioned image
Vadim,