### PR TITLE
VIRTIO_F_IOMMU_PLATFORM -> VIRTIO_F_ACCESS_PLATFORM

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -767,9 +767,9 @@ NDIS_STATUS ParaNdis_InitializeContext(
         pContext->u64HostFeatures = virtio_get_features(&pContext->IODevice);
         DumpVirtIOFeatures(pContext);
 
-        // Enable VIRTIO_F_IOMMU_PLATFORM feature on Windows 10 and Windows Server 2016
+        // Enable VIRTIO_F_ACCESS_PLATFORM feature on Windows 10 and Windows Server 2016
 #if (WINVER == 0x0A00)
-        AckFeature(pContext, VIRTIO_F_IOMMU_PLATFORM);
+        AckFeature(pContext, VIRTIO_F_ACCESS_PLATFORM);
 #endif
         AckFeature(pContext, VIRTIO_NET_F_STANDBY);
 

--- a/VirtIO/WDF/VirtIOWdf.c
+++ b/VirtIO/WDF/VirtIOWdf.c
@@ -131,8 +131,8 @@ NTSTATUS VirtIOWdfSetDriverFeatures(PVIRTIO_WDF_DRIVER pWdfDriver,
     if (virtio_is_feature_enabled(uDeviceFeatures, VIRTIO_F_ANY_LAYOUT)) {
         virtio_feature_enable(uFeatures, VIRTIO_F_ANY_LAYOUT);
     }
-    if (virtio_is_feature_enabled(uDeviceFeatures, VIRTIO_F_IOMMU_PLATFORM)) {
-        virtio_feature_enable(uFeatures, VIRTIO_F_IOMMU_PLATFORM);
+    if (virtio_is_feature_enabled(uDeviceFeatures, VIRTIO_F_ACCESS_PLATFORM)) {
+        virtio_feature_enable(uFeatures, VIRTIO_F_ACCESS_PLATFORM);
     }
 
     if ((uDeviceFeatures & uPrivateFeaturesOn) != uPrivateFeaturesOn) {

--- a/VirtIO/WDF/VirtIOWdf.h
+++ b/VirtIO/WDF/VirtIOWdf.h
@@ -89,7 +89,7 @@ NTSTATUS VirtIOWdfInitialize(PVIRTIO_WDF_DRIVER pWdfDriver,
  * the same features are automatically negotiated.
  * If the driver does not have any specific requirements for features
  * it may skip call to VirtIOWdfSetDriverFeatures, then features
- * VIRTIO_F_VERSION_1, VIRTIO_F_ANY_LAYOUT, VIRTIO_F_IOMMU_PLATFORM
+ * VIRTIO_F_VERSION_1, VIRTIO_F_ANY_LAYOUT, VIRTIO_F_ACCESS_PLATFORM
  * are negotiated automatically according to device deatures upon
  * call to VirtIOWdfInitQueues or VirtIOWdfInitQueuesCB
  */

--- a/VirtIO/linux/virtio_config.h
+++ b/VirtIO/linux/virtio_config.h
@@ -62,7 +62,7 @@
 /* v1.0 compliant. */
 #define VIRTIO_F_VERSION_1              32
 
-#define VIRTIO_F_IOMMU_PLATFORM         33
+#define VIRTIO_F_ACCESS_PLATFORM          33
 
 /* This feature indicates support for the packed virtqueue layout. */
 #define VIRTIO_F_RING_PACKED            34

--- a/viofs/pci/power.c
+++ b/viofs/pci/power.c
@@ -64,7 +64,7 @@ NTSTATUS VirtFsEvtDevicePrepareHardware(IN WDFDEVICE Device,
     HostFeatures = VirtIOWdfGetDeviceFeatures(&context->VDevice);
 
     VirtIOWdfSetDriverFeatures(&context->VDevice, GuestFeatures,
-        VIRTIO_F_IOMMU_PLATFORM);
+		VIRTIO_F_ACCESS_PLATFORM);
 
     VirtIOWdfDeviceGet(&context->VDevice,
         FIELD_OFFSET(VIRTIO_FS_CONFIG, RequestQueues),

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -319,8 +319,8 @@ ENTER_FN();
         guestFeatures |= (1ULL << VIRTIO_F_ANY_LAYOUT);
     }
 #if (WINVER == 0x0A00)
-    if (CHECKBIT(adaptExt->features, VIRTIO_F_IOMMU_PLATFORM)) {
-        guestFeatures |= (1ULL << VIRTIO_F_IOMMU_PLATFORM);
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_ACCESS_PLATFORM)) {
+        guestFeatures |= (1ULL << VIRTIO_F_ACCESS_PLATFORM);
     }
 #endif
     if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_EVENT_IDX)) {

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -653,8 +653,8 @@ RhelSetGuestFeatures(
     }
 
 #if (WINVER == 0x0A00)
-    if (CHECKBIT(adaptExt->features, VIRTIO_F_IOMMU_PLATFORM)) {
-        guestFeatures |= (1ULL << VIRTIO_F_IOMMU_PLATFORM);
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_ACCESS_PLATFORM)) {
+        guestFeatures |= (1ULL << VIRTIO_F_ACCESS_PLATFORM);
     }
 #endif
 


### PR DESCRIPTION
According to virtio v1.1 spec: https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html
VIRTIO_F_IOMMU_PLATFORM was renamed to VIRTIO_F_ACCESS_PLATFORM.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1887843
Triggered by: https://lkml.org/lkml/2020/6/28/37

Signed-off-by: Basil Salman <Basil@daynix.com>
Signed-off-by: Basil Salman <bsalman@redhat.com>