### PR TITLE
NetKVM: Cap max length of the packet with NB size

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -960,6 +960,8 @@ ULONG CNB::Copy(PVOID Dst, ULONG Length) const
     ULONG CurrOffset = NET_BUFFER_CURRENT_MDL_OFFSET(m_NB);
     ULONG Copied = 0;
 
+    Length = min(Length, NET_BUFFER_DATA_LENGTH(m_NB));
+
     for (PMDL CurrMDL = NET_BUFFER_CURRENT_MDL(m_NB);
          CurrMDL != nullptr && Copied < Length;
          CurrMDL = CurrMDL->Next)


### PR DESCRIPTION
It was noticed that as of build 20241 the sum of lengths of MDLs in NET_BUFFER
can be greater than the size of NET_BUFFER itself. As the result, the size of the
packet can be calculated incorrectly.

Instead of using the sum of MDLs lengths, we can cap the max length with the size
of NET_BUFFER.

Bug: https://github.com/virtio-win/kvm-guest-drivers-windows/issues/583

This PR is to also run HLK tests by CI. 