### PR TITLE
Fix missing adaptExt->scsi_config.seg_max in GetScsiConfig()

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -273,6 +273,10 @@ ENTER_FN();
 
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, event_info_size),
                       &adaptExt->scsi_config.event_info_size, sizeof(adaptExt->scsi_config.event_info_size));
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " event_info_size %lu\n", adaptExt->scsi_config.event_info_size);
+
+    virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, seg_max),
+                      &adaptExt->scsi_config.seg_max, sizeof(adaptExt->scsi_config.seg_max));
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " seg_max %lu\n", adaptExt->scsi_config.seg_max);
 
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, sense_size),


### PR DESCRIPTION
GetScsiConfig() missing actual virtio_get_config() call for adaptExt->scsi_config.seg_max

Signed-off-by: Albert Lavrentev <albertlav@gmail.com>