### PR TITLE
[viogpu-dod] disable MSI interrupt in inf file.

### DIFF
--- a/viogpu/viogpudo/viogpudo.h
+++ b/viogpu/viogpudo/viogpudo.h
@@ -108,7 +108,6 @@ public:
     virtual NTSTATUS SetPointerShape(_In_ CONST DXGKARG_SETPOINTERSHAPE* pSetPointerShape, _In_ CONST CURRENT_MODE* pModeCur) = 0;
     virtual NTSTATUS SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION* pSetPointerPosition, _In_ CONST CURRENT_MODE* pModeCur) = 0;
     ULONG GetInstanceId(void) { return m_Id; }
-    BOOLEAN IsPrimaryDevice() { return m_bPrimary; }
     VioGpuDod* GetVioGpu(void) { return m_pVioGpuDod; }
     virtual PBYTE GetEdidData(UINT Idx) = 0;
     virtual PHYSICAL_ADDRESS GetFrameBufferPA(void) = 0;
@@ -124,7 +123,6 @@ protected:
     ULONG  m_Id;
     BYTE m_EDIDs[MAX_CHILDREN][EDID_V1_BLOCK_SIZE];
     BOOLEAN m_bEDID;
-    BOOLEAN m_bPrimary;
 };
 
 class VioGpuAdapter :
@@ -224,6 +222,7 @@ private:
     D3DDDI_VIDEO_PRESENT_SOURCE_ID m_SystemDisplaySourceId;
     DXGKARG_SETPOINTERSHAPE m_PointerShape;
     IVioGpuAdapter* m_pHWDevice;
+    BOOLEAN m_bVgaDevice;
 public:
     VioGpuDod(_In_ DEVICE_OBJECT* pPhysicalDeviceObject);
     ~VioGpuDod(void);
@@ -292,6 +291,7 @@ public:
     PDXGKRNL_INTERFACE GetDxgkInterface(void) { return &m_DxgkInterface; }
 private:
     BOOLEAN CheckHardware();
