### PR TITLE
balloon: process the ISR status at startup

### DIFF
--- a/Balloon/sys/Device.c
+++ b/Balloon/sys/Device.c
@@ -510,14 +510,18 @@ BalloonInterruptIsr(
 
     UNREFERENCED_PARAMETER( MessageID );
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INTERRUPT, "--> %s\n", __FUNCTION__);
     Device = WdfInterruptGetDevice(WdfInterrupt);
     devCtx = GetDeviceContext(Device);
 
     if (VirtIOWdfGetISRStatus(&devCtx->VDevice) > 0)
     {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INTERRUPT, "--> %s\n", __FUNCTION__);
         WdfInterruptQueueDpcForIsr( WdfInterrupt );
         return TRUE;
+    }
+    else
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INTERRUPT, "--> %s No Isr indicated\n", __FUNCTION__);
     }
     return FALSE;
 }
@@ -622,6 +626,7 @@ BalloonInterruptEnable(
 
     devCtx = GetDeviceContext(WdfDevice);
     EnableInterrupt(WdfInterrupt, devCtx);
+    BalloonInterruptIsr(WdfInterrupt, 0);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_PNP, "<-- %s\n", __FUNCTION__);
     return STATUS_SUCCESS;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1553633
If on driver startup the ISR status is set, the driver
will not function properly as the ISR will not fire
anymore. At startup, after all the queues are prepared,
the driver shall process the ISR if it contains non-zero
value. This will also clear the ISR status and allow
further interrupts to come.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>