### PR TITLE
Add .vs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ sdv-map.h
 sdv-user.*
 SDV-default.xml
 netkvmmof.h
+.vs


### PR DESCRIPTION
Visual Studio 2017 creates .vs temporary directory.
It is added to .gitignore

Signed-off-by: Yan Vugenfirer <yan@daynix.com>