### PR TITLE
viostor: 4Kn disk corruption after DISCARD/UNMAP

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1508,12 +1508,15 @@ RhelScsiGetInquiryData(
         if ((CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD)) &&
             (dataLen >= 0x14)) {
             ULONG opt_unmap_granularity = 8;
+            ULONG max_discard_sectors = adaptExt->info.max_discard_sectors / (adaptExt->info.blk_size / SECTOR_SIZE);
+            ULONG discard_sector_alignment = adaptExt->info.discard_sector_alignment / (adaptExt->info.blk_size / SECTOR_SIZE);
+
             pageLen = 0x3c;
-            REVERSE_BYTES(&LimitsPage->MaximumUnmapLBACount, &adaptExt->info.max_discard_sectors);
+            REVERSE_BYTES(&LimitsPage->MaximumUnmapLBACount, &max_discard_sectors);
             REVERSE_BYTES(&LimitsPage->MaximumUnmapBlockDescriptorCount, &adaptExt->info.max_discard_seg);
             REVERSE_BYTES(&LimitsPage->OptimalUnmapGranularity, &opt_unmap_granularity);
-            REVERSE_BYTES(&LimitsPage->UnmapGranularityAlignment, &adaptExt->info.discard_sector_alignment);
-            LimitsPage->UGAValid = adaptExt->info.discard_sector_alignment ? 1 : 0;
+            REVERSE_BYTES(&LimitsPage->UnmapGranularityAlignment, &discard_sector_alignment);
+            LimitsPage->UGAValid = discard_sector_alignment ? 1 : 0;
         }
 #endif
         REVERSE_BYTES_SHORT(&LimitsPage->PageLength, &pageLen);

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -268,8 +268,8 @@ RhelDoUnMap(
         REVERSE_BYTES(&blockDescrLbaCount, BlockDescriptors[i].LbaCount);
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, "Count %d BlockDescrCount = %d blockDescrStartingLba = %llu blockDescrLbaCount = %lu\n",
                      i, BlockDescrCount, blockDescrStartingLba, blockDescrLbaCount);
-        adaptExt->blk_discard[i].sector = blockDescrStartingLba;
-        adaptExt->blk_discard[i].num_sectors = blockDescrLbaCount;
+        adaptExt->blk_discard[i].sector = blockDescrStartingLba * (adaptExt->info.blk_size / SECTOR_SIZE);
+        adaptExt->blk_discard[i].num_sectors = blockDescrLbaCount * (adaptExt->info.blk_size / SECTOR_SIZE);
         adaptExt->blk_discard[i].flags = 0;
     }
 


### PR DESCRIPTION
For DISCARD operation correct disk's sectors into virtio units (512-byte)
and vice versa. For 4Kn virtual disks factor will be 8, for disks with
512-byte sector size factor will be 1.

https://github.com/virtio-win/kvm-guest-drivers-windows/issues/513

Signed-off-by: Vitaliy Gusev <gusev.vitaliy@vstack.com>