### PR TITLE
netkvm and viostor: Proper do with enable msi.

### DIFF
--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -262,7 +262,11 @@ static CParaNdisAbstractPath *GetPathByMessageId(PARANDIS_ADAPTER *pContext, ULO
     CParaNdisAbstractPath *path = NULL;
 
     UINT bundleId = MessageId / 2;
-    if (pContext->CXPath.getMessageIndex() == MessageId)
+	if (pContext->CXPath.getMessageIndex() < MessageId)
+	{
+		path = NULL;
+	}
+	else if (pContext->CXPath.getMessageIndex() == MessageId)
     {
         path = &pContext->CXPath;
     }
@@ -307,6 +311,10 @@ static BOOLEAN MiniportMSIInterrupt(
     }
 
     CParaNdisAbstractPath *path = GetPathByMessageId(pContext, MessageId);
+	if (NULL == path) {
+		*QueueDefaultInterruptDpc = FALSE;
+		return TRUE;
+	}
 
     path->SetLastInterruptTimestamp(pContext->LastInterruptTimeStamp);
 

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1250,7 +1250,7 @@ VirtIoMSInterruptRoutine (
 {
     PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    if (MessageID > adaptExt->msix_vectors) {
+    if (MessageID > adaptExt->num_queues) {
         RhelDbgPrint(TRACE_LEVEL_ERROR, " MessageID = %d\n", MessageID);
         return FALSE;
     }


### PR DESCRIPTION
1: netkvm:  when qemu enable 8 queue (msi count is 17), nPathBundles is 2, qemu send msi large than 6, will result os crash.
2: viostor: same to netkvm,  vcpu 4, qemu hard queue 2, viostor  num_queues will be 1,  send msi 3 will result adpater->dpc null, os crash