### PR TITLE
This PR set supports of PVPANIC_CRASHLOADED in the pvpanic driver

### DIFF
--- a/pvpanic/pvpanic/bugcheck.c
+++ b/pvpanic/pvpanic/bugcheck.c
@@ -36,22 +36,22 @@ KBUGCHECK_CALLBACK_ROUTINE PVPanicOnBugCheck;
 
 VOID PVPanicOnBugCheck(IN PVOID Buffer, IN ULONG Length)
 {
-	if ((Buffer != NULL) && (Length == sizeof(PVOID)))
-	{
-		PUCHAR PortAddress = (PUCHAR)Buffer;
-		WRITE_PORT_UCHAR(PortAddress, (UCHAR)(PVPANIC_PANICKED));
-	}
+    if ((Buffer != NULL) && (Length == sizeof(PVOID)))
+    {
+        PUCHAR PortAddress = (PUCHAR)Buffer;
+        WRITE_PORT_UCHAR(PortAddress, (UCHAR)(PVPANIC_PANICKED));
+    }
 }
 
 BOOLEAN PVPanicRegisterBugCheckCallback(IN PVOID PortAddress)
 {
-	KeInitializeCallbackRecord(&CallbackRecord);
+    KeInitializeCallbackRecord(&CallbackRecord);
 
-	return KeRegisterBugCheckCallback(&CallbackRecord, PVPanicOnBugCheck,
-		(PVOID)PortAddress, sizeof(PVOID), (PUCHAR)("PVPanic"));
+    return KeRegisterBugCheckCallback(&CallbackRecord, PVPanicOnBugCheck,
+        (PVOID)PortAddress, sizeof(PVOID), (PUCHAR)("PVPanic"));
 }
 
 BOOLEAN PVPanicDeregisterBugCheckCallback()
 {
-	return KeDeregisterBugCheckCallback(&CallbackRecord);
+    return KeDeregisterBugCheckCallback(&CallbackRecord);
 }

--- a/pvpanic/pvpanic/power.c
+++ b/pvpanic/pvpanic/power.c
@@ -82,6 +82,7 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
                     context->IoBaseAddress =
                         (PVOID)(ULONG_PTR)desc->u.Port.Start.QuadPart;
                 }
+                PvPanicPortAddress = (PUCHAR)context->IoBaseAddress;
 
                 break;
             }
@@ -101,6 +102,7 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
     if ((features & (PVPANIC_PANICKED | PVPANIC_CRASHLOADED))
                        == (PVPANIC_PANICKED | PVPANIC_CRASHLOADED))
     {
+        bSupportCrashLoaded = TRUE;
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_POWER,
             "PVPANIC_PANICKED and PVPANIC_CRASHLOADED notification features are supported.");
     }

--- a/pvpanic/pvpanic/power.c
+++ b/pvpanic/pvpanic/power.c
@@ -98,7 +98,18 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
     }
 
     features = READ_PORT_UCHAR((PUCHAR)(context->IoBaseAddress));
-    if ((features & PVPANIC_PANICKED) != PVPANIC_PANICKED)
+    if ((features & (PVPANIC_PANICKED | PVPANIC_CRASHLOADED))
+                       == (PVPANIC_PANICKED | PVPANIC_CRASHLOADED))
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_POWER,
+            "PVPANIC_PANICKED and PVPANIC_CRASHLOADED notification features are supported.");
+    }
+    else if ((features & PVPANIC_PANICKED) == PVPANIC_PANICKED)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_POWER,
+            "PVPANIC_PANICKED notification feature is supported.");
+    }
+    else
     {
         TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
             "Panic notification feature is not supported.");

--- a/pvpanic/pvpanic/power.c
+++ b/pvpanic/pvpanic/power.c
@@ -43,7 +43,7 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
 {
     PDEVICE_CONTEXT context = GetDeviceContext(Device);
     PCM_PARTIAL_RESOURCE_DESCRIPTOR desc;
-	UCHAR features;
+    UCHAR features;
     ULONG i;
 
     UNREFERENCED_PARAMETER(Resources);
@@ -97,15 +97,15 @@ NTSTATUS PVPanicEvtDevicePrepareHardware(IN WDFDEVICE Device,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-	features = READ_PORT_UCHAR((PUCHAR)(context->IoBaseAddress));
-	if ((features & PVPANIC_PANICKED) != PVPANIC_PANICKED)
-	{
-		TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER, 
-			"Panic notification feature is not supported.");
-		return STATUS_DEVICE_CONFIGURATION_ERROR;
-	}
+    features = READ_PORT_UCHAR((PUCHAR)(context->IoBaseAddress));
+    if ((features & PVPANIC_PANICKED) != PVPANIC_PANICKED)
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
+            "Panic notification feature is not supported.");
+        return STATUS_DEVICE_CONFIGURATION_ERROR;
+    }
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
 
     return STATUS_SUCCESS;
 }
