### PR TITLE
netkvm: Use free to deallocate memory allocated with malloc

### DIFF
--- a/NetKVM/CoInstaller/RegAccess.cpp
+++ b/NetKVM/CoInstaller/RegAccess.cpp
@@ -26,7 +26,7 @@ neTKVMRegAccess::neTKVMRegAccess(HKEY hNewPrKey, LPCTSTR lpzNewRegPath)
 
 neTKVMRegAccess::~neTKVMRegAccess()
 {
-    delete m_lpsRegPath;
+    free(m_lpsRegPath);
 }
 
 VOID neTKVMRegAccess::SetPrimaryKey(HKEY hNewPrKey)
@@ -36,7 +36,7 @@ VOID neTKVMRegAccess::SetPrimaryKey(HKEY hNewPrKey)
 
 BOOL neTKVMRegAccess::SetRegPath(LPCTSTR lpzNewRegPath)
 {
-    delete m_lpsRegPath;
+    free(m_lpsRegPath);
 
     if (!lpzNewRegPath)
     {


### PR DESCRIPTION
_tcsdup is a macro that eventually evaluates to _strdup or a similar
call, which uses malloc() to allocate the required memory. Such pointer
should be released using a call to free(), not operator delete.

Signed-off-by: Michał Janiszewski <janisozaur@gmail.com>