### PR TITLE
[viostor] handle VERIFY(16) requests properly

### DIFF
--- a/viostor/virtio_stor_hw_helper.h
+++ b/viostor/virtio_stor_hw_helper.h
@@ -144,6 +144,12 @@ RhelGetLba(
     IN PCDB Cdb
     );
 
+ULONG
+RhelGetSectors(
+    IN PVOID DeviceExtension,
+    IN PCDB Cdb
+    );
+
 VOID
 RhelGetSerialNumber(
     IN PVOID DeviceExtension


### PR DESCRIPTION
Fix the problem reviled by HLK scsicompliance VERIFY(10)(16) test and reported by Yan. If the  LBA  and the verification length exceeds the capacity of the medium, then the device server will return CHECK CONDITION status.
