### PR TITLE
netkvm: allocate also inactive queues

### DIFF
--- a/NetKVM/Common/ParaNdis-AbstractPath.cpp
+++ b/NetKVM/Common/ParaNdis-AbstractPath.cpp
@@ -44,3 +44,12 @@ ULONG CParaNdisAbstractPath::getCPUIndex()
     return ParaNdis_GetIndexFromAffinity(DPCTargetProcessor);
 #endif
 }
+
+void CInactiveQueue::Create(PPARANDIS_ADAPTER Context, UINT Index)
+{
+    m_Context = Context;
+    m_queueIndex = (u16)Index;
+    CreatePath();
+    m_bCreated = m_VirtQueue.Create(Index, &m_Context->IODevice, m_Context->MiniportHandle);
+    DPrintf(0, "[%s]: index = %d %s\n", __FUNCTION__, Index, m_bCreated ? "OK" : "Failed");
+}

--- a/NetKVM/Common/ParaNdis-AbstractPath.h
+++ b/NetKVM/Common/ParaNdis-AbstractPath.h
@@ -144,3 +144,12 @@ protected:
     bool m_ObserverAdded;
     VQ m_VirtQueue;
 };
+
+class CInactiveQueue : public CParaNdisTemplatePath<CVirtQueue>, public CPlacementAllocatable
+{
+public:
+    CInactiveQueue() {}
+    ~CInactiveQueue() {}
+    void Create(PPARANDIS_ADAPTER Context, UINT Index);
+    bool m_bCreated = false;
+};

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -458,6 +458,9 @@ typedef struct _tagPARANDIS_ADAPTER
     CPUPathBundle               *pPathBundles;
     UINT                        nPathBundles;
 
+    CInactiveQueue              *inactiveQueueus;
+    UINT                        nInactiveQueues;
+
     CPUPathBundle              **RSS2QueueMap;
     USHORT                      RSS2QueueLength;
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1608226
In case the driver uses less queues than the device supports
and unused queues are not initialized vhost start fails and
the device works without vhost. The root cause of the problem
is that the device touches also queues that the guest will
not use. Fixing in QEMU currently seems more complicated than
workaround in the driver (Linux driver also allocates all the
queues, including inactive ones). See also rejected QEMU fix:
http://lists.nongnu.org/archive/html/qemu-devel/2019-02/msg03374.html

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>