### PR TITLE
PVPanic: RHBZ#1826336: revert "pvpanic: Add IOCTL_GET_CRASH_DUMP_HEADER"

### DIFF
--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -80,9 +80,6 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
     WDF_PNPPOWER_EVENT_CALLBACKS pnpPowerCallbacks;
     WDF_FILEOBJECT_CONFIG fileConfig;
     WDF_OBJECT_ATTRIBUTES attributes;
-    WDF_IO_QUEUE_CONFIG queueConfig;
-    PDEVICE_CONTEXT context;
-    DECLARE_CONST_UNICODE_STRING(dosDeviceName, PVPANIC_DOS_DEVICE_NAME);
 
     UNREFERENCED_PARAMETER(Driver);
 
@@ -119,39 +116,6 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
         return status;
     }
 
-    status = WdfDeviceCreateSymbolicLink(device, &dosDeviceName);
-    if (!NT_SUCCESS(status))
-    {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
-            "WdfDeviceCreateSymbolicLink failed: %!STATUS!", status);
-        return status;
-    }
-
-    WDF_IO_QUEUE_CONFIG_INIT(&queueConfig, WdfIoQueueDispatchSequential);
-    queueConfig.EvtIoDeviceControl = PVPanicEvtQueueDeviceControl;
-
-    context = GetDeviceContext(device);
-    status = WdfIoQueueCreate(device,
-                              &queueConfig,
-                              WDF_NO_OBJECT_ATTRIBUTES,
-                              &context->IoctlQueue);
-    if (!NT_SUCCESS(status))
-    {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
-            "WdfIoQueueCreate failed: %!STATUS!", status);
-        return status;
-    }
-
-    status = WdfDeviceConfigureRequestDispatching(device,
-                                                  context->IoctlQueue,
-                                                  WdfRequestTypeDeviceControl);
-    if (!NT_SUCCESS(status))
-    {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
-            "WdfDeviceConfigureRequestDispatching failed: %!STATUS!", status);
-        return status;
-    }
-
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_INIT, "<-- %!FUNC!");
 
     return status;
@@ -176,52 +140,5 @@ VOID PVPanicEvtDeviceFileCreate(IN WDFDEVICE Device,
     UNREFERENCED_PARAMETER(Device);
     UNREFERENCED_PARAMETER(FileObject);
 
-    WdfRequestComplete(Request, STATUS_SUCCESS);
-}
-
-VOID PVPanicEvtQueueDeviceControl(IN WDFQUEUE Queue,
-                                  IN WDFREQUEST Request,
-                                  IN size_t OutputBufferLength,
-                                  IN size_t InputBufferLength,
-                                  IN ULONG IoControlCode)
-{
-    NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
-    ULONG    length = 0;
-    PVOID    buffer;
-    size_t   buffer_length;
-
-    UNREFERENCED_PARAMETER(Queue);
-    UNREFERENCED_PARAMETER(InputBufferLength);
-    UNREFERENCED_PARAMETER(OutputBufferLength);
-
-    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_IOCTLS, "--> %!FUNC!");
-
-    switch (IoControlCode)
-    {
-    case IOCTL_GET_CRASH_DUMP_HEADER:
-    {
-        // Return the full result of KeInitializeCrashDumpHeader.
-        status = WdfRequestRetrieveOutputBuffer(Request, 0, &buffer, &buffer_length);
-        if (!NT_SUCCESS(status))
-        {
-            TraceEvents(TRACE_LEVEL_ERROR, DBG_IOCTLS,
-                "WdfRequestRetrieveInputBuffer failed: %!STATUS!", status);
-            break;
-        }
-
-        status = KeInitializeCrashDumpHeader(DUMP_TYPE_FULL,
-                                             0, // flags, must be 0
-                                             buffer,
-                                             (ULONG)buffer_length,
-                                             &length);
-        if (status == STATUS_INVALID_PARAMETER_4)
-        {
-            status = STATUS_BUFFER_TOO_SMALL;
-        }
-        break;
-    }
-    }
-
-    WdfRequestCompleteWithInformation(Request, status, NT_SUCCESS(status) ? length : 0);
-    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_IOCTLS, "<-- %!FUNC!");
+    WdfRequestComplete(Request, STATUS_ACCESS_DENIED);
 }

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -40,13 +40,6 @@
 #define PVPANIC_PANICKED        (1 << PVPANIC_F_PANICKED)
 #define PVPANIC_CRASHLOADED     (1 << PVPANIC_F_CRASHLOADED)
 
-// Name of the symbolic link object exposed in the guest.
-// The file name visible to user space is "\\.\PVPanicDevice".
-#define PVPANIC_DOS_DEVICE_NAME L"\\DosDevices\\Global\\PVPanicDevice"
-
-// IOCTLs supported by the symbolic link object.
-#define IOCTL_GET_CRASH_DUMP_HEADER CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_OUT_DIRECT, FILE_ANY_ACCESS)
-
 PUCHAR PvPanicPortAddress;
 BOOLEAN bEmitCrashLoadedEvent;
 UCHAR   SupportedFeature;
@@ -58,17 +51,9 @@ typedef struct _DEVICE_CONTEXT {
     ULONG               IoRange;
     BOOLEAN             MappedPort;
 
-    // IOCTL request queue.
-    WDFQUEUE            IoctlQueue;
-
 } DEVICE_CONTEXT, *PDEVICE_CONTEXT;
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
-
-#define PVPANIC_DRIVER_MEMORY_TAG (ULONG)'npVP'
-
-// Referenced in MSDN but not declared in SDK/WDK headers.
-#define DUMP_TYPE_FULL 1
 
 #ifndef _IRQL_requires_
 #define _IRQL_requires_(level)
@@ -99,4 +84,3 @@ EVT_WDF_DEVICE_D0_ENTRY PVPanicEvtDeviceD0Entry;
 EVT_WDF_DEVICE_D0_EXIT PVPanicEvtDeviceD0Exit;
 
 EVT_WDF_DEVICE_FILE_CREATE PVPanicEvtDeviceFileCreate;
-EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL PVPanicEvtQueueDeviceControl;

--- a/pvpanic/pvpanic/trace.h
+++ b/pvpanic/pvpanic/trace.h
@@ -39,7 +39,6 @@
         WPP_DEFINE_BIT(DBG_ALL)         \
         WPP_DEFINE_BIT(DBG_INIT)        \
         WPP_DEFINE_BIT(DBG_POWER)       \
-        WPP_DEFINE_BIT(DBG_IOCTLS)      \
     )
 
 #define WPP_FLAG_LEVEL_LOGGER(flag, level) \


### PR DESCRIPTION
First of all, according to Microsoft Driver Security Guidance driver shouldn't provide named device object (`\\.\PVPanicDevice`). Besides of that, no one uses PVPanic device in userspace. So, remove device object symbolic link.