### PR TITLE
Fix possible race conditions with CX path.

### DIFF
--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -35,10 +35,16 @@ bool CParaNdisCX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
     m_Context->m_CxStateMachine.Start();
 
     CreatePath();
+    InitDPC();
 
     return m_VirtQueue.Create(DeviceQueueIndex,
         &m_Context->IODevice,
         m_Context->MiniportHandle);
+}
+
+void CParaNdisCX::InitDPC()
+{
+    KeInitializeDpc(&m_DPC, MiniportMSIInterruptCXDpc, m_Context);
 }
 
 BOOLEAN CParaNdisCX::SendControlMessage(

--- a/NetKVM/Common/ParaNdis-CX.h
+++ b/NetKVM/Common/ParaNdis-CX.h
@@ -12,6 +12,8 @@ public:
 
     virtual NDIS_STATUS SetupMessageIndex(u16 vector);
 
+    void InitDPC();
+
     BOOLEAN CParaNdisCX::SendControlMessage(
         UCHAR cls,
         UCHAR cmd,
@@ -21,6 +23,8 @@ public:
         ULONG size2,
         int levelIfOK
         );
+
+    KDPC m_DPC;
 
 protected:
     tCompletePhysicalAddress m_ControlData;

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1852,7 +1852,7 @@ void ParaNdis_ReuseRxNBLs(PNET_BUFFER_LIST pNBL)
 void ParaNdis_CXDPCWorkBody(PARANDIS_ADAPTER *pContext)
 {
     InterlockedIncrement(&pContext->counterDPCInside);
-    if (pContext->bEnableInterruptHandlingDPC && pContext->CXPath.WasInterruptReported())
+    if (pContext->bEnableInterruptHandlingDPC)
     {
         UINT8 status = 0;
         status = ReadDeviceStatus(pContext);
@@ -1877,7 +1877,6 @@ void ParaNdis_CXDPCWorkBody(PARANDIS_ADAPTER *pContext)
             pContext->CXPath.SendControlMessage(VIRTIO_NET_CTRL_ANNOUNCE, VIRTIO_NET_CTRL_ANNOUNCE_ACK, NULL, 0, NULL, 0, 0);
             pContext->bGuestAnnounced = FALSE;
         }
-        pContext->CXPath.ClearInterruptReport();
     }
     InterlockedDecrement(&pContext->counterDPCInside);
 }

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -540,6 +540,8 @@ bool ParaNdis_DPCWorkBody(
     PARANDIS_ADAPTER *pContext,
     ULONG ulMaxPacketsToIndicate);
 
+void ParaNdis_CXDPCWorkBody(PARANDIS_ADAPTER *pContext);
+
 void ParaNdis_ReuseRxNBLs(PNET_BUFFER_LIST pNBL);
 
 #ifdef PARANDIS_SUPPORT_RSS
@@ -842,6 +844,17 @@ tTcpIpPacketParsingResult ParaNdis_CheckSumVerifyFlat(
     SGBuffer.size = ulDataLength;
     return ParaNdis_CheckSumVerify(&SGBuffer, ulDataLength, 0, flags, verifyLength, caller);
 }
+
+VOID MiniportMSIInterruptCXDpc(
+    struct _KDPC  *Dpc,
+    IN PVOID  MiniportInterruptContext,
+    IN PVOID                  NdisReserved1,
+    IN PVOID                  NdisReserved2
+);
+
+bool ParaNdis_RXTXDPCWorkBody(PARANDIS_ADAPTER *pContext,
+    ULONG ulMaxPacketsToIndicate);
+
 
 USHORT CheckSumCalculator(PVOID buffer, ULONG len);
 

--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -248,7 +248,6 @@ static BOOLEAN MiniportInterrupt(
     if (pContext->bCXPathCreated)
     {
         pContext->CXPath.DisableInterrupts();
-        pContext->CXPath.ReportInterrupt();
     }
     
     *QueueDefaultInterruptDpc = TRUE;
@@ -311,7 +310,6 @@ static BOOLEAN MiniportMSIInterrupt(
     path->SetLastInterruptTimestamp(pContext->LastInterruptTimeStamp);
 
     path->DisableInterrupts();
-    path->ReportInterrupt();
 
     if (path->getMessageIndex() == pContext->CXPath.getMessageIndex())
     {


### PR DESCRIPTION
This patch series address mainly the issues with CX interrupts that was originally reported in the following pull request:

https://github.com/virtio-win/kvm-guest-drivers-windows/pull/281
