### PR TITLE
viofs-svc: fix a memory leak on RENAME2 requests

### DIFF
--- a/viofs/svc/virtiofs.c
+++ b/viofs/svc/virtiofs.c
@@ -1513,6 +1513,8 @@ static NTSTATUS Rename(FSP_FILE_SYSTEM *FileSystem, PVOID FileContext0,
         Status = STATUS_ACCESS_DENIED;
     }
 
+    SafeHeapFree(rename2_in);
+
     return Status;
 }
 


### PR DESCRIPTION
Signed-off-by: Gal Hammer <ghammer@redhat.com>