### PR TITLE
viofs-svc: fix a slash/backslash typo

### DIFF
--- a/viofs/svc/virtiofs.c
+++ b/viofs/svc/virtiofs.c
@@ -628,7 +628,7 @@ static NTSTATUS VirtFsLookupFileName(HANDLE Device, PWSTR FileName,
     }
     else if (FileName[0] == TEXT('\\'))
     {
-        // Skip slash if exist.
+        // Skip backslash if exist.
         FileName += 1;
     }
 


### PR DESCRIPTION
Signed-off-by: Gal Hammer <ghammer@redhat.com>