### PR TITLE
support for VIRTIO_CONFIG_S_NEEDS_RESET to the NetKVM driver

### DIFF
--- a/NetKVM/Common/ParaNdis-AbstractPath.h
+++ b/NetKVM/Common/ParaNdis-AbstractPath.h
@@ -110,12 +110,17 @@ public:
         return !This->m_VirtQueue.Restart();
     }
 
-    /* We get notified by the state machine on surprise removal */
+    /* We get notified by the state machine on suprise removal or when the
+       device needs a reset*/
     void Notify(SMNotifications message) override
     {
-        if (message == SupriseRemoved)
+        if (message == SupriseRemoved || message == NeedsReset)
         {
             m_VirtQueue.DoNotTouchHardware();
+        }
+        else if (PoweredOn)
+        {
+            m_VirtQueue.AllowTouchHardware();
         }
     }
 protected:

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1209,6 +1209,11 @@ static void ReadLinkState(PARANDIS_ADAPTER *pContext)
     }
 }
 
+static UINT8 ReadDeviceStatus(PARANDIS_ADAPTER *pContext)
+{
+    return (UINT8) virtio_get_status(&pContext->IODevice);
+}
+
 static VOID ParaNdis_AddDriverOKStatus(PPARANDIS_ADAPTER pContext)
 {
     pContext->bDeviceInitialized = TRUE;

--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -1885,6 +1885,7 @@ bool ParaNdis_DPCWorkBody(PARANDIS_ADAPTER *pContext, ULONG ulMaxPacketsToIndica
             if (virtio_is_feature_enabled(pContext->u64HostFeatures, VIRTIO_F_VERSION_1) &&
                 (status & VIRTIO_CONFIG_S_NEEDS_RESET))
             {
+                DPrintf(0,"Received VIRTIO_CONFIG_S_NEEDS_RESET event");
                 pContext->m_StateMachine.NotifyDeviceNeedsReset();
                 pContext->bDeviceNeedsReset = TRUE;
             }

--- a/NetKVM/Common/ParaNdis-VirtQueue.h
+++ b/NetKVM/Common/ParaNdis-VirtQueue.h
@@ -183,6 +183,11 @@ public:
         m_CanTouchHardware = false;
     }
 
+    void AllowTouchHardware()
+    {
+        m_CanTouchHardware = true;
+    }
+
     bool CanTouchHardware()
     {
         return m_CanTouchHardware;

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -453,6 +453,7 @@ typedef struct _tagPARANDIS_ADAPTER
     CParaNdisCX CXPath;
     BOOLEAN bCXPathAllocated;
     BOOLEAN bCXPathCreated;
+    BOOLEAN bDeviceNeedsReset;
 
     CPUPathBundle               *pPathBundles;
     UINT                        nPathBundles;

--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -510,7 +510,9 @@ static NDIS_STATUS ParaNdis6_Reset(
         NDIS_HANDLE miniportAdapterContext,
         PBOOLEAN  pAddressingReset)
 {
-    UNREFERENCED_PARAMETER(miniportAdapterContext);
+    PARANDIS_ADAPTER *pContext = (PARANDIS_ADAPTER *)miniportAdapterContext;
+    ParaNdis_PowerOff(pContext);
+    ParaNdis_PowerOn(pContext);
     *pAddressingReset = FALSE;
     return NDIS_STATUS_SUCCESS;
 }

--- a/NetKVM/wlh/ParaNdis6-Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6-Driver.cpp
@@ -496,8 +496,10 @@ Required NDIS handler: happens unually each 2 second
 ***********************************************************/
 static BOOLEAN ParaNdis6_CheckForHang(NDIS_HANDLE miniportAdapterContext)
 {
-    UNREFERENCED_PARAMETER(miniportAdapterContext);
-    return FALSE;
+    PARANDIS_ADAPTER *pContext = (PARANDIS_ADAPTER *)miniportAdapterContext;
+    BOOLEAN ret = pContext->bDeviceNeedsReset;
+    pContext->bDeviceNeedsReset = FALSE;
+    return ret;
 }
 
 /**********************************************************

--- a/VirtIO/linux/virtio_config.h
+++ b/VirtIO/linux/virtio_config.h
@@ -39,6 +39,8 @@
 #define VIRTIO_CONFIG_S_DRIVER_OK           4
 /* Driver has finished configuring features */
 #define VIRTIO_CONFIG_S_FEATURES_OK         8
+/* Device entered invalid state, driver SHOULD reset it */
+#define VIRTIO_CONFIG_S_NEEDS_RESET         0x40
 /* We've given up on this device. */
 #define VIRTIO_CONFIG_S_FAILED              0x80
 /* virtio library features bits */


### PR DESCRIPTION
In this batch of commits, support for VIRTIO_CONFIG_S_NEEDS_RESET  was added to the NetKVM driver.