### PR TITLE
[vioscsi] introduce the Registry key to make number of physical breakes adjustable

### DIFF
--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -54,6 +54,9 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define IO_PORT_LENGTH          0x40
 #define MAX_CPU                 256
 
+#define MAX_PH_BREAKS           "PhysicalBreaks"
+
+
 /* Feature Bits */
 #define VIRTIO_SCSI_F_INOUT                    0
 #define VIRTIO_SCSI_F_HOTPLUG                  1
@@ -314,7 +317,7 @@ typedef struct _ADAPTER_EXTENSION {
     PGROUP_AFFINITY       pmsg_affinity;
     BOOLEAN               dpc_ok;
     PSTOR_DPC             dpc;
-
+    ULONG                 max_physical_breaks;
     SCSI_WMILIB_CONTEXT   WmiLibContext;
     ULONGLONG             hba_id;
     PUCHAR                ser_num;

--- a/vioscsi/vioscsi.mof
+++ b/vioscsi/vioscsi.mof
@@ -21,4 +21,5 @@ class VioScsiExtendedInfoGuid
     [read, WmiDataId(7), WmiVersion(1)] boolean InterruptMsgRanges;
     [read, WmiDataId(8), WmiVersion(1)] boolean CompletionDuringStartIo;
     [read, WmiDataId(9), WmiVersion(1)] boolean RingPacked;
+    [read, WmiDataId(10), WmiVersion(1)] uint32 PhysicalBreaks;
 };

--- a/vioscsi/vioscsidt.h
+++ b/vioscsi/vioscsidt.h
@@ -54,13 +54,18 @@ typedef struct _VioScsiExtendedInfo
     #define VioScsiExtendedInfo_CompletionDuringStartIo_SIZE sizeof(BOOLEAN)
     #define VioScsiExtendedInfo_CompletionDuringStartIo_ID 8
 
-    //
+    // 
     BOOLEAN RingPacked;
     #define VioScsiExtendedInfo_RingPacked_SIZE sizeof(BOOLEAN)
     #define VioScsiExtendedInfo_RingPacked_ID 9
 
+    // 
+    ULONG PhysicalBreaks;
+    #define VioScsiExtendedInfo_PhysicalBreaks_SIZE sizeof(ULONG)
+    #define VioScsiExtendedInfo_PhysicalBreaks_ID 10
+
 } VioScsiExtendedInfo, *PVioScsiExtendedInfo;
 
-#define VioScsiExtendedInfo_SIZE (FIELD_OFFSET(VioScsiExtendedInfo, RingPacked) + VioScsiExtendedInfo_RingPacked_SIZE)
+#define VioScsiExtendedInfo_SIZE (FIELD_OFFSET(VioScsiExtendedInfo, PhysicalBreaks) + VioScsiExtendedInfo_PhysicalBreaks_SIZE)
 
 #endif


### PR DESCRIPTION
Please use the following .reg file to export "PhysicalBreaks" parameter to the Registry

Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\vioscsi\Parameters\Device]
"PhysicalBreaks"=dword:000000ff