### PR TITLE
[NetKVM] BZ#1745818 - Remove TestOnly.RXThrottle parameter from INF

### DIFF
--- a/NetKVM/netkvm.inx
+++ b/NetKVM/netkvm.inx
@@ -233,13 +233,6 @@ HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "2",    0,      %Rx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "1",    0,      %Tx% 
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "0",    0,      %Disable% 
  
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       ParamDesc,  0,          %NumberOfHandledRXPacketsInDPC% 
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       type,       0,          "long" 
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       default,    0,          "1000" 
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       min,        0,          "1" 
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       max,        0,          "10000" 
-HKR, Ndi\params\NumberOfHandledRXPacketsInDPC,       step,       0,          "1" 
- 
 [kvmnet6.CopyFiles] 
 netkvm.sys,,,2 
  
@@ -291,7 +284,6 @@ DebugLevel = "Logging.Level"
 Tx = "Tx Enabled"; 
 Rx = "Rx Enabled"; 
 TxRx = "Rx & Tx Enabled"; 
-NumberOfHandledRXPacketsInDPC = "TestOnly.RXThrottle" 
 Std.LsoV2IPv4 = "Large Send Offload V2 (IPv4)" 
 Std.LsoV2IPv6 = "Large Send Offload V2 (IPv6)" 
 Std.UDPChecksumOffloadIPv4 = "UDP Checksum Offload (IPv4)" 

--- a/NetKVM/netkvm_no_RSC.inx
+++ b/NetKVM/netkvm_no_RSC.inx
@@ -220,13 +220,6 @@ HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "2",    0,      %Rx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "1",    0,      %Tx% 
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "0",    0,      %Disable% 
  
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       ParamDesc,  0,          %NumberOfHandledRXPackersInDPC% 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       type,       0,          "long" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       default,    0,          "1000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       min,        0,          "1" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       max,        0,          "10000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       step,       0,          "1" 
- 
 [kvmnet6.CopyFiles] 
 netkvm.sys,,,2 
  
@@ -278,7 +271,6 @@ DebugLevel = "Logging.Level"
 Tx = "Tx Enabled"; 
 Rx = "Rx Enabled"; 
 TxRx = "Rx & Tx Enabled"; 
-NumberOfHandledRXPackersInDPC = "TestOnly.RXThrottle" 
 Std.LsoV2IPv4 = "Large Send Offload V2 (IPv4)" 
 Std.LsoV2IPv6 = "Large Send Offload V2 (IPv6)" 
 Std.UDPChecksumOffloadIPv4 = "UDP Checksum Offload (IPv4)" 

--- a/NetKVM/netkvm_no_RSS.inx
+++ b/NetKVM/netkvm_no_RSS.inx
@@ -205,13 +205,6 @@ HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "2",    0,      %Rx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "1",    0,      %Tx% 
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "0",    0,      %Disable% 
  
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       ParamDesc,  0,          %NumberOfHandledRXPackersInDPC% 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       type,       0,          "long" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       default,    0,          "1000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       min,        0,          "1" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       max,        0,          "10000" 
-HKR, Ndi\params\NumberOfHandledRXPackersInDPC,       step,       0,          "1" 
- 
 [kvmnet6.CopyFiles] 
 netkvm.sys,,,2 
  
@@ -263,7 +256,6 @@ DebugLevel = "Logging.Level"
 Tx = "Tx Enabled"; 
 Rx = "Rx Enabled"; 
 TxRx = "Rx & Tx Enabled"; 
-NumberOfHandledRXPackersInDPC = "TestOnly.RXThrottle" 
 Std.LsoV2IPv4 = "Large Send Offload V2 (IPv4)" 
 Std.LsoV2IPv6 = "Large Send Offload V2 (IPv6)" 
 Std.UDPChecksumOffloadIPv4 = "UDP Checksum Offload (IPv4)" 


### PR DESCRIPTION
This is an internal parameter, and it was removed from GUI as it might
confuse users. The parameter can still be added manually to registry.
Before the commit - default throttling limit value = 1000 , possible range: 1-10000
After the commit throttling limit value = 1000 (wasn't changed)
On < 6.20 (Win7 and below) it defines throttling limit.
On >= 6.20 (Win7 and above) it defines throttling limit if the limit provided
by OS is higher than this limit.

Signed-off-by: Basil Salman <basil@daynix.com>