### PR TITLE
Fix issues found by CodeQL

### DIFF
--- a/fwcfg64/driver.c
+++ b/fwcfg64/driver.c
@@ -72,7 +72,7 @@ NTSTATUS GetKdbg(PDEVICE_CONTEXT ctx)
     CONTEXT context = { 0 };
     NTSTATUS status = STATUS_SUCCESS;
 
-    minidump = ExAllocatePoolWithTag(NonPagedPoolNx, 0x40000, 'pmdm');
+    minidump = ExAllocatePoolUninitialized(NonPagedPoolNx, 0x40000, 'pmdm');
     if (!minidump)
     {
          return STATUS_MEMORY_NOT_ALLOCATED;
@@ -87,7 +87,7 @@ NTSTATUS GetKdbg(PDEVICE_CONTEXT ctx)
         "KdDebuggerDataBlock size = %lx, offset = 0x%lx",
         kdbg_size, kdbg_offset);
 
-    ctx->kdbg = ExAllocatePoolWithTag(NonPagedPoolNx, kdbg_size, 'gbdk');
+    ctx->kdbg = ExAllocatePoolUninitialized(NonPagedPoolNx, kdbg_size, 'gbdk');
     if (!ctx->kdbg)
     {
         status = STATUS_MEMORY_NOT_ALLOCATED;

--- a/fwcfg64/fwcfg.c
+++ b/fwcfg64/fwcfg.c
@@ -92,7 +92,7 @@ UINT32 FWCfgGetEntriesNum(PVOID ioBase)
 NTSTATUS FWCfgFindEntry(PVOID ioBase, const char *name,
                         PUSHORT index, ULONG size)
 {
-    UINT16 i;
+    UINT32 i;
     UINT32 total = FWCfgGetEntriesNum(ioBase);
     FWCfgFile f;
 

--- a/vioserial/sys/Buffer.c
+++ b/vioserial/sys/Buffer.c
@@ -21,14 +21,14 @@ VIOSerialAllocateSinglePageBuffer(
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_QUEUEING, "--> %s\n", __FUNCTION__);
 
-    buf = ExAllocatePoolWithTag(
+    buf = ExAllocatePoolUninitialized(
                                  NonPagedPool,
                                  sizeof(PORT_BUFFER),
                                  VIOSERIAL_DRIVER_MEMORY_TAG
                                  );
     if (buf == NULL)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_QUEUEING, "ExAllocatePoolWithTag failed, %s::%d\n", __FUNCTION__, __LINE__);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_QUEUEING, "ExAllocatePoolUninitialized failed, %s::%d\n", __FUNCTION__, __LINE__);
         return NULL;
     }
     buf->va_buf = VirtIOWdfDeviceAllocDmaMemory(vdev, buf_size, id);
@@ -145,7 +145,7 @@ VIOSerialFreeBuffer(
 VOID VIOSerialProcessInputBuffers(IN PVIOSERIAL_PORT Port)
 {
     NTSTATUS status;
-    ULONG Read;
+    ULONG Read = 0;
     WDFREQUEST Request = NULL;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_QUEUEING, "--> %s\n", __FUNCTION__);

--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -280,18 +280,18 @@ VIOSerialEvtDevicePrepareHardware(
     }
 
     nr_ports = pContext->consoleConfig.max_nr_ports;
-    pContext->in_vqs = (struct virtqueue**)ExAllocatePoolWithTag(
+    pContext->in_vqs = (struct virtqueue**)ExAllocatePoolUninitialized(
                                  NonPagedPool,
                                  nr_ports * sizeof(struct virtqueue*),
                                  VIOSERIAL_DRIVER_MEMORY_TAG);
 
     if(pContext->in_vqs == NULL)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,"ExAllocatePoolWithTag failed\n");
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "ExAllocatePoolUninitialized failed\n");
         return STATUS_INSUFFICIENT_RESOURCES;
     }
     memset(pContext->in_vqs, 0, nr_ports * sizeof(struct virtqueue*));
-    pContext->out_vqs = (struct virtqueue**)ExAllocatePoolWithTag(
+    pContext->out_vqs = (struct virtqueue**)ExAllocatePoolUninitialized(
                                  NonPagedPool,
                                  nr_ports * sizeof(struct virtqueue*),
                                  VIOSERIAL_DRIVER_MEMORY_TAG
@@ -299,7 +299,7 @@ VIOSerialEvtDevicePrepareHardware(
 
     if(pContext->out_vqs == NULL)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "ExAllocatePoolWithTag failed\n");
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "ExAllocatePoolUninitialized failed\n");
         return STATUS_INSUFFICIENT_RESOURCES;
     }
     memset(pContext->out_vqs, 0, nr_ports * sizeof(struct virtqueue*));

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -980,7 +980,7 @@ VIOSerialPortCreateName(
         length = buf->len - buf->offset - sizeof(VIRTIO_CONSOLE_CONTROL);
         port->NameString.Length = (USHORT)( length );
         port->NameString.MaximumLength = port->NameString.Length + 1;
-        port->NameString.Buffer = (PCHAR)ExAllocatePoolWithTag(
+        port->NameString.Buffer = (PCHAR)ExAllocatePoolUninitialized(
                                  NonPagedPool,
                                  port->NameString.MaximumLength,
                                  VIOSERIAL_DRIVER_MEMORY_TAG
@@ -1158,7 +1158,7 @@ VIOSerialPortPnpNotifyWork(
     if (NT_SUCCESS(status))
     {
         notification = (PTARGET_DEVICE_CUSTOM_NOTIFICATION)
-                       ExAllocatePoolWithTag(NonPagedPool,
+                       ExAllocatePoolUninitialized(NonPagedPool,
                                  requiredSize,
                                  VIOSERIAL_DRIVER_MEMORY_TAG);
 
@@ -1228,7 +1228,7 @@ VIOSerialEvtChildListIdentificationDescriptionDuplicate(
         // sure that we're not allocating from paged pool here.
         _Analysis_assume_(NonPagedPool == NonPagedPoolNx);
 
-        dst->NameString.Buffer = (PCHAR)ExAllocatePoolWithTag(
+        dst->NameString.Buffer = (PCHAR)ExAllocatePoolUninitialized(
                                  NonPagedPool,
                                  dst->NameString.MaximumLength,
                                  VIOSERIAL_DRIVER_MEMORY_TAG


### PR DESCRIPTION
FwCfg, VirtIOSerial:
* Replace ExAllocatePoolWithTag by ExAllocatePoolUninitialized
* Fix comparison of different types
* Fix uninitialized variable