### PR TITLE
Fixed SDV Code analysis warnings

### DIFF
--- a/NetKVM/Common/ParaNdis-VirtIO.cpp
+++ b/NetKVM/Common/ParaNdis-VirtIO.cpp
@@ -380,8 +380,8 @@ static void mem_free_nonpaged_block(void *context, void *addr)
 {
     PARANDIS_ADAPTER *pContext = (PARANDIS_ADAPTER *)context;
 
-    NdisFreeMemoryWithTagPriority(pContext->MiniportHandle, addr, PARANDIS_MEMORY_TAG);
     DPrintf(6, "[%s] freed %p\n", __FUNCTION__, addr);
+    NdisFreeMemoryWithTagPriority(pContext->MiniportHandle, addr, PARANDIS_MEMORY_TAG);
 }
 
 static int PCIReadConfig(

--- a/NetKVM/Common/ParaNdis_LockFreeQueue.h
+++ b/NetKVM/Common/ParaNdis_LockFreeQueue.h
@@ -317,6 +317,10 @@ private:
 
         if (!m_QueueFullListIsEmpty)
         {
+            /* LockedContext Locker will always be locked during all of it's lifetime,
+            especially when it's being destructed. SDV does not recognize that due to encapsulation
+            so the warning is suppressed*/
+#pragma warning(suppress: 26110)
             TPassiveSpinLocker LockedContext(m_QueueFullListLock);
             do
             {

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -845,7 +845,7 @@ tTcpIpPacketParsingResult ParaNdis_CheckSumVerifyFlat(
     return ParaNdis_CheckSumVerify(&SGBuffer, ulDataLength, 0, flags, verifyLength, caller);
 }
 
-VOID MiniportMSIInterruptCXDpc(
+VOID _Function_class_(KDEFERRED_ROUTINE) MiniportMSIInterruptCXDpc(
     struct _KDPC  *Dpc,
     IN PVOID  MiniportInterruptContext,
     IN PVOID                  NdisReserved1,

--- a/NetKVM/wlh/ParaNdis6-Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6-Impl.cpp
@@ -399,7 +399,7 @@ Parameters:
 KDPC *  Dpc - The dpc structure for CX
 IN ULONG  MessageId - specific interrupt index
 ***********************************************************/
-VOID MiniportMSIInterruptCXDpc(
+VOID _Function_class_(KDEFERRED_ROUTINE) MiniportMSIInterruptCXDpc(
     struct _KDPC  *Dpc,
     IN PVOID  MiniportInterruptContext,
     IN PVOID                  NdisReserved1,


### PR DESCRIPTION
Running SDV code analysis, 3 warnings were found.
2 warnings were fixed, 1 was supperesssed due to encapsulation that was not recognized by SDV tool.