### PR TITLE
balloon: bz#1546821: use universal api in window 10 build

### DIFF
--- a/Balloon/app/blnsvr.props
+++ b/Balloon/app/blnsvr.props
@@ -10,8 +10,4 @@ Enabling and customizing virtio build features
     <Feature_AlwaysDefaultVendor>false</Feature_AlwaysDefaultVendor>
     <CopyrightStrings>BalloonCopyrightStrings</CopyrightStrings>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Win10 Release' OR '$(Configuration)'=='Win10 Debug'">
-	<DriverTargetPlatform>Desktop</DriverTargetPlatform>
-  </PropertyGroup>
 </Project>

--- a/Balloon/app/blnsvr.vcxproj
+++ b/Balloon/app/blnsvr.vcxproj
@@ -263,6 +263,7 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>objfre_win10_amd64\amd64\</OutDir>
     <IntDir>objfre_win10_amd64\amd64\</IntDir>
+    <ApiValidator_Enable>true</ApiValidator_Enable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -316,7 +317,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;UNIVERSAL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\sys\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -326,7 +327,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>setupapi.lib;wbemuuid.lib</AdditionalDependencies>
+      <AdditionalDependencies>OneCoreUAP.lib;wbemuuid.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>kernel32.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">
@@ -459,7 +461,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;UNIVERSAL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\sys\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -469,7 +471,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>setupapi.lib;wbemuuid.lib</AdditionalDependencies>
+      <AdditionalDependencies>OneCoreUAP.lib;wbemuuid.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>kernel32.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">

--- a/Balloon/app/device.h
+++ b/Balloon/app/device.h
@@ -4,12 +4,13 @@
 #include <wtypes.h>
 
 class CMemStat;
+class CService;
 
 class CDevice {
 public:
     CDevice();
     ~CDevice();
-    BOOL Init(SERVICE_STATUS_HANDLE hService);
+    BOOL Init(CService *Service);
     VOID Fini();
     BOOL Start();
     VOID Stop();
@@ -21,7 +22,7 @@ private:
     static DWORD WINAPI DeviceThread(LPDWORD lParam);
     VOID WriteLoop(HANDLE hDevice);
     CMemStat* m_pMemStat;
-    SERVICE_STATUS_HANDLE m_hService;
+    CService *m_pService;
     HANDLE m_hThread;
     HANDLE m_evtInitialized;
     HANDLE m_evtTerminate;

--- a/Balloon/app/service.h
+++ b/Balloon/app/service.h
@@ -4,6 +4,12 @@
 #include <windows.h>
 #include <dbt.h>
 
+#ifdef UNIVERSAL
+#define NOTIFY_HANDLE HCMNOTIFICATION
+#else
+#define NOTIFY_HANDLE HDEVNOTIFY
+#endif
+
 class CDevice;
 
 class CService
@@ -17,16 +23,26 @@ public:
     static void __stdcall ServiceMainThunk(CService* service, DWORD argc, TCHAR* argv[]);
     SERVICE_STATUS_HANDLE m_StatusHandle;
 
+    NOTIFY_HANDLE RegisterDeviceInterfaceNotification();
+    NOTIFY_HANDLE RegisterDeviceHandleNotification(HANDLE DeviceHandle);
+    BOOL UnregisterNotification(NOTIFY_HANDLE Handle);
+
+#ifdef UNIVERSAL
+    static DWORD WINAPI DeviceNotificationCallback(HCMNOTIFICATION Notify,
+        PVOID Context, CM_NOTIFY_ACTION Action,
+        PCM_NOTIFY_EVENT_DATA EventData, DWORD EventDataSize);
+#endif
+
 private:
     BOOL SendStatusToSCM(DWORD dwCurrentState, DWORD dwWin32ExitCode, DWORD dwServiceSpecificExitCode, DWORD dwCheckPoint, DWORD dwWaitHint);
     void StopService();
     void terminate(DWORD error);
     void ServiceCtrlHandler(DWORD controlCode);
     void ServiceMain(DWORD argc, LPTSTR *argv);
-    DWORD ServiceHandleDeviceChange(DWORD evtype, _DEV_BROADCAST_HEADER* dbhdr);
+    DWORD ServiceHandleDeviceChange(DWORD evtype);
     DWORD ServiceHandlePowerEvent(DWORD evtype, DWORD flags);
 
-    HDEVNOTIFY m_hDevNotify;
+    NOTIFY_HANDLE m_hDevNotify;
     HANDLE m_evTerminate;
     BOOL   m_bRunningService;
     DWORD  m_Status;

--- a/Balloon/app/stdafx.h
+++ b/Balloon/app/stdafx.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-
 #include <windows.h>
 #include <stdio.h>
 #include <tchar.h>
@@ -15,12 +14,13 @@
 #include <stdlib.h>
 #include <strsafe.h>
 
+#ifdef UNIVERSAL
+#include <cfgmgr32.h>
+#endif // UNIVERSAL
+
 #include "targetver.h"
 #include "utils.h"
 #include "service.h"
 #include "device.h"
 #include "memstat.h"
 #include "public.h"
-
-
-// TODO: reference additional headers your program requires here


### PR DESCRIPTION
In order to support the ARM64 platform for Windows, the balloon service is compiled for the "Universal" platform and must not use non-universal APIs.