### PR TITLE
Balloon: RHBZ#1826336: add security descriptor string

### DIFF
--- a/Balloon/sys/balloon.inx
+++ b/Balloon/sys/balloon.inx
@@ -53,6 +53,11 @@ CopyFiles=Drivers_Dir
 [Drivers_Dir]
 balloon.sys
 
+[BALLOON_Device.NT.HW]
+AddReg=BALLOON_SD
+
+[BALLOON_SD]
+HKR,,Security,,"D:P(A;;GA;;;SY)"
 
 ;-------------- Service installation
 [BALLOON_Device.NT.Services]


### PR DESCRIPTION
According to Microsoft Driver Security Guidance, access to the device object should be controlled by SDDL string.

Kernel-mode code and user-mode code running as System is allowed to open the device for any access with `"D:P(A;;GA;;;SY)"`:

```
SIDs:
[SY] - Local System Account

Rights:
[GA] - Generic All
```