### PR TITLE
This patch enables the CX path to send and receive more than one buffer in the CX path

### DIFF
--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -6,6 +6,8 @@
 #include "ParaNdis-CX.tmh"
 #endif
 
+#define ALIGN_OFFSET(OFFSET) (OFFSET = ((OFFSET + 3) & ~3))
+
 CParaNdisCX::CParaNdisCX()
 {
     m_ControlData.Virtual = nullptr;
@@ -42,9 +44,15 @@ bool CParaNdisCX::Create(PPARANDIS_ADAPTER Context, UINT DeviceQueueIndex)
         m_Context->MiniportHandle);
 }
 
+
 void CParaNdisCX::InitDPC()
 {
     KeInitializeDpc(&m_DPC, MiniportMSIInterruptCXDpc, m_Context);
+}
+
+VOID CParaNdisCX::InsertBuffersToList(BufferList &list)
+{
+    UNREFERENCED_PARAMETER(list);
 }
 
 BOOLEAN CParaNdisCX::SendControlMessage(
@@ -55,84 +63,178 @@ BOOLEAN CParaNdisCX::SendControlMessage(
     PVOID buffer2,
     ULONG size2,
     int levelIfOK
-    )
+)
+{
+    BufferList outList;
+    BufferList inList;
+    CBuffer buff1, buff2;
+
+    buff1.buffer = buffer1;
+    buff1.size = size1;
+    buff2.buffer = buffer2;
+    buff2.size = size2;
+
+    InsertBuffersToList(outList, &buff1, &buff2);
+
+    return SendControlMessage(cls, cmd, outList, inList, levelIfOK);
+}
+
+ULONG SumBuffersSize(BufferList &list)
+{
+    ULONG size = 0;
+    list.ForEach([&size](CBuffer *buffer) { size += buffer->size; });
+    return size;
+}
+
+UINT CParaNdisCX::GetBuffer(PVOID inBuff)
+{
+    UINT len;
+    int tries = 1000;
+    do
+    {
+        inBuff = m_VirtQueue.GetBuf(&len);
+        UINT interval = 1;
+        NdisStallExecution(interval);
+        tries--;
+    } while (inBuff == nullptr && tries);
+
+    return len;
+}
+
+/* According to section "5.1.6.5 Control Virtqueue" of the virtio spec, the
+ * send convention to the CX path is:
+ *
+ * struct virtio_net_ctrl {
+ *         u8 class;
+ *         u8 command;
+ *         u8 command-specific-data[];
+ *         u8 ack;
+ * };
+ *
+ * How it is implemented:
+ *
+ * * Send a scatter gather to the device which includes:
+ *  ** virtio_net_ctrl_hdr as an output (class and command fields)
+ *  ** 0 or more output buffers
+ *  ** 0 or more input buffers
+ *  ** virtio_net_ctrl_ack as an input buffer
+ */
+
+BOOLEAN CParaNdisCX::SendControlMessage(
+    UCHAR cls,
+    UCHAR cmd,
+    BufferList &outList,
+    BufferList &inList,
+    int levelIfOK
+)
 {
     BOOLEAN bOK = FALSE;
     CLockedContext<CNdisSpinLock> autoLock(m_Lock);
+    ULONG totalSize = SumBuffersSize(inList) + SumBuffersSize(outList) + sizeof(virtio_net_ctrl_hdr) + sizeof(virtio_net_ctrl_ack);
 
-    if (m_ControlData.Virtual && m_ControlData.size > (size1 + size2 + 16))
+    if (m_ControlData.Virtual && m_ControlData.size > (totalSize) || inList.GetCount() + outList.GetCount() + 2 > MAX_SCATTER_GATHER_BUFFERS)
     {
-        struct VirtIOBufferDescriptor sg[4];
+        struct VirtIOBufferDescriptor sg[MAX_SCATTER_GATHER_BUFFERS];
         PUCHAR pBase = (PUCHAR)m_ControlData.Virtual;
         PHYSICAL_ADDRESS phBase = m_ControlData.Physical;
-        ULONG offset = 0;
+        ULONG inBaseOffset = 0, offset = 0;
         UINT nOut = 1;
+        UINT nIn = 0;
 
         ((virtio_net_ctrl_hdr *)pBase)->class_of_command = cls;
         ((virtio_net_ctrl_hdr *)pBase)->cmd = cmd;
         sg[0].physAddr = phBase;
         sg[0].length = sizeof(virtio_net_ctrl_hdr);
         offset += sg[0].length;
-        offset = (offset + 3) & ~3;
-        if (size1)
+        ALIGN_OFFSET(offset);
+
+        outList.ForEach([&](CBuffer *buffer)
         {
-            NdisMoveMemory(pBase + offset, buffer1, size1);
+            NdisMoveMemory(pBase + offset, buffer->buffer, buffer->size);
             sg[nOut].physAddr = phBase;
             sg[nOut].physAddr.QuadPart += offset;
-            sg[nOut].length = size1;
-            offset += size1;
-            offset = (offset + 3) & ~3;
+            sg[nOut].length = buffer->size;
+            offset += buffer->size;
+            ALIGN_OFFSET(offset);
             nOut++;
-        }
-        if (size2)
+        });
+
+        inBaseOffset = offset;
+
+        inList.ForEach([&](CBuffer *buffer)
         {
-            NdisMoveMemory(pBase + offset, buffer2, size2);
-            sg[nOut].physAddr = phBase;
-            sg[nOut].physAddr.QuadPart += offset;
-            sg[nOut].length = size2;
-            offset += size2;
-            offset = (offset + 3) & ~3;
-            nOut++;
-        }
-        sg[nOut].physAddr = phBase;
-        sg[nOut].physAddr.QuadPart += offset;
-        sg[nOut].length = sizeof(virtio_net_ctrl_ack);
+            NdisMoveMemory(pBase + offset, buffer->buffer, buffer->size);
+            sg[nOut + nIn].physAddr = phBase;
+            sg[nOut + nIn].physAddr.QuadPart += offset;
+            sg[nOut + nIn].length = buffer->size;
+            offset += buffer->size;
+            ALIGN_OFFSET(offset);
+            nIn++;
+        });
+
+        sg[nOut + nIn].physAddr = phBase;
+        sg[nOut + nIn].physAddr.QuadPart += offset;
+        sg[nOut + nIn].length = sizeof(virtio_net_ctrl_ack);
+        nIn++;
         *(virtio_net_ctrl_ack *)(pBase + offset) = VIRTIO_NET_ERR;
 
