### PR TITLE
[IVSHMEM] Use NonPagedPoolNx where appropriate

### DIFF
--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -122,7 +122,7 @@ NTSTATUS IVSHMEMEvtDevicePrepareHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
 
       if (deviceContext->interruptCount > 0)
       {
-          deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolWithTag(NonPagedPool,
+          deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolWithTag(IVSHMEM_NONPAGED_POOL,
               sizeof(WDFINTERRUPT) * deviceContext->interruptCount, 'sQRI');
 
           if (!deviceContext->interrupts)

--- a/ivshmem/Driver.h
+++ b/ivshmem/Driver.h
@@ -2,6 +2,12 @@
 #include <wdf.h>
 #include <initguid.h>
 
+#if (NTDOI_VERSION >= NTDOI_WIN8)
+#define IVSHMEM_NONPAGED_POOL NonPagedPoolNx
+#else
+#define IVSHMEM_NONPAGED_POOL NonPagedPool
+#endif
+
 #include "device.h"
 #include "queue.h"
 


### PR DESCRIPTION
This should fix this issue: https://github.com/virtio-win/kvm-guest-drivers-windows/issues/319

Signed-off-by: Lior Haim <lior@daynix.com>