### PR TITLE
Viosock: getting the AF value from the driver + fixes for couple of bugs

### DIFF
--- a/viosock/inc/vio_sockets.h
+++ b/viosock/inc/vio_sockets.h
@@ -37,13 +37,32 @@
 
 #include <ws2def.h>
 
-/*VSOCK address family value*/
-#ifndef AF_VSOCK
-#define AF_VSOCK    40
+#define  VIOSOCK_NAME L"\\??\\Viosock"
+
+#ifdef _WINBASE_
+
+#ifndef IOCTL_GET_AF
+#define IOCTL_GET_AF    0x0801300C
 #endif
 
-#ifndef PF_VSOCK
-#define PF_VSOCK    AF_VSOCK
+__inline
+ADDRESS_FAMILY
+ViosockGetAF()
+{
+    DWORD dwAF = AF_UNSPEC;
+    HANDLE hDevice = CreateFileW(VIOSOCK_NAME, GENERIC_READ, FILE_SHARE_READ,
+        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hDevice != INVALID_HANDLE_VALUE)
+    {
+        DWORD dwReturned;
+        if (!DeviceIoControl(hDevice, IOCTL_GET_AF, NULL, 0, &dwAF, sizeof(dwAF),&dwReturned, NULL))
+            dwAF = AF_UNSPEC;
+
+        CloseHandle(hDevice);
+    }
+    return (ADDRESS_FAMILY)dwAF;
+}
 #endif
 
 /* Option name for STREAM socket buffer size.  Use as the option name in

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -861,8 +861,8 @@ VIOSockAccept(
 
     PAGED_CODE();
 
-    status = ObReferenceObjectByHandle(hListenSocket, STANDARD_RIGHTS_REQUIRED, *IoFileObjectType,
-        KernelMode, (PVOID)&pFileObj, NULL);
+    status = ObReferenceObjectByHandle(hListenSocket, FILE_READ_ACCESS, *IoFileObjectType,
+        WdfRequestGetRequestorMode(Request), (PVOID)&pFileObj, NULL);
 
     if (NT_SUCCESS(status))
     {
@@ -872,7 +872,7 @@ VIOSockAccept(
 
         if (!pListenSocket)
         {
-            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Listen socket not found\n");
+            TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Listen socket not found\n");
             status = STATUS_NOT_SOCKET;
         }
         else if (VIOSockStateGet(pListenSocket) != VIOSOCK_STATE_LISTEN)

--- a/viosock/sys/public.h
+++ b/viosock/sys/public.h
@@ -29,7 +29,6 @@
 #if !defined(PUBLIC_H)
 #define PUBLIC_H
 
-#define  VIOSOCK_NAME L"\\??\\Viosock"
 #define  VIOSOCK_SYMLINK_NAME L"\\DosDevices\\Viosock"
 
  // {6B58DC1F-01C3-440F-BE1C-B95D000F1FF5}
@@ -44,6 +43,7 @@ DEFINE_GUID(GUID_DEVINTERFACE_VIOSOCK,
 //device ioctls
 #define IOCTL_GET_CONFIG                DEFINE_DEVICE_IOCTL(1)
 #define IOCTL_SELECT                    DEFINE_DEVICE_IOCTL(2)
+#define IOCTL_GET_AF                    DEFINE_DEVICE_IOCTL(3)
 
 //socket ioctls
 #define IOCTL_SOCKET_BIND               DEFINE_SOCKET_IOCTL(1)
@@ -58,6 +58,15 @@ DEFINE_GUID(GUID_DEVINTERFACE_VIOSOCK,
 #define IOCTL_SOCKET_GET_SOCK_OPT       DEFINE_SOCKET_IOCTL(10)
 #define IOCTL_SOCKET_SET_SOCK_OPT       DEFINE_SOCKET_IOCTL(11)
 #define IOCTL_SOCKET_IOCTL              DEFINE_SOCKET_IOCTL(12)
+
+/*VSOCK address family value*/
+#ifndef AF_VSOCK
+#define AF_VSOCK    40
+#endif
+
+#ifndef PF_VSOCK
+#define PF_VSOCK    AF_VSOCK
+#endif
 
 typedef struct _VIRTIO_VSOCK_CONFIG {
     ULONG32 guest_cid;

--- a/viosock/viosocklib-test/viosocklib-test.c
+++ b/viosock/viosocklib-test/viosocklib-test.c
@@ -327,6 +327,7 @@ SocketConnectTest(
 {
     SOCKET sock = INVALID_SOCKET;
     WSADATA wsaData = { 0 };
+    ADDRESS_FAMILY AF;
 
     int iRes = WSAStartup(MAKEWORD(2, 2), &wsaData);
 
@@ -336,13 +337,21 @@ SocketConnectTest(
         return 1;
     }
 
+    AF = ViosockGetAF();
+    if (AF == AF_UNSPEC)
+    {
+        _tprintf(_T("ViosockGetAF failed: %d\n"), GetLastError());
+        return 3;
+    }
+
     _tprintf(_T("socket(AF_VSOCK, SOCK_STREAM, 0)\n"));
-    sock = socket(AF_VSOCK, SOCK_STREAM, 0);
+    sock = socket(AF, SOCK_STREAM, 0);
     if (sock != INVALID_SOCKET)
     {
         if (addr->svm_cid == VMADDR_CID_ANY)
             addr->svm_cid = VMADDR_CID_HOST;
 
+        addr->svm_family = AF;
         if (ERROR_SUCCESS == connect(sock, (struct sockaddr*)addr, sizeof(*addr)))
         {
             PVOID Buffer;
@@ -391,6 +400,7 @@ SocketListenTest(
 {
     SOCKET sock = INVALID_SOCKET;
     WSADATA wsaData = { 0 };
+    ADDRESS_FAMILY AF;
 
     int iRes = WSAStartup(MAKEWORD(2, 2), &wsaData);
 
@@ -406,10 +416,19 @@ SocketListenTest(
         return 2;
     }
 
+    AF = ViosockGetAF();
+    if (AF == AF_UNSPEC)
+    {
+        _tprintf(_T("ViosockGetAF failed: %d\n"), GetLastError());
+        return 3;
+    }
+
     _tprintf(_T("socket(AF_VSOCK, SOCK_STREAM, 0)\n"));
-    sock = socket(AF_VSOCK, SOCK_STREAM, 0);
+    sock = socket(AF, SOCK_STREAM, 0);
     if (sock != INVALID_SOCKET)
     {
+        addr->svm_family = AF;
+
         if (ERROR_SUCCESS == bind(sock, (struct sockaddr*)addr, sizeof(*addr)))
         {
             if (ERROR_SUCCESS == listen(sock, 10))
@@ -502,7 +521,6 @@ ParseAddr(
         }
     }
 
-    addr->svm_family = AF_VSOCK;
     return TRUE;
 }
 


### PR DESCRIPTION
The Viosock provider uses AF_VSOCK == 40 just because it was copied from Linux and does not conflict with the AFs currently defined for Windows. However, there may be conflicts with third party socket providers and in the future with new AF supported by Windows. Until MS adds AF_VSOCK to ws2def.h, the best solution would be to request the AF value from the viosock driver itself. At the moment, the driver returns a constant value of 40, dynamic calculation will be implemented later. See Viosocklib-test project to find out how to use sockets with dynamic AF.