-        if (0 <= m_VirtQueue.AddBuf(sg, nOut, 1, (PVOID)1, NULL, 0))
+        if (0 <= m_VirtQueue.AddBuf(sg, nOut, nIn, (PVOID)1, NULL, 0))
         {
-            UINT len;
-            void *p;
+            UINT len, i = nOut;
+            PVOID inBuff = nullptr;
+
             m_Context->m_CxStateMachine.RegisterOutstandingItem();
 
             m_VirtQueue.Kick();
-            p = m_VirtQueue.GetBuf(&len);
-            for (int i = 0; i < 1000 && !p; ++i)
-            {
-                UINT interval = 1;
-                NdisStallExecution(interval);
-                p = m_VirtQueue.GetBuf(&len);
-            }
+            len = GetBuffer(inBuff);
+
             m_Context->m_CxStateMachine.UnregisterOutstandingItem();
 
-            if (!p)
+            if (!inBuff)
             {
                 DPrintf(0, "%s - ERROR: get_buf failed\n", __FUNCTION__);
             }
-            else if (len != sizeof(virtio_net_ctrl_ack))
+            /* Receive the input buffers, they are packed as one virtqueue element */
+            else if (len != SumBuffersSize(inList) + sizeof(virtio_net_ctrl_ack))
             {
                 DPrintf(0, "%s - ERROR: wrong len %d\n", __FUNCTION__, len);
+                m_Context->m_CxStateMachine.UnregisterOutstandingItem();
+                return bOK;
             }
-            else if (*(virtio_net_ctrl_ack *)(pBase + offset) != VIRTIO_NET_OK)
+
+            /* Iterate over the input buffers and return them to the user */
+            offset = inBaseOffset;
+            inList.ForEach([&](CBuffer *buffer)
+            {
+                inBuff = pBase + offset;
+                NdisMoveMemory(buffer->buffer, inBuff, sg[nOut + i].length);
+                offset += sg[nOut + i].length;
+                ALIGN_OFFSET(offset);
+                i++;
+            });
+
+            ASSERT(i < nIn + nOut);
+
+            /* Now all is left to check the virtio_net_ctrl_ack buffer, the
+            * virtio_net_ctrl_ack should be the last element that we should
+            * receive from the device in the queue
+            */
+
+            i++;
+            if ((i == nOut + nIn) && *(virtio_net_ctrl_ack *)(pBase + offset) != VIRTIO_NET_OK)
             {
                 DPrintf(0, "%s - ERROR: error %d returned for class %d\n", __FUNCTION__, *(virtio_net_ctrl_ack *)(pBase + offset), cls);
             }
-            else
+            else if (i == nOut + nIn)
             {
                 // everything is OK
-                DPrintf(levelIfOK, "%s OK(%d.%d,buffers of %d and %d) \n", __FUNCTION__, cls, cmd, size1, size2);
+                DPrintf(levelIfOK, "%s OK(%d.%d) \n", __FUNCTION__, cls, cmd);
                 bOK = TRUE;
+            } else
+            {
+                DPrintf(0, "%s - ERROR: Some output buffers didn't get returned for class %d\n", __FUNCTION__, cls);
             }
+
         }
         else
         {
@@ -141,7 +243,7 @@ BOOLEAN CParaNdisCX::SendControlMessage(
     }
     else
     {
-        DPrintf(0, "%s (buffer %d,%d) - ERROR: message too LARGE\n", __FUNCTION__, size1, size2);
+        DPrintf(0, "%s - ERROR: message too LARGE\n", __FUNCTION__);
     }
     return bOK;
 }

