### PR TITLE
[vioserial] Bugfix for BZ#1802466 There is no need in making write request cancelable

### DIFF
--- a/vioserial/sys/Buffer.c
+++ b/vioserial/sys/Buffer.c
@@ -107,22 +107,6 @@ DmaWriteCallback(PVIRTIO_DMA_TRANSACTION_PARAMS params)
         goto error;
     }
 
-    status = WdfRequestMarkCancelableEx(Entry->Request,
-        VIOSerialPortWriteRequestCancel);
-
-    if (!NT_SUCCESS(status))
-    {
-        /* complete the request only */
-        WDFREQUEST req = Entry->Request;
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE,
-            "Failed to mark request %p as cancelable: %x\n", req, status);
-        Entry->Request = NULL;
-        WdfSpinLockRelease(Port->OutVqLock);
-        WdfRequestComplete(req, status);
-        /* the rest will be freed on packet completion */
-        return FALSE;
-    }
-
     WdfSpinLockRelease(Port->OutVqLock);
 
     if (prepared)
@@ -242,17 +226,6 @@ BOOLEAN VIOSerialReclaimConsumedBuffers(IN PVIOSERIAL_PORT Port)
 
                 if (buffer == entry)
                 {
-                    if (entry->Request != NULL)
-                    {
-                        request = entry->Request;
-                        if (WdfRequestUnmarkCancelable(request) == STATUS_CANCELLED)
-                        {
-                            TraceEvents(TRACE_LEVEL_INFORMATION, DBG_QUEUEING,
-                                "Request %p was cancelled.\n", request);
-                            entry->Request = NULL;
-                        }
-                    }
-
                     // remove from WriteBuffersList
                     iter->Next = entry->ListEntry.Next;
 


### PR DESCRIPTION
Especially from DMA write callback when this request is processing by QEMU.

Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>