### PR TITLE
Fix CodeQL and SDV issues in VirtIOFS

### DIFF
--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -384,17 +384,13 @@ VOID VirtFsEvtIoStop(IN WDFQUEUE Queue,
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_IOCTL,
         "--> %!FUNC! Request: %p ActionFlags: 0x%08x", Request, ActionFlags);
 
-    if (ActionFlags & WdfRequestStopRequestCancelable)
-    {
-        if (WdfRequestUnmarkCancelable(Request) == STATUS_CANCELLED)
-        {
-            goto request_cancelled;
-        }
-    }
-
-    if (ActionFlags & WdfRequestStopActionSuspend)
+    if (WdfRequestUnmarkCancelable(Request) == STATUS_CANCELLED)
     {
         WdfRequestStopAcknowledge(Request, FALSE);
+    }
+    else if (ActionFlags & WdfRequestStopActionSuspend)
+    {
+        WdfRequestStopAcknowledge(Request, TRUE);
     }
     else if (ActionFlags & WdfRequestStopActionPurge)
     {
@@ -419,8 +415,11 @@ VOID VirtFsEvtIoStop(IN WDFQUEUE Queue,
 
         WdfRequestComplete(Request, STATUS_CANCELLED);
     }
+    else
+    {
+        WdfRequestComplete(Request, STATUS_UNSUCCESSFUL);
+    }
 
-request_cancelled:
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_IOCTL, "<-- %!FUNC!");
 }
 

--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -88,7 +88,7 @@ static int FillScatterGatherFromMdl(OUT struct scatterlist sg[],
         {
             len = (ULONG)(min(Length, PAGE_SIZE));
             Length -= len;
-            sg[i].physAddr.QuadPart = (ULONGLONG)(*(pfn + j)) << PAGE_SHIFT;
+            sg[i].physAddr.QuadPart = (ULONGLONG)pfn[j] << PAGE_SHIFT;
             sg[i].length = len;
             i += 1;
         }

--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -116,7 +116,7 @@ static NTSTATUS VirtFsEnqueueRequest(IN PDEVICE_CONTEXT Context,
     vq_lock = Context->VirtQueueLocks[vq_index];
 
     sg_size = GetRequiredScatterGatherSize(Request);
-    sg = ExAllocatePoolWithTag(NonPagedPool,
+    sg = ExAllocatePoolUninitialized(NonPagedPool,
         sg_size * sizeof(struct scatterlist), VIRT_FS_MEMORY_TAG);
 
     if (sg == NULL)

--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -327,7 +327,9 @@ static VOID HandleSubmitFuseRequest(IN PDEVICE_CONTEXT Context,
     status = VirtFsEnqueueRequest(Context, fs_req);
     if (!NT_SUCCESS(status))
     {
-        if (WdfRequestUnmarkCancelable(Request) != STATUS_CANCELLED)
+        status = WdfRequestUnmarkCancelable(Request);
+        __analysis_assume(status != STATUS_NOT_SUPPORTED);
+        if (status != STATUS_CANCELLED)
         {
             goto complete_wdf_req;
         }

--- a/viofs/pci/power.c
+++ b/viofs/pci/power.c
@@ -74,7 +74,7 @@ NTSTATUS VirtFsEvtDevicePrepareHardware(IN WDFDEVICE Device,
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_POWER,
         "Request queues: %d", context->RequestQueues);
 
-    context->VirtQueues = ExAllocatePoolWithTag(NonPagedPool,
+    context->VirtQueues = ExAllocatePoolUninitialized(NonPagedPool,
         context->RequestQueues * sizeof(struct virtqueue*),
         VIRT_FS_MEMORY_TAG);
 
@@ -93,7 +93,7 @@ NTSTATUS VirtFsEvtDevicePrepareHardware(IN WDFDEVICE Device,
 
     if (NT_SUCCESS(status))
     {
-        context->VirtQueueLocks = ExAllocatePoolWithTag(NonPagedPool,
+        context->VirtQueueLocks = ExAllocatePoolUninitialized(NonPagedPool,
             context->RequestQueues * sizeof(WDFSPINLOCK),
             VIRT_FS_MEMORY_TAG);
     }


### PR DESCRIPTION
In fact, commit [537a1ea](https://github.com/virtio-win/kvm-guest-drivers-windows/commit/537a1ea40441241945d1837bb0f6ea9b382f22cc) does partial suppression of SDV rule (InvalidReqAccess).

The rule ignores the fact that WdfRequestUnmarkCancelable is called only if WdfRequestMarkCancelableEx succeeded and Request is either Cancelled already or cancel is done by this call and checks branch `status == STATUS_NOT_SUPPORTED`.

It looks like problem described here [e8f5974a](https://github.com/virtio-win/kvm-guest-drivers-windows/commit/e8f5974a40d82d2f0924f71391263c04ff3a4623).