--- a/NetKVM/Common/ParaNdis-CX.h
+++ b/NetKVM/Common/ParaNdis-CX.h
@@ -3,6 +3,16 @@
 #include "ndis56common.h"
 #include "ParaNdis-AbstractPath.h"
 
+#define MAX_SCATTER_GATHER_BUFFERS 10
+
+struct CBuffer {
+    PVOID buffer;
+    ULONG size;
+    DECLARE_CNDISLIST_ENTRY(CBuffer);
+};
+
+typedef CNdisList<CBuffer, CRawAccess, CCountingObject> BufferList;
+
 class CParaNdisCX : public CParaNdisTemplatePath<CVirtQueue>, public CPlacementAllocatable {
 public:
     CParaNdisCX();
@@ -26,6 +36,28 @@ public:
 
     KDPC m_DPC;
 
+    BOOLEAN CParaNdisCX::SendControlMessage(
+        UCHAR cls,
+        UCHAR cmd,
+        BufferList &outList,
+        BufferList &inList,
+        int levelIfOK
+        );
+
+    template<typename ...Args>
+    VOID CParaNdisCX::InsertBuffersToList(BufferList &list, CBuffer *buff, Args ... args)
+    {
+        if (buff && buff->buffer)
+        {
+            list.PushBack(buff);
+        }
+        InsertBuffersToList(list, args...);
+    }
+
 protected:
     tCompletePhysicalAddress m_ControlData;
+
+private:
+    UINT CParaNdisCX::GetBuffer(PVOID inBuff);
+    VOID InsertBuffersToList(BufferList &list);
 };

--- a/NetKVM/Common/ParaNdis-Util.h
+++ b/NetKVM/Common/ParaNdis-Util.h
@@ -405,6 +405,15 @@ public:
         Remove_LockLess(Entry->GetListEntry());
     }
 
+    void EmptyList()
+    {
+        CLockedContext<TAccessStrategy> LockedContext(*this);
+        while (!IsListEmpty(&m_List))
+        {
+            Pop_LockLess();
+        }
+    }
+
     template <typename TFunctor>
     void ForEachDetached(TFunctor Functor)
     {


### PR DESCRIPTION
The Control Queue can handle as much buffers as we want to, currently we
only support 2 buffers from the driver and both of them are from the
driver to the device.

This patch is not currently needed but should be required in the future for implemented RSS offload feature/ steering mode implementation.