### PR TITLE
Changed WindowsTargetPlatformVersion to $(LatestTargetPlatformVersion)

### DIFF
--- a/ivshmem/test/ivshmem-test.vcxproj
+++ b/ivshmem/test/ivshmem-test.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{87AEE822-FF8B-4743-A567-8B46F4FA6D99}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ivshmemtest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <ProjectName>ivshmem-test</ProjectName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'" Label="Configuration">

--- a/viocrypt/dll/viocrypt-prov.vcxproj
+++ b/viocrypt/dll/viocrypt-prov.vcxproj
@@ -86,7 +86,7 @@
     <ProjectGuid>{F93779E1-51C1-4D12-9DC6-28FF6EB5589B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>viocryptprov</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(Platform)\$(Configuration)\</OutDir>

--- a/viocrypt/test/viocrypt-test.vcxproj
+++ b/viocrypt/test/viocrypt-test.vcxproj
@@ -102,7 +102,7 @@
     <ProjectGuid>{DD9D3949-C1BC-426F-BFDA-D9310B8F9E3F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>viocrypttest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup>

--- a/viofs/svc/virtiofs.vcxproj
+++ b/viofs/svc/virtiofs.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{9D87E5A8-84AE-4775-90B5-CC75CA420670}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>virtiofs</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <ProjectName>virtiofs</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/viorng/test/viorngtest.vcxproj
+++ b/viorng/test/viorngtest.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{8CB5D2D4-F3EA-4568-89A8-DCD332BDCF4E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>viorngtest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Changed WindowsTargetPlatformVersion to \$(LatestTargetPlatformVersion) in all instances where it was hardcoded.

Signed-off-by: Rob Scheepens <rob.scheepens@nutanix.com>