### PR TITLE
Fix issues found by SDV in Balloon and VirtIOSerial

### DIFF
--- a/Balloon/sys/queue.c
+++ b/Balloon/sys/queue.c
@@ -121,16 +121,21 @@ VOID BalloonIoStop(IN WDFQUEUE Queue,
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_READ,
         "--> %!FUNC! Request: %p", Request);
 
-    if (ActionFlags & WdfRequestStopActionSuspend)
+    if (WdfRequestUnmarkCancelable(Request) == STATUS_CANCELLED)
     {
         WdfRequestStopAcknowledge(Request, FALSE);
     }
+    else if (ActionFlags & WdfRequestStopActionSuspend)
+    {
+        WdfRequestStopAcknowledge(Request, TRUE);
+    }
     else if (ActionFlags & WdfRequestStopActionPurge)
     {
-        if (WdfRequestUnmarkCancelable(Request) != STATUS_CANCELLED)
-        {
-            WdfRequestComplete(Request, STATUS_CANCELLED);
-        }
+        WdfRequestComplete(Request, STATUS_CANCELLED);
+    }
+    else
+    {
+        WdfRequestComplete(Request, STATUS_UNSUCCESSFUL);
     }
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_READ, "<-- %!FUNC!");

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1346,37 +1346,37 @@ VOID VIOSerialPortWriteIoStop(IN WDFQUEUE Queue,
                               IN WDFREQUEST Request,
                               IN ULONG ActionFlags)
 {
-   PRAWPDO_VIOSERIAL_PORT pdoData = RawPdoSerialPortGetData(
-      WdfIoQueueGetDevice(Queue));
-   PVIOSERIAL_PORT pport = pdoData->port;
+    PRAWPDO_VIOSERIAL_PORT pdoData = RawPdoSerialPortGetData(
+        WdfIoQueueGetDevice(Queue));
+    PVIOSERIAL_PORT pport = pdoData->port;
 
-   TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "--> %s\n", __FUNCTION__);
 
-   WdfSpinLockAcquire(pport->OutVqLock);
-   if (ActionFlags & WdfRequestStopActionSuspend)
-   {
-      WdfRequestStopAcknowledge(Request, FALSE);
-   }
-   else if (ActionFlags & WdfRequestStopActionPurge)
-   {
-      if (WdfRequestUnmarkCancelable(Request) != STATUS_CANCELLED)
-      {
-         PSINGLE_LIST_ENTRY iter = &pport->WriteBuffersList;
-         while ((iter = iter->Next) != NULL)
-         {
-            PWRITE_BUFFER_ENTRY entry = CONTAINING_RECORD(iter, WRITE_BUFFER_ENTRY, ListEntry);
-            if (entry->Request == Request)
+    WdfSpinLockAcquire(pport->OutVqLock);
+    if (ActionFlags & WdfRequestStopActionSuspend)
+    {
+        WdfRequestStopAcknowledge(Request, FALSE);
+    }
+    else if (ActionFlags & WdfRequestStopActionPurge)
+    {
+        if (WdfRequestUnmarkCancelable(Request) != STATUS_CANCELLED)
+        {
+            PSINGLE_LIST_ENTRY iter = &pport->WriteBuffersList;
+            while ((iter = iter->Next) != NULL)
             {
-               entry->Request = NULL;
-               break;
+                PWRITE_BUFFER_ENTRY entry = CONTAINING_RECORD(iter, WRITE_BUFFER_ENTRY, ListEntry);
+                if (entry->Request == Request)
+                {
+                    entry->Request = NULL;
+                    break;
+                }
             }
-         }
-         WdfRequestComplete(Request, STATUS_OBJECT_NO_LONGER_EXISTS);
-      }
-   }
-   WdfSpinLockRelease(pport->OutVqLock);
+            WdfRequestComplete(Request, STATUS_OBJECT_NO_LONGER_EXISTS);
+        }
+    }
+    WdfSpinLockRelease(pport->OutVqLock);
 
-   TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "<-- %s\n", __FUNCTION__);
 }
 
 NTSTATUS VIOSerialPortEvtDeviceD0Entry(

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1352,29 +1352,36 @@ VOID VIOSerialPortWriteIoStop(IN WDFQUEUE Queue,
 
     TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "--> %s\n", __FUNCTION__);
 
-    WdfSpinLockAcquire(pport->OutVqLock);
-    if (ActionFlags & WdfRequestStopActionSuspend)
+    if (WdfRequestUnmarkCancelable(Request) == STATUS_CANCELLED)
     {
         WdfRequestStopAcknowledge(Request, FALSE);
     }
+    else if (ActionFlags & WdfRequestStopActionSuspend)
+    {
+        WdfRequestStopAcknowledge(Request, TRUE);
+    }
     else if (ActionFlags & WdfRequestStopActionPurge)
     {
-        if (WdfRequestUnmarkCancelable(Request) != STATUS_CANCELLED)
+        PSINGLE_LIST_ENTRY iter;
+
+        WdfSpinLockAcquire(pport->OutVqLock);
+        iter = &pport->WriteBuffersList;
+        while ((iter = iter->Next) != NULL)
         {
-            PSINGLE_LIST_ENTRY iter = &pport->WriteBuffersList;
-            while ((iter = iter->Next) != NULL)
+            PWRITE_BUFFER_ENTRY entry = CONTAINING_RECORD(iter, WRITE_BUFFER_ENTRY, ListEntry);
+            if (entry->Request == Request)
             {
-                PWRITE_BUFFER_ENTRY entry = CONTAINING_RECORD(iter, WRITE_BUFFER_ENTRY, ListEntry);
-                if (entry->Request == Request)
-                {
-                    entry->Request = NULL;
-                    break;
-                }
+                entry->Request = NULL;
+                break;
             }
-            WdfRequestComplete(Request, STATUS_OBJECT_NO_LONGER_EXISTS);
         }
+        WdfRequestComplete(Request, STATUS_OBJECT_NO_LONGER_EXISTS);
+        WdfSpinLockRelease(pport->OutVqLock);
     }
-    WdfSpinLockRelease(pport->OutVqLock);
+    else
+    {
+        WdfRequestComplete(Request, STATUS_UNSUCCESSFUL);
+    }
 
     TraceEvents(TRACE_LEVEL_ERROR, DBG_WRITE, "<-- %s\n", __FUNCTION__);
 }


### PR DESCRIPTION
Fix two SDV issues marked as mustfix in Balloon and VirtIOSerial:    

- EvtIoStopCancel: 
     - Requires EvtIoStop to unmark request cancellable
- EvtIoStopCompleteOrStopAck: 
     - Requires EvIoStop to complete/cancel/postpone request

So, EvtIoStop handler
- Calls WdfRequestUnmarkCancelable for every request
- Calls WdfRequestStopAcknowledge/WdfRequestComplete for every request