### PR TITLE
NetKVM: RHBZ#1979024: restrict max VLAN ID to 4094

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -40,7 +40,7 @@ static VOID ParaNdis_UpdateMAC(PARANDIS_ADAPTER *pContext);
 
 static __inline pRxNetDescriptor ReceiveQueueGetBuffer(PPARANDIS_RECEIVE_QUEUE pQueue);
 
-#define MAX_VLAN_ID     4095
+#define MAX_VLAN_ID     4094
 
 /**********************************************************
 Validates MAC address
@@ -1899,8 +1899,8 @@ static VOID SetAllVlanFilters(PARANDIS_ADAPTER *pContext, BOOLEAN bOn)
 /*
     possible values of filter set (pContext->ulCurrentVlansFilterSet):
     0 - all disabled
-    1..4095 - one selected enabled
-    4096 - all enabled
+    1..4094 - one selected enabled
+    4095 - all enabled
     Note that only 0th vlan can't be enabled
 */
 VOID ParaNdis_DeviceFiltersUpdateVlanId(PARANDIS_ADAPTER *pContext)

--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -73,7 +73,7 @@ HKR, Ndi\params\VlanID,         ParamDesc,  0,          %VLan_ID%
 HKR, Ndi\params\VlanID,         type,       0,          "int"
 HKR, Ndi\params\VlanID,         default,    0,          "0"
 HKR, Ndi\params\VlanID,         min,        0,          "0"
-HKR, Ndi\params\VlanID,         max,        0,          "4095"
+HKR, Ndi\params\VlanID,         max,        0,          "4094"
 
 HKR, Ndi\Params\DoLog,              ParamDesc,  0,          %EnableLogging%
 HKR, Ndi\Params\DoLog,              Default,    0,          "1"


### PR DESCRIPTION
NetKVM treats VLAN ID = 4095 as well as IDs from 1-4094, that is frames
with ID = 4095 pass and others don't. According to IEEE 802.1Q, 4095
can't be valid VLAN ID. Also, Win2022 HLK assumes that NDIS accepts
ID <= 4094.

Signed-off-by: Viktor Prutyanov <viktor.prutyanov@phystech.edu>