### PR TITLE
cleanup: Fix cleanup scripts to remove temp directories

### DIFF
--- a/Balloon/app/cleanAll.bat
+++ b/Balloon/app/cleanAll.bat
@@ -8,6 +8,7 @@ rmdir /S /Q Release
 rmdir /S /Q Debug\x86
 rmdir /S /Q Debug\amd64
 rmdir /S /Q Debug
+rmdir /S /Q x64
 
 del /F *.log *.wrn *.err
 

--- a/NetKVM/clean.bat
+++ b/NetKVM/clean.bat
@@ -17,6 +17,7 @@ call :rmdir Install
 call :rmdir Install_Debug
 call :rmdir x64
 call :rmdir x86
+call :rmdir ARM64
 call :rmfiles build.err build.log buildfre_*.log buildchk_*.log msbuild.log
 call :rmfiles netkvm.DVL.XML SDV-default.xml sdv-user.sdv
 

--- a/pvpanic/clean.bat
+++ b/pvpanic/clean.bat
@@ -32,4 +32,5 @@ goto rmfiles
 :cleandir
 call :rmdir Win32
 call :rmdir x64
+call :rmdir ARM64
 goto :eof


### PR DESCRIPTION
ARM64 temp directory was not removed for NetKVM and Balloon
x64 temp directory was not removed for pvpanic

Signed-off-by: Yan Vugenfirer <yvugenfi@redhat.com>