### PR TITLE
netkvm: add printout for RSC related features

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -401,6 +401,9 @@ static void DumpVirtIOFeatures(PPARANDIS_ADAPTER pContext)
         {VIRTIO_F_ANY_LAYOUT, "VIRTIO_F_ANY_LAYOUT"},
         {VIRTIO_RING_F_EVENT_IDX, "VIRTIO_RING_F_EVENT_IDX"},
         {VIRTIO_F_VERSION_1, "VIRTIO_F_VERSION_1"},
+        {VIRTIO_NET_F_CTRL_GUEST_OFFLOADS, "VIRTIO_NET_F_CTRL_GUEST_OFFLOADS" },
+        {VIRTIO_NET_F_GUEST_RSC4, "VIRTIO_NET_F_GUEST_RSC4" },
+        {VIRTIO_NET_F_GUEST_RSC6, "VIRTIO_NET_F_GUEST_RSC6" },
     };
     UINT i;
     for (i = 0; i < sizeof(Features)/sizeof(Features[0]); ++i)


### PR DESCRIPTION
Indicate presence of host features:
VIRTIO_NET_F_GUEST_RSC4
VIRTIO_NET_F_GUEST_RSC6
VIRTIO_NET_F_CTRL_GUEST_OFFLOADS

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>