### PR TITLE
pvpanic: support pvpanic event properly

### DIFF
--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -94,7 +94,7 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
 
     PvPanicPortAddress = NULL;
     bEmitCrashLoadedEvent = FALSE;
-    bSupportCrashLoaded = FALSE;
+    SupportedFeature = 0;
 
     pnpPowerCallbacks.EvtDevicePrepareHardware = PVPanicEvtDevicePrepareHardware;
     pnpPowerCallbacks.EvtDeviceReleaseHardware = PVPanicEvtDeviceReleaseHardware;

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -49,7 +49,7 @@
 
 PUCHAR PvPanicPortAddress;
 BOOLEAN bEmitCrashLoadedEvent;
-BOOLEAN bSupportCrashLoaded;
+UCHAR   SupportedFeature;
 
 typedef struct _DEVICE_CONTEXT {
 
@@ -78,8 +78,8 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 // Bug check callback registration functions.
 //
 
-BOOLEAN PVPanicRegisterBugCheckCallback(IN PVOID PortAddress);
-BOOLEAN PVPanicDeregisterBugCheckCallback();
+VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress);
+VOID PVPanicDeregisterBugCheckCallback();
 
 //
 // WDFDRIVER events.


### PR DESCRIPTION
The following qemu patch advertises the 'PVPANIC_CRASHLOADED'
event,

https://lore.kernel.org/qemu-devel/20201109143311.1000958-1-pbonzini@redhat.com/

a custom set of supported events can be specified in the pvpanic
device command line options, e.g.:

-device pvpanic,events=<#>

The supported value of events is 1, 2 or 3, setting events value
other than these 3 values will cause Windows pvpanic driver failure.
Further restrictions of setting these values should be done in QEMU
side to avoid the failure in Windows pvpanic driver.

The pvpanic driver reads the property(events) supported by the
pvpanic device. When Windows guest crashes, the driver triggers
the following events based on the event value retrieved:

event   crashdump enabled        crashdump disabled
   1    PVPANIC_PANICKED         PVPANIC_PANICKED
   2    PVPANIC_CRASHLOADED      no event triggered
   3    PVPANIC_CRASHLOADED      PVPANIC_PANICKED

For older qemu which only advertises 'PVPANIC_PANICKED' event, the
event triggered is same as the result of 'event = 1'.

In case of 'event = 2', 'PVPANIC_CRASHLOADED' is for user who
specifically intends to get the notification when the crashdump
file is being generated. So when the crashdump is disabled inside
the Windows guest, there is no events gets triggered.

The discussion of this issue is in the following link,

https://github.com/virtio-win/kvm-guest-drivers-windows/pull/516

Reported-by: Yan Vugenfirer <yvugenfi@redhat.com>
Signed-off-by: Annie Li annie.li@oracle.com
Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
Reviewed-by: Alejandro Jimenez <alejandro.j.jimenez@oracle.com>