### PR TITLE
netkvm: Increase timeout of control command completion

### DIFF
--- a/NetKVM/Common/ParaNdis-CX.cpp
+++ b/NetKVM/Common/ParaNdis-CX.cpp
@@ -107,7 +107,7 @@ BOOLEAN CParaNdisCX::SendControlMessage(
 
             m_VirtQueue.Kick();
             p = m_VirtQueue.GetBuf(&len);
-            for (int i = 0; i < 1000 && !p; ++i)
+            for (int i = 0; i < 500000 && !p; ++i)
             {
                 UINT interval = 1;
                 NdisStallExecution(interval);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1716248
Previous commit 2eea7a77b709f sets timeout on waiting
for response on control command. The command stops waiting
after 1,000 attempts to get the response with 1 microsecond
wait between attempts. The intention was to prevent infinite
wait in case of unexpected IOCTL after the miniport received
shutdown indication (note that NDIS should not call adapter's
callbacks after that, see
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/ndis/nc-ndis-miniport_shutdown).
In this case the control queue is not initialized and
the QEMU does not receive the command and does not send
the response. But in case the limit is not sufficient and
the timeout happens during regular initialization flow and
QEMU does send the response, further commands might be
executed incorrectly and cause unpredictable result and
loss of functionality. Example of such case is sending
VIRTIO_NET_CTRL_MQ when the VM uses only part of queues (the
QEMU issues rollback, prints error message etc).
We increase the limit to 500,000 attempts.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>