### PR TITLE
virtio-blk: set slot number to vpd

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -223,10 +223,6 @@ VirtIoInterrupt(
 #define SCSI_SENSEQ_CAPACITY_DATA_CHANGED        0x09
 #endif
 
-#ifndef NTDDI_WIN10
-#define NTDDI_WIN10                              0x0A000000
-#endif
-
 #ifdef MSI_SUPPORTED
 #ifndef PCIX_TABLE_POINTER
 typedef struct {


### PR DESCRIPTION
Since virtio disks' vpds are same in pre-win10 os, different virtio disks have same
unique id. It affects some apps' behavior.

Signed-off-by: Zhou Wenjian <zhouwj.fi@gmail.com>