@@ -127,52 +127,52 @@ NTSTATUS PVPanicEvtDeviceReleaseHardware(IN WDFDEVICE Device,
         context->IoBaseAddress = NULL;
     }
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
 
     return STATUS_SUCCESS;
 }
 
 NTSTATUS PVPanicEvtDeviceD0Entry(IN WDFDEVICE Device,
-								 IN WDF_POWER_DEVICE_STATE PreviousState)
+                                 IN WDF_POWER_DEVICE_STATE PreviousState)
 {
-	PDEVICE_CONTEXT context = GetDeviceContext(Device);
+    PDEVICE_CONTEXT context = GetDeviceContext(Device);
 
-	UNREFERENCED_PARAMETER(PreviousState);
+    UNREFERENCED_PARAMETER(PreviousState);
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "--> %!FUNC! Device: %p",
-		Device);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "--> %!FUNC! Device: %p",
+        Device);
 
-	PAGED_CODE();
+    PAGED_CODE();
 
-	if (PVPanicRegisterBugCheckCallback(context->IoBaseAddress) == FALSE)
-	{
-		TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
-			"Failed to register bug check callback function.");
-	}
+    if (PVPanicRegisterBugCheckCallback(context->IoBaseAddress) == FALSE)
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
+            "Failed to register bug check callback function.");
+    }
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
 
-	return STATUS_SUCCESS;
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS PVPanicEvtDeviceD0Exit(IN WDFDEVICE Device,
-								IN WDF_POWER_DEVICE_STATE TargetState)
+                                IN WDF_POWER_DEVICE_STATE TargetState)
 {
-	UNREFERENCED_PARAMETER(Device);
-	UNREFERENCED_PARAMETER(TargetState);
+    UNREFERENCED_PARAMETER(Device);
+    UNREFERENCED_PARAMETER(TargetState);
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "--> %!FUNC! Device: %p",
-		Device);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "--> %!FUNC! Device: %p",
+        Device);
 
-	PAGED_CODE();
+    PAGED_CODE();
 
-	if (PVPanicDeregisterBugCheckCallback() == FALSE)
-	{
-		TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
-			"Failed to unregister bug check callback function.");
-	}
+    if (PVPanicDeregisterBugCheckCallback() == FALSE)
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
+            "Failed to unregister bug check callback function.");
+    }
 
-	TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "<-- %!FUNC!");
 
-	return STATUS_SUCCESS;
+    return STATUS_SUCCESS;
 }

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -78,7 +78,7 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
     NTSTATUS status;
     WDFDEVICE device;
     WDF_PNPPOWER_EVENT_CALLBACKS pnpPowerCallbacks;
-	WDF_FILEOBJECT_CONFIG fileConfig;
+    WDF_FILEOBJECT_CONFIG fileConfig;
     WDF_OBJECT_ATTRIBUTES attributes;
     WDF_IO_QUEUE_CONFIG queueConfig;
     PDEVICE_CONTEXT context;
@@ -94,18 +94,18 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
 
     pnpPowerCallbacks.EvtDevicePrepareHardware = PVPanicEvtDevicePrepareHardware;
     pnpPowerCallbacks.EvtDeviceReleaseHardware = PVPanicEvtDeviceReleaseHardware;
-	pnpPowerCallbacks.EvtDeviceD0Entry = PVPanicEvtDeviceD0Entry;
-	pnpPowerCallbacks.EvtDeviceD0Exit = PVPanicEvtDeviceD0Exit;
+    pnpPowerCallbacks.EvtDeviceD0Entry = PVPanicEvtDeviceD0Entry;
+    pnpPowerCallbacks.EvtDeviceD0Exit = PVPanicEvtDeviceD0Exit;
 
     WdfDeviceInitSetPnpPowerEventCallbacks(DeviceInit, &pnpPowerCallbacks);
 
