### PR TITLE
balloon: support VIRTIO_BALLOON_S_AVAIL for "serviceless" driver

### DIFF
--- a/Balloon/sys/ntddkex.h
+++ b/Balloon/sys/ntddkex.h
@@ -36,6 +36,7 @@
 
 #define SystemBasicInformation 0
 #define SystemPerformanceInformation 2
+#define SystemFileCacheInformationEx 81
 
 typedef struct _SYSTEM_BASIC_INFORMATION {
     ULONG Reserved;
@@ -134,6 +135,18 @@ typedef struct _SYSTEM_PERFORMANCE_INFORMATION
     ULONGLONG MmSharedCommit; //is this Windows 8 or 8.1?
 #endif
 } SYSTEM_PERFORMANCE_INFORMATION, *PSYSTEM_PERFORMANCE_INFORMATION;
+
+typedef struct _SYSTEM_FILECACHE_INFORMATION {
+    ULONG_PTR CurrentSize;
+    ULONG_PTR PeakSize;
+    ULONG PageFaultCount;
+    ULONG_PTR MinimumWorkingSet;
+    ULONG_PTR MaximumWorkingSet;
+    ULONG_PTR CurrentSizeIncludingTransitionInPages;
+    ULONG_PTR PeakSizeIncludingTransitionInPages;
+    ULONG TransitionRePurposeCount;
+    ULONG Flags;
+} SYSTEM_FILECACHE_INFORMATION, *PSYSTEM_FILECACHE_INFORMATION;
 
 NTSYSAPI
 NTSTATUS


### PR DESCRIPTION
VIRTIO_BALLOON_S_AVAIL stat value was not updated for driver, built
without USE_BALLOON_SERVICE defined. Now this value is set as available
memory size + cache size/2

Signed-off-by: Ilya Rudakov <irudakov@virtuozzo.com>