### PR TITLE
vioscsi: Increasing max phys breaks to 512

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -209,7 +209,6 @@ ENTER_FN();
 
     srbExt->psgl = srbExt->vio_sg;
     srbExt->pdesc = srbExt->desc_alias;
-    srbExt->allocated = 0;
     sgElement = 0;
     srbExt->psgl[sgElement].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &cmd->req.tmf, &fragLen);
     srbExt->psgl[sgElement].length   = sizeof(cmd->req.tmf);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1322,7 +1322,6 @@ ENTER_FN_SRB();
     srbExt->psgl = srbExt->vio_sg;
     srbExt->pdesc = srbExt->desc_alias;
 
-    srbExt->allocated = 0;
 #ifdef USE_CPU_TO_VQ_MAP
     srbExt->cpu = (UCHAR)cpu;
 #endif
@@ -1587,16 +1586,6 @@ ENTER_FN_SRB();
            break;
 
     }
-#if (NTDDI_VERSION > NTDDI_WIN7)
-    srbExt = SRB_EXTENSION(Srb);
-    if (srbExt && (srbExt->allocated > 0)) {
-        StorPortFreePool(DeviceExtension, srbExt->psgl);
-        StorPortFreeContiguousMemorySpecifyCache(DeviceExtension, srbExt->pdesc, sizeof(VRING_DESC_ALIAS) * (srbExt->allocated), MmCached);
-        srbExt->allocated = 0;
-        srbExt->psgl = srbExt->vio_sg;
-        srbExt->pdesc = srbExt->desc_alias;
-    }
-#endif
 EXIT_FN_SRB();
 }
 

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -245,7 +245,6 @@ typedef struct _SRB_EXTENSION {
     ULONG                 Xfer;
     VirtIOSCSICmd         cmd;
     ULONG                 vq_num;
-    ULONG                 allocated;
     PVIO_SG               psgl;
     PVRING_DESC_ALIAS     pdesc;
     VIO_SG                vio_sg[VIRTIO_MAX_SG];

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -45,10 +45,13 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_SCSI_CDB_SIZE   32
 #define VIRTIO_SCSI_SENSE_SIZE 96
 
+#if (NTDDI_VERSION > NTDDI_WIN7)
+#define MAX_PHYS_SEGMENTS       512
+#else
 #define MAX_PHYS_SEGMENTS       64
-#define MAX_PHYS_INDIRECT_SEGMENTS 256
+#endif
 #define VIOSCSI_POOL_TAG        'SoiV'
-#define VIRTIO_MAX_SG            (3+MAX_PHYS_SEGMENTS)
+#define VIRTIO_MAX_SG            (1+1+MAX_PHYS_SEGMENTS+1) //cmd + resp + (MAX_PHYS_SEGMENTS + extra_page)
 
 #define SECTOR_SIZE             512
 #define IO_PORT_LENGTH          0x40


### PR DESCRIPTION
The maximum block size has been increased to 512 pages and is now the same as Viostor's maximum block size. This can give io performance gains of up to 30% on fast storage. Dynamic memory allocation for sglist has been removed because the SRB extension now has enough pre-allocated space to hold the complete sglist. In addition, there was a bug in this code that led to unnecessary allocation and copying for requests of MAX_PHYS_SEGMENTS size, which also reduced performance.
We found that in some cases Vioscsi is up to 4 times slower than Viostore, setting the same number of max physical breaks (512) reduces this difference up to 2,5 times. :)
PS: Several months ago, @vrozenfe kindly suggested increasing the number of physical breaks to 512, but then it seemed unnecessary.