### PR TITLE
balloon: skip reporting to the host when it is not available

### DIFF
--- a/Balloon/sys/ProtoTypes.h
+++ b/Balloon/sys/ProtoTypes.h
@@ -63,6 +63,7 @@ typedef struct _DEVICE_CONTEXT {
     PUCHAR                  PortBase;
     ULONG                   PortCount;
     BOOLEAN                 PortMapped;
+    BOOLEAN                 SurpriseRemoval;
     PKEVENT                 evLowMem;
     HANDLE                  hLowMem;
     VIRTIO_WDF_DRIVER       VDevice;
@@ -120,6 +121,7 @@ EVT_WDF_DEVICE_RELEASE_HARDWARE                BalloonEvtDeviceReleaseHardware;
 EVT_WDF_DEVICE_D0_ENTRY                        BalloonEvtDeviceD0Entry;
 EVT_WDF_DEVICE_D0_EXIT                         BalloonEvtDeviceD0Exit;
 EVT_WDF_DEVICE_D0_EXIT_PRE_INTERRUPTS_DISABLED BalloonEvtDeviceD0ExitPreInterruptsDisabled;
+EVT_WDF_DEVICE_SURPRISE_REMOVAL                BalloonEvtDeviceSurpriseRemoval;
 EVT_WDF_INTERRUPT_ISR                          BalloonInterruptIsr;
 EVT_WDF_INTERRUPT_DPC                          BalloonInterruptDpc;
 EVT_WDF_INTERRUPT_ENABLE                       BalloonInterruptEnable;

--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -270,6 +270,11 @@ BalloonTellHost(
     bool                do_notify;
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_HW_ACCESS, "--> %s\n", __FUNCTION__);
+    if (devCtx->SurpriseRemoval)
+    {
+        TraceEvents(TRACE_LEVEL_WARNING, DBG_HW_ACCESS, "<-- %s Skipped\n", __FUNCTION__);
+        return;
+    }
 
     sg.physAddr = VirtIOWdfDeviceGetPhysicalAddress(&devCtx->VDevice.VIODevice, devCtx->pfns_table);
     sg.length = sizeof(devCtx->pfns_table[0]) * devCtx->num_pfns;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1828654

When the device was surprisingly removed the driver begins
removal flow and the host is not available. The driver
tries to report freed pages, each report takes 1 second
(timeout value), so the driver might not work for several
minutes. Skip reporting to host after surprise removal detected.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>