### PR TITLE
README: Update Fedora docs URL; links by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ paravirtual and emulated hardware. The code builds and ships as part
 of the virtio-win RPM on Fedora and Red Hat Enterprise Linux, and the
 binaries are also available in the form of distribution-neutral ISO
 and VFD images. If all you want is use virtio-win in your Windows
-virtual machines, go to
-https://fedoraproject.org/wiki/Windows_Virtio_Drivers for information
-on obtaining the binaries.
+virtual machines, go to the
+[Fedora virtIO-win documentation][fedora-virtio]
+for information on obtaining the binaries.
 
 If you'd like to build virtio-win from sources, clone this repo and
-follow the instructions in
-https://github.com/virtio-win/kvm-guest-drivers-windows/wiki/Building-the-drivers.
+follow the instructions in [Building the Drivers][wiki-building].
 Note that the drivers you build will be either unsigned or test-signed
 with Tools/VirtIOTestCert.cer, which means that Windows will not load
-them by default. See
-https://docs.microsoft.com/en-us/windows-hardware/drivers/install/installing-test-signed-driver-packages
+them by default. See [Microsoft's driver signing page][ms-signing]
 for more information on test-signing.
 
 If you want to build cross-signed binaries (like the ones that ship in
@@ -33,10 +31,13 @@ license used prior to this commit is not compatible with WHQL.
 Additionally, we ask that you make a change to the Hardware IDs so
 that your drivers will *not* match devices exposed by the upstream
 versions of KVM/QEMU. This is especially important if you plan to
-distribute the drivers with Windows Update, see
-https://docs.microsoft.com/en-us/windows-hardware/drivers/dashboard/publishing-restrictions
-for more details.
+distribute the drivers with Windows Update, see the 
+[Microsoft publishing restrictions][ms-publishing] for more details.
 
+[fedora-virtio]:https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html
+[wiki-building]:https://github.com/virtio-win/kvm-guest-drivers-windows/wiki/Building-the-drivers
+[ms-signing]:https://docs.microsoft.com/en-us/windows-hardware/drivers/install/installing-test-signed-driver-packages
+[ms-publishing]:https://docs.microsoft.com/en-us/windows-hardware/drivers/dashboard/publishing-restrictions
 - - - -
 
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/virtio-win/kvm-guest-drivers-windows?branch=master&svg=true)](https://ci.appveyor.com/project/daynix/kvm-guest-drivers-windows)


### PR DESCRIPTION
The Fedora URL in the README has been moved to a new server and now has a _much_ longer URL that wouldn't even remotely fit on a single line. So I ended up reformatting all four URLs as text links, with the URLs associated by reference (listed at the end of the README content).