### PR TITLE
[viscsi] report VPD_IDENTIFICATION_PAGE (0x83) vpd page in case id qe…

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -382,6 +382,7 @@ InitHW(
 ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     adaptExt->system_io_bus_number = ConfigInfo->SystemIoBusNumber;
+    adaptExt->slot_number = ConfigInfo->SlotNumber;
 
     /* read PCI config space */
     pci_cfg_len = StorPortGetBusData(

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -292,6 +292,7 @@ typedef struct _ADAPTER_EXTENSION {
     };
     VIRTIO_BAR            pci_bars[PCI_TYPE0_ADDRESSES];
     ULONG                 system_io_bus_number;
+    ULONG                 slot_number;
 
     ULONG                 queue_depth;
     BOOLEAN               dump_mode;


### PR DESCRIPTION
…mu does not do this.

According to Windows HC Specification a drive must report its port address for device
identification VPD page 83h inquiry association. Unfortunately, for some configurations
QEMU reports an empty page which leads to BSOD when Windows 10 recognises more
than one "identical" devices in the system. BZ#1708490, BZ#1722710#c10 and more.