### PR TITLE
nekvm: workaround for LSO failures on HCK 1903

### DIFF
--- a/NetKVM/wlh/ParaNdis6_Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6_Driver.cpp
@@ -1109,7 +1109,7 @@ DRIVER_INITIALIZE DriverEntry;
 
 static void SetRuntimeNdisVersion()
 {
-#if (NDIS_SUPPORT_NDIS650)
+#if (NDIS_SUPPORT_NDIS680)
     ULONG ul = NdisGetVersion();
     UCHAR major = (UCHAR)(ul >> 16);
     UCHAR minor = ul & 0xff;
@@ -1119,13 +1119,17 @@ static void SetRuntimeNdisVersion()
         major = NDIS_MINIPORT_MAJOR_VERSION;
         minor = NDIS_MINIPORT_MINOR_VERSION;
     }
-    if (minor > NDIS_MINIPORT_MINOR_VERSION)
-    {
-        minor = NDIS_MINIPORT_MINOR_VERSION;
-    }
-    if (minor < NDIS_MINIPORT_MINOR_VERSION)
+    else if (minor < NDIS_MINIPORT_MINOR_VERSION)
     {
         minor = 30;
+    }
+    else if (minor == 83)
+    {
+        // temporary workaround: ack 6.83
+    }
+    else if (minor > NDIS_MINIPORT_MINOR_VERSION)
+    {
+        minor = NDIS_MINIPORT_MINOR_VERSION;
     }
     _ParandisVersion.major = major;
     _ParandisVersion.minor = minor;


### PR DESCRIPTION
HCT OffloadLso test fails when runs after Mini6Performance.
This change may improve the test behavior.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>