### PR TITLE
Revert "NetKVM: Set AffinityPolicy to IrqPolicySpecifiedProcessors"

### DIFF
--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -732,7 +732,6 @@ static void SetupInterrruptAffinity(PIO_RESOURCE_REQUIREMENTS_LIST prrl)
                     desc->Flags |= CM_RESOURCE_INTERRUPT_POLICY_INCLUDED;
                     desc->u.Interrupt.Group = procNumber.Group;
                     desc->u.Interrupt.TargetedProcessors = 1i64 << procNumber.Number;
-                    desc->u.Interrupt.AffinityPolicy = IrqPolicySpecifiedProcessors;
                     DPrintf(0, "[%s]: Assigning CmResourceTypeInterrupt, min/max = %lx/%lx Option = 0x%lx, ShareDisposition = %u to #CPU = %d\n", __FUNCTION__,
                         desc->u.Interrupt.MinimumVector, desc->u.Interrupt.MaximumVector, desc->Option, desc->ShareDisposition, procNumber.Number);
                 }


### PR DESCRIPTION
This reverts commit a79dae286ffc90fa6b97dd2b81b00679ab8f6401.

The reverted commit changes the msi vector assignment behavior, prior to
this
patch, Windows was assigning the vectors on his own even though in the
driver
code we attempted to assign it by ourselves. So this commit probably
revealed
that our assignment is not correct.

Let's try and understand how should we assign the vectors without causing
BSODs and then re-enable the commit.

This commit resolves BZ#1599631

Signed-off-by: Sameeh Jubran <sameeh@daynix.com>