+    BOOLEAN IsVgaDevice(void) { return m_bVgaDevice; }
     NTSTATUS WriteRegistryString(_In_ HANDLE DevInstRegKeyHandle, _In_ PCWSTR pszwValueName, _In_ PCSTR pszValue);
     NTSTATUS WriteRegistryDWORD(_In_ HANDLE DevInstRegKeyHandle, _In_ PCWSTR pszwValueName, _In_ PDWORD pdwValue);
     NTSTATUS SetSourceModeAndPath(CONST D3DKMDT_VIDPN_SOURCE_MODE* pSourceMode,

--- a/viogpu/viogpudo/viogpudo.h
+++ b/viogpu/viogpudo/viogpudo.h
@@ -40,7 +40,8 @@ typedef struct
 {
     UINT DriverStarted : 1;
     UINT HardwareInit : 1;
-    UINT Unused : 30;
+    UINT PointerEnabled : 1;
+    UINT Unused : 29;
 } DRIVER_STATUS_FLAG;
 
 #pragma pack(pop)
@@ -91,7 +92,6 @@ public:
     USHORT GetModeNumber(USHORT idx) { return m_ModeNumbers[idx]; }
     USHORT GetCurrentModeIndex(void) { return m_CurrentMode; }
     VOID SetCurrentModeIndex(USHORT idx) { m_CurrentMode = idx; }
-    virtual BOOLEAN EnablePointer(void) = 0;
     virtual NTSTATUS ExecutePresentDisplayOnly(_In_ BYTE*             DstAddr,
         _In_ UINT              DstBitPerPixel,
         _In_ BYTE*             SrcAddr,
@@ -136,7 +136,6 @@ public:
     NTSTATUS SetPowerState(DXGK_DEVICE_INFO* pDeviceInfo, DEVICE_POWER_STATE DevicePowerState, CURRENT_MODE* pCurrentMode);
     NTSTATUS HWInit(PCM_RESOURCE_LIST pResList, DXGK_DISPLAY_INFORMATION* pDispInfo);
     NTSTATUS HWClose(void);
-    BOOLEAN EnablePointer(void) { return TRUE; }
     NTSTATUS ExecutePresentDisplayOnly(_In_ BYTE*       DstAddr,
         _In_ UINT              DstBitPerPixel,
         _In_ BYTE*             SrcAddr,
@@ -240,6 +239,14 @@ public:
     {
         m_Flags.HardwareInit = init;
     }
+    BOOLEAN IsPointerEnabled() const
+    {
+        return m_Flags.PointerEnabled;
+    }
+    void SetPointerEnabled(BOOLEAN Enabled)
+    {
+        m_Flags.PointerEnabled = Enabled;
+    }
 #pragma code_seg(pop)
 
     NTSTATUS StartDevice(_In_  DXGK_START_INFO*   pDxgkStartInfo,
@@ -294,6 +301,7 @@ private:
     BOOLEAN IsVgaDevice(void) { return m_bVgaDevice; }
     NTSTATUS WriteRegistryString(_In_ HANDLE DevInstRegKeyHandle, _In_ PCWSTR pszwValueName, _In_ PCSTR pszValue);
     NTSTATUS WriteRegistryDWORD(_In_ HANDLE DevInstRegKeyHandle, _In_ PCWSTR pszwValueName, _In_ PDWORD pdwValue);
+    NTSTATUS ReadRegistryDWORD(_In_ HANDLE DevInstRegKeyHandle, _In_ PCWSTR pszwValueName, _Inout_ PDWORD pdwValue);
     NTSTATUS SetSourceModeAndPath(CONST D3DKMDT_VIDPN_SOURCE_MODE* pSourceMode,
         CONST D3DKMDT_VIDPN_PRESENT_PATH* pPath);
     NTSTATUS AddSingleMonitorMode(_In_ CONST DXGKARG_RECOMMENDMONITORMODES* CONST pRecommendMonitorModes);

--- a/viogpu/viogpudo/viogpudo.inx
+++ b/viogpu/viogpudo/viogpudo.inx
@@ -62,7 +62,7 @@ HKR,,EventMessageFile,%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\IoLogMsg.dll"
 HKR,,TypesSupported,%REG_DWORD%,7
 
 [VioGpuDod_DeviceSettings]
-HKR,, VgaCompatible,               %REG_DWORD%, 0
+HKR,, HWCursor,                    %REG_DWORD%, 0
 
 [VioGpuDod_PCI_MSIX]
 HKR, "Interrupt Management",, 0x00000010

--- a/viogpu/viogpudo/viogpudo.inx
+++ b/viogpu/viogpudo/viogpudo.inx
@@ -67,11 +67,11 @@ HKR,, VgaCompatible,               %REG_DWORD%, 0
 [VioGpuDod_PCI_MSIX]
 HKR, "Interrupt Management",, 0x00000010
 HKR, "Interrupt Management\MessageSignaledInterruptProperties",, 0x00000010
-HKR, "Interrupt Management\MessageSignaledInterruptProperties", MSISupported, 0x00010001, 1
-HKR, "Interrupt Management\MessageSignaledInterruptProperties", MessageNumberLimit, 0x00010001, 16
-HKR, "Interrupt Management\Affinity Policy",, 0x00000010
-HKR, "Interrupt Management\Affinity Policy", DevicePolicy, 0x00010001, 5
-HKR, "Interrupt Management\Affinity Policy", DevicePriority, 0x00010001, 3
+HKR, "Interrupt Management\MessageSignaledInterruptProperties", MSISupported, 0x00010001, 0
+HKR, "Interrupt Management\MessageSignaledInterruptProperties", MessageNumberLimit, 0x00010001, 4
+;HKR, "Interrupt Management\Affinity Policy",, 0x00000010
+;HKR, "Interrupt Management\Affinity Policy", DevicePolicy, 0x00010001, 5
+;HKR, "Interrupt Management\Affinity Policy", DevicePriority, 0x00010001, 3
 
 [Strings]
 


### PR DESCRIPTION
Temp solution for BZ#1918113. For some reason Win8 fails to allocate TranslatedResourceList
member of DXGK_DEVICE_INFO https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/dispmprt/ns-dispmprt-_dxgk_device_info if MSISupported is enabled. Win10 seems to be working fine. I disable MSISupported for now. Going
to investigate this issue in the future.

Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>