### PR TITLE
Instruct NDIS Scatter-Gather DMA stack to use HAL DMA v3 APIs when available (NDIS_SUPPORT_NDIS650)

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -767,8 +767,7 @@ NDIS_STATUS ParaNdis_InitializeContext(
         DumpVirtIOFeatures(pContext);
 
         // Enable VIRTIO_F_IOMMU_PLATFORM feature on Windows 10 and Windows Server 2016
-        // Do not enable it on arm64 yet.
-#if (WINVER == 0x0A00) && !defined(_ARM64_)
+#if (WINVER == 0x0A00)
         AckFeature(pContext, VIRTIO_F_IOMMU_PLATFORM);
 #endif
         AckFeature(pContext, VIRTIO_NET_F_STANDBY);
@@ -785,7 +784,7 @@ NDIS_STATUS ParaNdis_InitializeContext(
         }
 
         InitializeLinkPropertiesConfig(pContext);
-
+        pContext->bControlQueueSupported = AckFeature(pContext, VIRTIO_NET_F_CTRL_VQ);
         pContext->bGuestAnnounceSupported = pContext->bLinkDetectSupported && pContext->bControlQueueSupported && AckFeature(pContext, VIRTIO_NET_F_GUEST_ANNOUNCE);
         InitializeMAC(pContext, CurrentMAC);
         InitializeMaxMTUConfig(pContext);

--- a/NetKVM/Common/ParaNdis_Util.cpp
+++ b/NetKVM/Common/ParaNdis_Util.cpp
@@ -23,19 +23,7 @@ bool CNdisSharedMemory::Allocate(ULONG Size, bool IsCached)
 {
     m_Size = Size;
     m_IsCached = IsCached;
-#if defined(_ARM64_)
-    /*
-     * On Windows on Arm, do not use NdisMAllocateSharedMemory.
-     * TODO: Figure out a neater way to allocate memory in those cases.
-     */
-    LARGE_INTEGER bound1, bound2;
-    bound1.QuadPart = 0;
-    bound2.QuadPart = MAXUINT64;
-    m_VA = MmAllocateContiguousMemorySpecifyCache(m_Size, bound1, bound2, bound1, MmCached);
-    m_PA = MmGetPhysicalAddress(m_VA);
-#else
     NdisMAllocateSharedMemory(m_DrvHandle, Size, m_IsCached, &m_VA, &m_PA);
-#endif
     return m_VA != nullptr;
 }
 
@@ -43,11 +31,7 @@ CNdisSharedMemory::~CNdisSharedMemory()
 {
     if(m_VA != nullptr)
     {
-#if defined(_ARM64_)
-        MmFreeContiguousMemorySpecifyCache(m_VA, m_Size, MmCached);
-#else
         NdisMFreeSharedMemory(m_DrvHandle, m_Size, m_IsCached, m_VA, m_PA);
-#endif
         m_VA = nullptr;
     }
 }


### PR DESCRIPTION
NDIS Scatter-Gather DMA APIs are showing signs of old age and are becoming inefficient, especially on SoC systems. This driver should ultimately migrate from NDIS Scatter-Gather DMA APIs and move to either the WDF or WDM (HAL DMA v3) APIs as instructed here.

https://docs.microsoft.com/en-us/windows-hardware/drivers/network/ndis-scatter-gather-dma

This will result in a significantly improved performance, especially on SoC systems.

The migration process can be found here, by Jeffrey_Tippet_[MSFT], maitanier of these APIs in HAL by Microsoft:
https://community.osr.com/discussion/291413/getscattergatherlistex-and-ownership-lifetime-semantics

Meanwhile, the NDIS_SG_DMA_V3_HAL_API flag, added to NDIS_SG_DMA_DESCRIPTION::Flags allows unlocking a small portion of these benefits. One of such benefits is to allow NDIS on ARM64 to honor the PCI cacheable attributes (_CCA) for DMA memory as expressed by the device (or its parent bridge).

This means we can have NDIS naturally allocate cacheable memory, without having to special case / override memory allocation paths for ARM64.
