### PR TITLE
[vioscsi] clamp NumberOfPhysicalBreaks against max_sectors

### DIFF
--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -51,6 +51,7 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_MAX_SG            (3+MAX_PHYS_SEGMENTS)
 
 #define SECTOR_SIZE             512
+#define SECTOR_SHIFT            9
 #define IO_PORT_LENGTH          0x40
 #define MAX_CPU                 256
 


### PR DESCRIPTION
Since qemu commit 1bf8a989a566b2ba41c197004ec2a02562a766a4, seg_max
can be adjusted via the parameter virtqueue_size. There's no reason
for us not to at least allow NumberOfPhysicalBreaks to be lowered.

Signed-off-by: Tom Yan <tom.ty89@gmail.com>