### PR TITLE
Fix CodeQL issues in VirtIOInput and Ivshmem

### DIFF
--- a/ivshmem/Device.c
+++ b/ivshmem/Device.c
@@ -122,7 +122,7 @@ NTSTATUS IVSHMEMEvtDevicePrepareHardware(_In_ WDFDEVICE Device, _In_ WDFCMRESLIS
 
       if (deviceContext->interruptCount > 0)
       {
-          deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolWithTag(IVSHMEM_NONPAGED_POOL,
+          deviceContext->interrupts = (WDFINTERRUPT*)ExAllocatePoolUninitialized(IVSHMEM_NONPAGED_POOL,
               sizeof(WDFINTERRUPT) * deviceContext->interruptCount, 'sQRI');
 
           if (!deviceContext->interrupts)

--- a/vioinput/sys/Array.c
+++ b/vioinput/sys/Array.c
@@ -49,7 +49,7 @@ BOOLEAN DynamicArrayReserve(PDYNAMIC_ARRAY pArray, SIZE_T cbSize)
         // initial allocation
         pArray->Size = 0;
         pArray->MaxSize = cbSize;
-        pArray->Ptr = ExAllocatePoolWithTag(
+        pArray->Ptr = ExAllocatePoolUninitialized(
             NonPagedPool,
             pArray->MaxSize,
             VIOINPUT_DRIVER_MEMORY_TAG);
@@ -69,7 +69,7 @@ BOOLEAN DynamicArrayReserve(PDYNAMIC_ARRAY pArray, SIZE_T cbSize)
         {
             pArray->MaxSize *= 2;
         }
-        pArray->Ptr = ExAllocatePoolWithTag(
+        pArray->Ptr = ExAllocatePoolUninitialized(
             NonPagedPool,
             pArray->MaxSize,
             VIOINPUT_DRIVER_MEMORY_TAG);

--- a/vioinput/sys/HidKeyboard.c
+++ b/vioinput/sys/HidKeyboard.c
@@ -488,7 +488,7 @@ HIDKeyboardProbe(
         }
 
         // allocate and initialize a buffer holding the last seen output report
-        pKeyboardDesc->pLastOutputReport = ExAllocatePoolWithTag(
+        pKeyboardDesc->pLastOutputReport = ExAllocatePoolUninitialized(
             NonPagedPool,
             pKeyboardDesc->cbOutputReport,
             VIOINPUT_DRIVER_MEMORY_TAG);

--- a/vioinput/sys/vioinput.h
+++ b/vioinput/sys/vioinput.h
@@ -448,7 +448,7 @@ HIDJoystickProbe(
 
 static inline PVOID VIOInputAlloc(SIZE_T cbNumberOfBytes)
 {
-    PVOID pPtr = ExAllocatePoolWithTag(
+    PVOID pPtr = ExAllocatePoolUninitialized(
         NonPagedPool,
         cbNumberOfBytes,
         VIOINPUT_DRIVER_MEMORY_TAG);


### PR DESCRIPTION
This is another batch of fixes where ExAllocatePoolWithTag is replaced by ExAllocatePoolUninitialized