### PR TITLE
viofs-svc: fix commit 298ff119 (resolve links on path walkthough)

### DIFF
--- a/viofs/svc/virtiofs.c
+++ b/viofs/svc/virtiofs.c
@@ -637,6 +637,8 @@ static NTSTATUS PathWalkthough(HANDLE Device, CHAR *FullPath,
                 break;
             }
 
+            SubstituteName[SubstituteNameLength] = L'\0';
+
             Status = VirtFsLookupFileName(Device, SubstituteName, &LookupOut);
             if (!NT_SUCCESS(Status))
             {


### PR DESCRIPTION
File's path was not null-terminated in the Lookup request.

Signed-off-by: Gal Hammer <ghammer@redhat.com>