### PR TITLE
vioscsi: add inquiry support for VPD_SUPPORTED_PAGES VPD page

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1926,6 +1926,18 @@ ENTER_FN_SRB();
 
     if (cdb->CDB6INQUIRY3.EnableVitalProductData == 1) {
         switch (cdb->CDB6INQUIRY3.PageCode) {
+            case VPD_SUPPORTED_PAGES: {
+                PVPD_SUPPORTED_PAGES_PAGE SupportPages;
+                SupportPages = (PVPD_SUPPORTED_PAGES_PAGE)SRB_DATA_BUFFER(Srb);
+                memset(SupportPages, 0, sizeof(VPD_SUPPORTED_PAGES_PAGE));
+                SupportPages->PageCode = VPD_SUPPORTED_PAGES;
+                SupportPages->SupportedPageList[0] = VPD_SUPPORTED_PAGES;
+                SupportPages->SupportedPageList[1] = VPD_SERIAL_NUMBER;
+                SupportPages->SupportedPageList[2] = VPD_DEVICE_IDENTIFIERS;
+                SupportPages->PageLength = 3;
+                SRB_SET_DATA_TRANSFER_LENGTH(Srb, (sizeof(VPD_SUPPORTED_PAGES_PAGE) + SupportPages->PageLength));
+            }
+            break;
             case VPD_SERIAL_NUMBER: {
                 PVPD_SERIAL_NUMBER_PAGE SerialPage;
                 SerialPage = (PVPD_SERIAL_NUMBER_PAGE)dataBuffer;


### PR DESCRIPTION
Due to missing inquiry support of VPD_SUPPORTED_PAGES VPD page, Windows may incorrectly detect valid inquiry pages. It can affect certain features. For example, as of Windows 2019 Bitlocker cannot be enabled as it tries to inquiry VPD_BLOCK_LIMITS page, which is not supported.

From kernel (Windows 2019 with vioscsi based off mm201) for vioscsi disk: 
```
1: kd> dt classpnp!_FUNCTIONAL_DEVICE_EXTENSION ffffc08270a367e0 FunctionSupportInfo
   +0x480 FunctionSupportInfo : 0xffffc082`7057ef50 _CLASS_FUNCTION_SUPPORT_INFO

1: kd> dt _CLASS_FUNCTION_SUPPORT_INFO 0xffffc082`7057ef50 ValidInquiryPages.
CLASSPNP!_CLASS_FUNCTION_SUPPORT_INFO
   +0x010 ValidInquiryPages  : 
      +0x000 BlockLimits        : 0y1
      +0x000 BlockDeviceCharacteristics : 0y0
      +0x000 LBProvisioning     : 0y1
      +0x000 BlockDeviceRODLimits : 0y0
      +0x000 Reserved           : 0y0000000000000000000000000000 (0)
```

And when you try to enable Bitlocker it will fail with the below error: 
```[2]0004.0988::10/30/19-14:34:27.6364717 [System ] BitLocker encryption on write failed for volume C: due to disk I/O error. Check the disk for bad sectors. 0xC0000001, C:```

This fix adds support of VPD_SUPPORTED_PAGES VPD page when EVPD is set. The code is simply a copy-paste from viostor. With this patch, classpnp structures do not have BlockLimits set as valid inquiry page: 
```0: kd> dt classpnp!_FUNCTIONAL_DEVICE_EXTENSION ffff810bfa6367e0 FunctionSupportInfo
   +0x480 FunctionSupportInfo : 0xffff810b`fa175e30 _CLASS_FUNCTION_SUPPORT_INFO
0: kd> dt _CLASS_FUNCTION_SUPPORT_INFO 0xffff810b`fa175e30 ValidInquiryPages.
CLASSPNP!_CLASS_FUNCTION_SUPPORT_INFO
   +0x010 ValidInquiryPages  : 
      +0x000 BlockLimits        : 0y0
      +0x000 BlockDeviceCharacteristics : 0y0
      +0x000 LBProvisioning     : 0y0
      +0x000 BlockDeviceRODLimits : 0y0
      +0x000 Reserved           : 0y0000000000000000000000000000 (0)```
