### PR TITLE
netkvm: fix error flow on power on

### DIFF
--- a/NetKVM/Common/ParaNdis-Common.cpp
+++ b/NetKVM/Common/ParaNdis-Common.cpp
@@ -2157,6 +2157,7 @@ NDIS_STATUS ParaNdis_PowerOn(PARANDIS_ADAPTER *pContext)
     if (!NT_SUCCESS(nt_status))
     {
         DPrintf(0, "[%s] virtio_set_features failed with %x\n", __FUNCTION__, nt_status);
+        pContext->m_StateMachine.NotifyResumed();
         return NTStatusToNdisStatus(nt_status);
     }
 


### PR DESCRIPTION
If power on procedure fails, it still must resume the
state machine, otherwise following pause flow never
completes.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>