### PR TITLE
nekvm: Use standard *JumboPacket instead of private MTU

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -92,7 +92,7 @@ typedef struct _tagConfigurationEntries
     tConfigurationEntry stdLsoV2ip6;
     tConfigurationEntry PriorityVlanTagging;
     tConfigurationEntry VlanId;
-    tConfigurationEntry MTU;
+    tConfigurationEntry JumboPacket;
     tConfigurationEntry NumberOfHandledRXPacketsInDPC;
 #if PARANDIS_SUPPORT_RSS
     tConfigurationEntry RSSOffloadSupported;
@@ -125,7 +125,7 @@ static const tConfigurationEntries defaultConfiguration =
     { "*LsoV2IPv6", 1, 0, 1 },
     { "*PriorityVLANTag", 3, 0, 3},
     { "VlanId", 0, 0, MAX_VLAN_ID},
-    { "MTU", 1500, 576, 65500},
+    { "*JumboPacket", 1514, 590, 65500},
     { "NumberOfHandledRXPacketsInDPC", MAX_RX_LOOPS, 1, 10000},
 #if PARANDIS_SUPPORT_RSS
     { "*RSS", 1, 0, 1},
@@ -254,7 +254,7 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             GetConfigurationEntry(cfg, &pConfiguration->stdLsoV2ip6);
             GetConfigurationEntry(cfg, &pConfiguration->PriorityVlanTagging);
             GetConfigurationEntry(cfg, &pConfiguration->VlanId);
-            GetConfigurationEntry(cfg, &pConfiguration->MTU);
+            GetConfigurationEntry(cfg, &pConfiguration->JumboPacket);
             GetConfigurationEntry(cfg, &pConfiguration->NumberOfHandledRXPacketsInDPC);
 #if PARANDIS_SUPPORT_RSS
             GetConfigurationEntry(cfg, &pConfiguration->RSSOffloadSupported);
@@ -300,7 +300,7 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             pContext->InitialOffloadParameters.LsoV2IPv6 = (UCHAR)pConfiguration->stdLsoV2ip6.ulValue;
             pContext->ulPriorityVlanSetting = pConfiguration->PriorityVlanTagging.ulValue;
             pContext->VlanId = pConfiguration->VlanId.ulValue & 0xfff;
-            pContext->MaxPacketSize.nMaxDataSize = pConfiguration->MTU.ulValue;
+            pContext->MaxPacketSize.nMaxDataSize = pConfiguration->JumboPacket.ulValue - ETH_HEADER_SIZE;
 #if PARANDIS_SUPPORT_RSS
             pContext->bRSSOffloadSupported = pConfiguration->RSSOffloadSupported.ulValue ? TRUE : FALSE;
             pContext->RSSMaxQueuesNumber = (CCHAR) pConfiguration->NumRSSQueues.ulValue;

--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -88,12 +88,12 @@ HKR, Ndi\params\DebugLevel,         min,        0,          "0"
 HKR, Ndi\params\DebugLevel,         max,        0,          "8"
 HKR, Ndi\params\DebugLevel,         step,       0,          "1"
 
-HKR, Ndi\params\MTU,                ParamDesc,  0,          %MTU%
-HKR, Ndi\params\MTU,                type,       0,          "long"
-HKR, Ndi\params\MTU,                default,    0,          "1500"
-HKR, Ndi\params\MTU,                min,        0,          "576"
-HKR, Ndi\params\MTU,                max,        0,          "65500"
-HKR, Ndi\params\MTU,                step,       0,          "1"
+HKR, Ndi\params\*JumboPacket,       ParamDesc,  0,          %JumboPacket%
+HKR, Ndi\params\*JumboPacket,       type,       0,          "long"
+HKR, Ndi\params\*JumboPacket,       default,    0,          "1514"
+HKR, Ndi\params\*JumboPacket,       min,        0,          "590"
+HKR, Ndi\params\*JumboPacket,       max,        0,          "65500"
+HKR, Ndi\params\*JumboPacket,       step,       0,          "1"
 
 HKR, Ndi\params\TxCapacity,         ParamDesc,  0,          %TxCapacity%
 HKR, Ndi\params\TxCapacity,         type,       0,          "enum"
@@ -238,7 +238,7 @@ kvmnet6.Service.DispName    = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Service"
 DiskId1 = "INX_PREFIX_VENDORVirtIO Ethernet Adapter Driver Disk #1"
 NetworkAddress = "Assign MAC"
 Priority = "Init.Do802.1PQ"
-MTU = "Init.MTUSize"
+JumboPacket = "Jumbo Packet"
 TxCapacity = "Init.MaxTxBuffers"
 RxCapacity = "Init.MaxRxBuffers"
 Offload.TxChecksum = "Offload.Tx.Checksum"


### PR DESCRIPTION
*JamboPacket provides the same control over MTU.
The difference is that *JumboPacket includes ethernet header
size while the previous MTU does not.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>