### PR TITLE
netkvm: Fix functionality with single MSIX vector

### DIFF
--- a/NetKVM/Common/ParaNdis-AbstractPath.h
+++ b/NetKVM/Common/ParaNdis-AbstractPath.h
@@ -67,6 +67,8 @@ public:
     KAFFINITY DPCTargetProcessor = 0;
 #endif
 
+    virtual bool FireDPC(ULONG messageId) = 0;
+
 protected:
     PPARANDIS_ADAPTER m_Context;
     CVirtQueue *m_pVirtQueue;
@@ -122,6 +124,20 @@ public:
         {
             m_VirtQueue.AllowTouchHardware();
         }
+    }
+
+    // this default implementation is for RX/TX queues
+    // CX queue shall redefine it
+    bool FireDPC(ULONG messageId) override
+    {
+#if NDIS_SUPPORT_NDIS620
+        if (DPCAffinity.Mask)
+        {
+            NdisMQueueDpcEx(m_Context->InterruptHandle, messageId, &DPCAffinity, NULL);
+            return TRUE;
+        }
+#endif
+        return FALSE;
     }
 protected:
     CNdisSpinLock m_Lock;

--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -154,3 +154,10 @@ NDIS_STATUS CParaNdisCX::SetupMessageIndex(u16 vector)
 
     return CParaNdisAbstractPath::SetupMessageIndex(vector);
 }
+
+bool CParaNdisCX::FireDPC(ULONG messageId)
+{
+    DPrintf(0, "[%s] message %u\n", __FUNCTION__, messageId);
+    KeInsertQueueDpc(&m_DPC, NULL, NULL);
+    return TRUE;
+}

--- a/NetKVM/Common/ParaNdis-CX.h
+++ b/NetKVM/Common/ParaNdis-CX.h
@@ -24,6 +24,7 @@ public:
         int levelIfOK
         );
 
+    bool FireDPC(ULONG messageId) override;
     KDPC m_DPC;
 
 protected:

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -452,6 +452,7 @@ typedef struct _tagPARANDIS_ADAPTER
     CParaNdisCX CXPath;
     BOOLEAN bCXPathAllocated;
     BOOLEAN bCXPathCreated;
+    BOOLEAN bSharedVectors;
     BOOLEAN bDeviceNeedsReset;
 
     CPUPathBundle               *pPathBundles;
@@ -534,10 +535,6 @@ NDIS_STATUS ParaNdis_ConfigureMSIXVectors(
 
 VOID ParaNdis_CleanupContext(
     PARANDIS_ADAPTER *pContext);
-
-bool ParaNdis_DPCWorkBody(
-    PARANDIS_ADAPTER *pContext,
-    ULONG ulMaxPacketsToIndicate);
 
 void ParaNdis_CXDPCWorkBody(PARANDIS_ADAPTER *pContext);
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1666940
Set clear and simple rule for assignment of vectors to queues
and translation of MSIX messages to queues:
in case of one or two vectors they are assigned
to TX/RX queues and CX reuses the last vector. In this case
we do not spawn DPC for CX and process it during regular
RX/TX processing. For case of 3 and more vectors the processing
is the same as before.

Signed-off-by: Yuri Benditovich <yuri.benditovich@janustech.com>