### PR TITLE
IVSHMEM: Adding project version resource

### DIFF
--- a/ivshmem/ivshmem.rc
+++ b/ivshmem/ivshmem.rc
@@ -1,0 +1,41 @@
+/*
+ * This file contains resource (version) definitions for vioinput driver.
+ *
+ * Copyright (c) 2016-2017 Red Hat, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <windows.h>
+#include <ntverp.h>
+
+#include "..\Tools\vendor.ver"
+
+#undef  VER_FILEDESCRIPTION_STR
+#undef  VER_INTERNALNAME_STR
+
+#define VENDOR_VIRTIO_PRODUCT      VENDOR_PRODUCT_PREFIX "IVSHMEM Device"
+#define VER_FILEDESCRIPTION_STR    VENDOR_DESC_PREFIX "IVSHMEM Driver" VENDOR_DESC_POSTFIX
+#define VER_INTERNALNAME_STR       "ivshmem.sys"
+
+#include "common.ver"

--- a/ivshmem/ivshmem.vcxproj
+++ b/ivshmem/ivshmem.vcxproj
@@ -220,6 +220,9 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ResourceCompile Include="ivshmem.rc" />
+  </ItemGroup>
+  <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/ivshmem/ivshmem.vcxproj.filters
+++ b/ivshmem/ivshmem.vcxproj.filters
@@ -48,4 +48,9 @@
       <Filter>Driver Files</Filter>
     </Inf>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="ivshmem.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The Ivshmem driver file didn't had a  version resource which caused Microsoft HLK tests in some windows versions to not run.
Adding the resource file should solve this.
Signed-off-by: Lior Haim <lior@daynix.com>