-	WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, DEVICE_CONTEXT);
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, DEVICE_CONTEXT);
 
-	WDF_FILEOBJECT_CONFIG_INIT(&fileConfig, PVPanicEvtDeviceFileCreate,
-		WDF_NO_EVENT_CALLBACK, WDF_NO_EVENT_CALLBACK);
+    WDF_FILEOBJECT_CONFIG_INIT(&fileConfig, PVPanicEvtDeviceFileCreate,
+        WDF_NO_EVENT_CALLBACK, WDF_NO_EVENT_CALLBACK);
 
-	WdfDeviceInitSetFileObjectConfig(DeviceInit, &fileConfig,
-		WDF_NO_OBJECT_ATTRIBUTES);
+    WdfDeviceInitSetFileObjectConfig(DeviceInit, &fileConfig,
+        WDF_NO_OBJECT_ATTRIBUTES);
 
     status = WdfDeviceCreate(&DeviceInit, &attributes, &device);
     if (!NT_SUCCESS(status))
@@ -166,13 +166,13 @@ VOID PVPanicEvtDriverContextCleanup(IN WDFOBJECT DriverObject)
 }
 
 VOID PVPanicEvtDeviceFileCreate(IN WDFDEVICE Device,
-								IN WDFREQUEST Request,
-								IN WDFFILEOBJECT FileObject)
+                                IN WDFREQUEST Request,
+                                IN WDFFILEOBJECT FileObject)
 {
-	UNREFERENCED_PARAMETER(Device);
-	UNREFERENCED_PARAMETER(FileObject);
+    UNREFERENCED_PARAMETER(Device);
+    UNREFERENCED_PARAMETER(FileObject);
 
-	WdfRequestComplete(Request, STATUS_SUCCESS);
+    WdfRequestComplete(Request, STATUS_SUCCESS);
 }
 
 VOID PVPanicEvtQueueDeviceControl(IN WDFQUEUE Queue,

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -92,6 +92,10 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
 
     WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&pnpPowerCallbacks);
 
+    PvPanicPortAddress = NULL;
+    bEmitCrashLoadedEvent = FALSE;
+    bSupportCrashLoaded = FALSE;
+
     pnpPowerCallbacks.EvtDevicePrepareHardware = PVPanicEvtDevicePrepareHardware;
     pnpPowerCallbacks.EvtDeviceReleaseHardware = PVPanicEvtDeviceReleaseHardware;
     pnpPowerCallbacks.EvtDeviceD0Entry = PVPanicEvtDeviceD0Entry;

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -47,6 +47,10 @@
 // IOCTLs supported by the symbolic link object.
 #define IOCTL_GET_CRASH_DUMP_HEADER CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_OUT_DIRECT, FILE_ANY_ACCESS)
 
+PUCHAR PvPanicPortAddress;
+BOOLEAN bEmitCrashLoadedEvent;
+BOOLEAN bSupportCrashLoaded;
+
 typedef struct _DEVICE_CONTEXT {
 
     // HW Resources.

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -34,9 +34,11 @@
 
 // The bit of supported PV event.
 #define PVPANIC_F_PANICKED      0
+#define PVPANIC_F_CRASHLOADED   1
 
 // The PV event value.
 #define PVPANIC_PANICKED        (1 << PVPANIC_F_PANICKED)
+#define PVPANIC_CRASHLOADED     (1 << PVPANIC_F_CRASHLOADED)
 
 // Name of the symbolic link object exposed in the guest.
 // The file name visible to user space is "\\.\PVPanicDevice".


### PR DESCRIPTION
This patch set supports PVPANIC_CRASHLOADED in the pvpanic driver, and it contains 3 patches.
The 1/3 patch unifies the code style.
The 2/3 patch requires the patch posted for QEMU - https://lore.kernel.org/qemu-devel/1604346639-27090-1-git-send-email-alejandro.j.jimenez@oracle.com/
In Patch 3/3, when the crash dump is enabled in Windows guest, PVPANIC_CRASHLOADED will be triggered before the crash dump. It indicates a crash dump file will be generated in the guest. Otherwise, PVPANIC_PANICKED will be emitted. This means the guest crashes without a crash dump file created.
