### PR TITLE
 NetKVM: Observee: Make list countable

### DIFF
--- a/NetKVM/Common/Parandis_DesignPatterns.h
+++ b/NetKVM/Common/Parandis_DesignPatterns.h
@@ -72,7 +72,7 @@ protected:
     CObservee() {}
 
 private:
-    CNdisList<CObserver<TNotifyObject>, CRawAccess, CNonCountingObject> m_ObserversList;
+    CNdisList<CObserver<TNotifyObject>, CRawAccess, CCountingObject> m_ObserversList;
 
     CObservee(const CObservee& observee);
     CObservee& operator=(const CObservee& observee);

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -127,12 +127,10 @@ struct CPUPathBundle : public CPlacementAllocatable {
     {
         if (rxCreated)
         {
-            rxPath.~CParaNdisRX();
             rxCreated = false;
         }
         if (txCreated)
         {
-            txPath.~CParaNdisTX();
             txCreated = false;
         }
     }


### PR DESCRIPTION
The Add method should return the size of list after the element has been
added. This method will always return 0 when the list's typename is
CNonCountingObject.

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>