### PR TITLE
fwcfg: fix issues found by CodeQL

### DIFF
--- a/fwcfg64/driver.c
+++ b/fwcfg64/driver.c
@@ -72,7 +72,7 @@ NTSTATUS GetKdbg(PDEVICE_CONTEXT ctx)
     CONTEXT context = { 0 };
     NTSTATUS status = STATUS_SUCCESS;
 
-    minidump = ExAllocatePoolWithTag(NonPagedPoolNx, 0x40000, 'pmdm');
+    minidump = ExAllocatePoolUninitialized(NonPagedPoolNx, 0x40000, 'pmdm');
     if (!minidump)
     {
          return STATUS_MEMORY_NOT_ALLOCATED;
@@ -87,7 +87,7 @@ NTSTATUS GetKdbg(PDEVICE_CONTEXT ctx)
         "KdDebuggerDataBlock size = %lx, offset = 0x%lx",
         kdbg_size, kdbg_offset);
 
-    ctx->kdbg = ExAllocatePoolWithTag(NonPagedPoolNx, kdbg_size, 'gbdk');
+    ctx->kdbg = ExAllocatePoolUninitialized(NonPagedPoolNx, kdbg_size, 'gbdk');
     if (!ctx->kdbg)
     {
         status = STATUS_MEMORY_NOT_ALLOCATED;

--- a/fwcfg64/fwcfg.c
+++ b/fwcfg64/fwcfg.c
@@ -92,7 +92,7 @@ UINT32 FWCfgGetEntriesNum(PVOID ioBase)
 NTSTATUS FWCfgFindEntry(PVOID ioBase, const char *name,
                         PUSHORT index, ULONG size)
 {
-    UINT16 i;
+    UINT32 i;
     UINT32 total = FWCfgGetEntriesNum(ioBase);
     FWCfgFile f;
 


### PR DESCRIPTION
- Replace ExAllocatePoolWithTag by ExAllocatePoolUninitialized
- Fix comparison of different types