### PR TITLE
NetKVM: Use 'enum class' instead of 'enum' (CA warning 26812)

### DIFF
--- a/NetKVM/Common/DebugData.h
+++ b/NetKVM/Common/DebugData.h
@@ -35,7 +35,7 @@
 #ifndef PARANDIS_DEBUG_DATA_H
 #define PARANDIS_DEBUG_DATA_H
 
-typedef enum _etagHistoryLogOperation
+typedef enum class _etagHistoryLogOperation
 {
     hopPowerOff,                // common::PowerOff, 1/0 - entry/exit (none, entry, none, none)
     hopPowerOn,                 // common::PowerOn, 1/0 - entry/exit (none, entry, none, none)

--- a/NetKVM/Common/ParaNdis-AbstractPath.h
+++ b/NetKVM/Common/ParaNdis-AbstractPath.h
@@ -116,11 +116,11 @@ public:
        device needs a reset*/
     void Notify(SMNotifications message) override
     {
-        if (message == SupriseRemoved || message == NeedsReset)
+        if (message == SMNotifications::SupriseRemoved || message == SMNotifications::NeedsReset)
         {
             m_VirtQueue.DoNotTouchHardware();
         }
-        else if (message == PoweredOn)
+        else if (message == SMNotifications::PoweredOn)
         {
             m_VirtQueue.AllowTouchHardware();
         }

--- a/NetKVM/Common/ParaNdis-RSS.h
+++ b/NetKVM/Common/ParaNdis-RSS.h
@@ -9,7 +9,7 @@
 
 #define PARANDIS_RSS_MAX_RECEIVE_QUEUES (32)
 
-typedef enum _tagPARANDIS_RSS_MODE
+typedef enum class _tagPARANDIS_RSS_MODE
 {
     PARANDIS_RSS_DISABLED = 0,
     PARANDIS_RSS_HASHING  = 1,
@@ -51,7 +51,7 @@ public:
     bool              FailedInitialization;
     CCHAR             ReceiveQueuesNumber;
 
-    PARANDIS_RSS_MODE RSSMode = PARANDIS_RSS_DISABLED;
+    PARANDIS_RSS_MODE RSSMode = PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED;
 
     PARANDIS_HASHING_SETTINGS ReceiveHashingSettings = {};
     PARANDIS_HASHING_SETTINGS RSSHashingSettings = {};

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -118,7 +118,7 @@ protected:
 
     enum { StoppedMask = 0x40000000 };
 
-    using FlowState = enum
+    enum class FlowState
     {
         Running,
         Stopping,

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -3,7 +3,7 @@
 #include "ParaNdis-Util.h"
 #include "Parandis_DesignPatterns.h"
 
-enum SMNotifications {
+enum class SMNotifications {
     Started,
     stopped,
     SupriseRemoved,

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -351,7 +351,7 @@ public:
         CMiniportStateMachine& operator= (const CMiniportStateMachine&) = delete;
 
 private:
-    using MiniportState = enum
+    enum class MiniportState
     {
         Halted,
         Running,

--- a/NetKVM/Common/ParaNdis-SM.h
+++ b/NetKVM/Common/ParaNdis-SM.h
@@ -5,7 +5,7 @@
 
 enum class SMNotifications {
     Started,
-    stopped,
+    Stopped,
     SupriseRemoved,
     NeedsReset,
     PoweredOn,

--- a/NetKVM/Common/ParaNdis-VirtQueue.h
+++ b/NetKVM/Common/ParaNdis-VirtQueue.h
@@ -17,7 +17,7 @@ class CNB;
 class CTXVirtQueue;
 typedef struct _PARANDIS_ADAPTER *PPARANDIS_ADAPTER;
 
-typedef enum
+typedef enum class _tagSubmitTxPacketResult
 {
     SUBMIT_SUCCESS = 0,
     SUBMIT_PACKET_TOO_LARGE,

--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -2154,10 +2154,10 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
     else
     {
         ppr.value = 0;
-        ppr.ipStatus = ppresNotIP;
+        ppr.ipStatus = static_cast<ULONG>(ppResult::ppresNotIP);
     }
 
-    if (ppr.ipCheckSum == ppresIPTooShort || ppr.xxpStatus == ppresXxpIncomplete)
+    if (ppr.ipCheckSum == ppResult::ppresIPTooShort || ppr.xxpStatus == ppResult::ppresXxpIncomplete)
     {
         res.flags.IpOK = FALSE;
         res.flags.IpFailed = TRUE;
@@ -2167,23 +2167,23 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
     if (virtioFlags & VIRTIO_NET_HDR_F_DATA_VALID)
     {
         pContext->extraStatistics.framesRxCSHwOK++;
-        ppr.xxpCheckSum = ppresCSOK;
+        ppr.xxpCheckSum = static_cast<ULONG>(ppResult::ppresCSOK);
     }
 
-    if (ppr.ipStatus == ppresIPV4 && !ppr.IsFragment)
+    if (ppr.ipStatus == ppResult::ppresIPV4 && !ppr.IsFragment)
     {
         if (f.fRxIPChecksum)
         {
-            res.flags.IpOK =  ppr.ipCheckSum == ppresCSOK;
-            res.flags.IpFailed = ppr.ipCheckSum == ppresCSBad;
+            res.flags.IpOK =  ppr.ipCheckSum == ppResult::ppresCSOK;
+            res.flags.IpFailed = ppr.ipCheckSum == ppResult::ppresCSBad;
         }
-        if(ppr.xxpStatus == ppresXxpKnown)
+        if(ppr.xxpStatus == ppResult::ppresXxpKnown)
         {
-            if(ppr.TcpUdp == ppresIsTCP) /* TCP */
+            if(ppr.TcpUdp == ppResult::ppresIsTCP) /* TCP */
             {
                 if (f.fRxTCPChecksum)
                 {
-                    res.flags.TcpOK = ppr.xxpCheckSum == ppresCSOK || ppr.fixedXxpCS;
+                    res.flags.TcpOK = ppr.xxpCheckSum == ppResult::ppresCSOK || ppr.fixedXxpCS;
                     res.flags.TcpFailed = !res.flags.TcpOK;
                 }
             }
@@ -2191,21 +2191,21 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
             {
                 if (f.fRxUDPChecksum)
                 {
-                    res.flags.UdpOK = ppr.xxpCheckSum == ppresCSOK || ppr.fixedXxpCS;
+                    res.flags.UdpOK = ppr.xxpCheckSum == ppResult::ppresCSOK || ppr.fixedXxpCS;
                     res.flags.UdpFailed = !res.flags.UdpOK;
                 }
             }
         }
     }
-    else if (ppr.ipStatus == ppresIPV6)
+    else if (ppr.ipStatus == ppResult::ppresIPV6)
     {
-        if(ppr.xxpStatus == ppresXxpKnown)
+        if(ppr.xxpStatus == ppResult::ppresXxpKnown)
         {
-            if(ppr.TcpUdp == ppresIsTCP) /* TCP */
+            if(ppr.TcpUdp == ppResult::ppresIsTCP) /* TCP */
             {
                 if (f.fRxTCPv6Checksum)
                 {
-                    res.flags.TcpOK = ppr.xxpCheckSum == ppresCSOK || ppr.fixedXxpCS;
+                    res.flags.TcpOK = ppr.xxpCheckSum == ppResult::ppresCSOK || ppr.fixedXxpCS;
                     res.flags.TcpFailed = !res.flags.TcpOK;
                 }
             }
@@ -2213,7 +2213,7 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
             {
                 if (f.fRxUDPv6Checksum)
                 {
-                    res.flags.UdpOK = ppr.xxpCheckSum == ppresCSOK || ppr.fixedXxpCS;
+                    res.flags.UdpOK = ppr.xxpCheckSum == ppResult::ppresCSOK || ppr.fixedXxpCS;
                     res.flags.UdpFailed = !res.flags.UdpOK;
                 }
             }

--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -1895,7 +1895,7 @@ VOID ParaNdis_OnPnPEvent(
         default:
             break;
     }
-    ParaNdis_DebugHistory(pContext, hopPnpEvent, NULL, pEvent, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopPnpEvent, NULL, pEvent, 0, 0);
     DPrintf(0, "[%s] (%s)\n", __FUNCTION__, pName);
     if (pEvent == NdisDevicePnPEventSurpriseRemoved)
     {
@@ -2016,7 +2016,7 @@ NDIS_STATUS ParaNdis_PowerOn(PARANDIS_ADAPTER *pContext)
     UINT i;
 
     DEBUG_ENTRY(0);
-    ParaNdis_DebugHistory(pContext, hopPowerOn, NULL, 1, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopPowerOn, NULL, 1, 0, 0);
 
     pContext->m_StateMachine.NotifyPowerOn();
 
@@ -2055,7 +2055,7 @@ NDIS_STATUS ParaNdis_PowerOn(PARANDIS_ADAPTER *pContext)
 
     pContext->m_StateMachine.NotifyResumed();
 
-    ParaNdis_DebugHistory(pContext, hopPowerOn, NULL, 0, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopPowerOn, NULL, 0, 0, 0);
 
     return NDIS_STATUS_SUCCESS;
 }
@@ -2063,7 +2063,7 @@ NDIS_STATUS ParaNdis_PowerOn(PARANDIS_ADAPTER *pContext)
 VOID ParaNdis_PowerOff(PARANDIS_ADAPTER *pContext)
 {
     DEBUG_ENTRY(0);
-    ParaNdis_DebugHistory(pContext, hopPowerOff, NULL, 1, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopPowerOff, NULL, 1, 0, 0);
 
     pContext->m_StateMachine.NotifySuspended();
 
@@ -2097,7 +2097,7 @@ VOID ParaNdis_PowerOff(PARANDIS_ADAPTER *pContext)
         pContext->CXPath.Shutdown();
     }
 
-    ParaNdis_DebugHistory(pContext, hopPowerOff, NULL, 0, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopPowerOff, NULL, 0, 0, 0);
 }
 
 void ParaNdis_CallOnBugCheck(PARANDIS_ADAPTER *pContext)

--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -2128,20 +2128,20 @@ tChecksumCheckResult ParaNdis_CheckRxChecksum(
     //VIRTIO_NET_HDR_F_NEEDS_CSUM - we need to calculate TCP/UDP CS
     //VIRTIO_NET_HDR_F_DATA_VALID - host tells us TCP/UDP CS is OK
 
-    if (f.fRxIPChecksum) flagsToCalculate |= pcrIpChecksum; // check only
+    if (f.fRxIPChecksum) flagsToCalculate |= tPacketOffloadRequest::pcrIpChecksum; // check only
 
     if (!(virtioFlags & VIRTIO_NET_HDR_F_DATA_VALID))
     {
         if (virtioFlags & VIRTIO_NET_HDR_F_NEEDS_CSUM)
         {
-            flagsToCalculate |= pcrFixXxpChecksum | pcrTcpChecksum | pcrUdpChecksum;
+            flagsToCalculate |= tPacketOffloadRequest::pcrFixXxpChecksum | tPacketOffloadRequest::pcrTcpChecksum | tPacketOffloadRequest::pcrUdpChecksum;
         }
         else
         {
-            if (f.fRxTCPChecksum) flagsToCalculate |= pcrTcpV4Checksum;
-            if (f.fRxUDPChecksum) flagsToCalculate |= pcrUdpV4Checksum;
-            if (f.fRxTCPv6Checksum) flagsToCalculate |= pcrTcpV6Checksum;
-            if (f.fRxUDPv6Checksum) flagsToCalculate |= pcrUdpV6Checksum;
+            if (f.fRxTCPChecksum) flagsToCalculate |= tPacketOffloadRequest::pcrTcpV4Checksum;
+            if (f.fRxUDPChecksum) flagsToCalculate |= tPacketOffloadRequest::pcrUdpV4Checksum;
+            if (f.fRxTCPv6Checksum) flagsToCalculate |= tPacketOffloadRequest::pcrTcpV6Checksum;
+            if (f.fRxUDPv6Checksum) flagsToCalculate |= tPacketOffloadRequest::pcrUdpV6Checksum;
         }
     }
 

--- a/NetKVM/Common/ParaNdis_Protocol.cpp
+++ b/NetKVM/Common/ParaNdis_Protocol.cpp
@@ -1439,8 +1439,8 @@ void CProtocolBinding::SetRSS()
         current->rsp.Header.Size = NDIS_SIZEOF_RECEIVE_SCALE_PARAMETERS_REVISION_2;
         switch (m_BoundAdapter->RSSParameters.RSSMode)
         {
-            case PARANDIS_RSS_FULL:
-            case PARANDIS_RSS_HASHING:
+            case PARANDIS_RSS_MODE::PARANDIS_RSS_FULL:
+            case PARANDIS_RSS_MODE::PARANDIS_RSS_HASHING:
                 current->rsp.HashInformation = m_BoundAdapter->RSSParameters.ActiveHashingSettings.HashInformation;
                 current->rsp.HashSecretKeyOffset = FIELD_OFFSET(RSSSet, key);
                 current->rsp.HashSecretKeySize = m_BoundAdapter->RSSParameters.ActiveHashingSettings.HashSecretKeySize;

--- a/NetKVM/Common/ParaNdis_Protocol.cpp
+++ b/NetKVM/Common/ParaNdis_Protocol.cpp
@@ -116,20 +116,20 @@ public:
     }
     void NotifyAdapterRemoval()
     {
-        Notifier(m_Binding, Removal);
+        Notifier(m_Binding, NotifyEvent::Removal);
     }
     void NotifyAdapterArrival()
     {
-        Notifier(m_Binding, Arrival, m_Adapter);
+        Notifier(m_Binding, NotifyEvent::Arrival, m_Adapter);
     }
     void NotifyAdapterDetach()
     {
-        Notifier(m_Binding, Detach);
+        Notifier(m_Binding, NotifyEvent::Detach);
     }
     PARANDIS_ADAPTER *m_Adapter;
     PVOID m_Binding;
 private:
-    enum NotifyEvent
+    enum class NotifyEvent
     {
         Arrival,
         Removal,
@@ -1253,13 +1253,13 @@ void CAdapterEntry::Notifier(PVOID Binding, NotifyEvent Event, PARANDIS_ADAPTER 
     }
     switch (Event)
     {
-        case Arrival:
+        case NotifyEvent::Arrival:
             pb->OnAdapterFound(Adapter);
             break;
-        case Removal:
+        case NotifyEvent::Removal:
             pb->OnAdapterHalted();
             break;
-        case Detach:
+        case NotifyEvent::Detach:
             pb->OnAdapterDetach();
             break;
         default:

--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -286,7 +286,7 @@ static FORCEINLINE BOOLEAN ParaNdis_PerformPacketAnalysis(
         return FALSE;
 
 #if PARANDIS_SUPPORT_RSS
-    if (RSSParameters->RSSMode != PARANDIS_RSS_DISABLED)
+    if (RSSParameters->RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED)
     {
         ParaNdis6_RSSAnalyzeReceivedPacket(RSSParameters, HeadersBuffer, PacketInfo);
     }

--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -817,14 +817,14 @@ void CNB::SetupLSO(virtio_net_hdr *VirtioHeader, PVOID IpHeader, ULONG EthPayloa
                                                FALSE,
                                                __FUNCTION__);
 
-    if (packetReview.xxpCheckSum == ppresPCSOK || packetReview.fixedXxpCS)
+    if (packetReview.xxpCheckSum == ppResult::ppresPCSOK || packetReview.fixedXxpCS)
     {
         auto IpHeaderOffset = m_Context->Offload.ipHeaderOffset;
         auto VHeader = static_cast<virtio_net_hdr*>(VirtioHeader);
         auto PriorityHdrLen = (m_ParentNBL->TCI() != 0) ? ETH_PRIORITY_HEADER_SIZE : 0;
 
         VHeader->flags = VIRTIO_NET_HDR_F_NEEDS_CSUM;
-        VHeader->gso_type = packetReview.ipStatus == ppresIPV4 ? VIRTIO_NET_HDR_GSO_TCPV4 : VIRTIO_NET_HDR_GSO_TCPV6;
+        VHeader->gso_type = packetReview.ipStatus == ppResult::ppresIPV4 ? VIRTIO_NET_HDR_GSO_TCPV4 : VIRTIO_NET_HDR_GSO_TCPV6;
         VHeader->hdr_len = (USHORT)(packetReview.XxpIpHeaderSize + IpHeaderOffset + PriorityHdrLen);
         VHeader->gso_size = (USHORT)m_ParentNBL->MSS();
         VHeader->csum_start = (USHORT)(m_ParentNBL->TCPHeaderOffset() + PriorityHdrLen);
@@ -842,7 +842,7 @@ void CNB::SetupUSO(virtio_net_hdr *VirtioHeader, PVOID IpHeader, ULONG EthPayloa
         FALSE,
         __FUNCTION__);
 
-    if (packetReview.xxpCheckSum == ppresPCSOK || packetReview.fixedXxpCS)
+    if (packetReview.xxpCheckSum == ppResult::ppresPCSOK || packetReview.fixedXxpCS)
     {
         auto IpHeaderOffset = m_Context->Offload.ipHeaderOffset;
         auto VHeader = static_cast<virtio_net_hdr*>(VirtioHeader);
@@ -863,7 +863,7 @@ USHORT CNB::QueryL4HeaderOffset(PVOID PacketData, ULONG IpHeaderOffset) const
     USHORT Res;
     auto ppr = ParaNdis_ReviewIPPacket(RtlOffsetToPointer(PacketData, IpHeaderOffset),
                                        GetDataLength(), FALSE, __FUNCTION__);
-    if (ppr.ipStatus != ppresNotIP)
+    if (ppr.ipStatus != ppResult::ppresNotIP)
     {
         Res = static_cast<USHORT>(IpHeaderOffset + ppr.ipHeaderSize);
     }

--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -529,7 +529,7 @@ void CParaNdisTX::Notify(SMNotifications message)
 
     __super::Notify(message);
 
-    if (message != SupriseRemoved)
+    if (message != SMNotifications::SupriseRemoved)
     {
         // probably similar processing we'll do in case of reset
         return;

--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -813,7 +813,8 @@ void CNB::SetupLSO(virtio_net_hdr *VirtioHeader, PVOID IpHeader, ULONG EthPayloa
 
     tTcpIpPacketParsingResult packetReview;
     packetReview = ParaNdis_CheckSumVerifyFlat(reinterpret_cast<IPv4Header*>(IpHeader), EthPayloadLength,
-                                               pcrIpChecksum | pcrFixIPChecksum | pcrTcpChecksum | pcrFixPHChecksum,
+                                               tPacketOffloadRequest::pcrIpChecksum | tPacketOffloadRequest::pcrFixIPChecksum |
+                                               tPacketOffloadRequest::pcrTcpChecksum | tPacketOffloadRequest::pcrFixPHChecksum,
                                                FALSE,
                                                __FUNCTION__);
 
@@ -838,7 +839,8 @@ void CNB::SetupUSO(virtio_net_hdr *VirtioHeader, PVOID IpHeader, ULONG EthPayloa
 
     tTcpIpPacketParsingResult packetReview;
     packetReview = ParaNdis_CheckSumVerifyFlat(reinterpret_cast<IPv4Header*>(IpHeader), EthPayloadLength,
-        pcrIpChecksum | pcrFixIPChecksum | pcrUdpChecksum | pcrFixPHChecksum,
+        tPacketOffloadRequest::pcrIpChecksum | tPacketOffloadRequest::pcrFixIPChecksum | 
+        tPacketOffloadRequest::pcrUdpChecksum | tPacketOffloadRequest::pcrFixPHChecksum,
         FALSE,
         __FUNCTION__);
 
@@ -888,8 +890,8 @@ void CNB::DoIPHdrCSO(PVOID IpHeader, ULONG EthPayloadLength) const
 {
     ParaNdis_CheckSumVerifyFlat(IpHeader,
                                 EthPayloadLength,
-                                pcrIpChecksum | pcrFixIPChecksum, FALSE,
-                                __FUNCTION__);
+                                tPacketOffloadRequest::pcrIpChecksum | tPacketOffloadRequest::pcrFixIPChecksum,
+                                FALSE, __FUNCTION__);
 }
 
 bool CNB::FillDescriptorSGList(CTXDescriptor &Descriptor, ULONG ParsedHeadersLength) const

--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -624,17 +624,17 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList& toWaitingList)
 
                 switch (result)
                 {
-                case SUBMIT_NO_PLACE_IN_QUEUE:
+                case SubmitTxPacketResult::SUBMIT_NO_PLACE_IN_QUEUE:
                     NBLHolder->PushMappedNB(NBHolder);
                     HaveBuffers = false;
                     // break the loop, allow to kick and free some buffers
                     break;
 
-                case SUBMIT_FAILURE:
+                case SubmitTxPacketResult::SUBMIT_FAILURE:
                     __fallthrough;
-                case SUBMIT_SUCCESS:
+                case SubmitTxPacketResult::SUBMIT_SUCCESS:
                     __fallthrough;
-                case SUBMIT_PACKET_TOO_LARGE:
+                case SubmitTxPacketResult::SUBMIT_PACKET_TOO_LARGE:
                     // if this NBL finished?
                     if (!NBLHolder->HaveMappedBuffers())
                     {
@@ -650,7 +650,7 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList& toWaitingList)
                         // no, keep it in the queue
                     }
 
-                    if (result == SUBMIT_SUCCESS)
+                    if (result == SubmitTxPacketResult::SUBMIT_SUCCESS)
                     {
                         SentOutSomeBuffers = true;
                     }

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -736,7 +736,7 @@ VOID ParaNdis_SetLinkState(
 
 #endif //-OFFLOAD_UNIT_TEST
 
-typedef enum _tagppResult
+typedef enum class _tagppResult
 {
     ppresNotTested = 0,
     ppresNotIP     = 1,
@@ -752,6 +752,16 @@ typedef enum _tagppResult
     ppresIsTCP         = 0,
     ppresIsUDP         = 1,
 }ppResult;
+
+inline bool operator ==(ULONG a, ppResult b)
+{
+    return a == static_cast<ULONG>(b);
+}
+
+inline bool operator !=(ULONG a, ppResult b)
+{
+    return a != static_cast<ULONG>(b);
+}
 
 typedef union _tagTcpIpPacketParsingResult
 {

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -787,7 +787,7 @@ typedef union _tagTcpIpPacketParsingResult
     ULONG value;
 }tTcpIpPacketParsingResult;
 
-typedef enum _tagPacketOffloadRequest
+typedef enum class _tagPacketOffloadRequest
 {
     pcrIpChecksum  = (1 << 0),
     pcrTcpV4Checksum = (1 << 1),
@@ -809,6 +809,31 @@ typedef enum _tagPacketOffloadRequest
     pcrPriorityTag = (1 << 13),
     pcrNoIndirect  = (1 << 14)
 }tPacketOffloadRequest;
+
+inline ULONG operator |(tPacketOffloadRequest a, tPacketOffloadRequest b)
+{
+    return static_cast<ULONG>(a) | static_cast<ULONG>(b);
+}
+
+inline ULONG operator |(ULONG a, tPacketOffloadRequest b)
+{
+    return a | static_cast<ULONG>(b);
+}
+
+inline ULONG& operator |=(ULONG& a, tPacketOffloadRequest b)
+{
+    return a |= static_cast<ULONG>(b);
+}
+
+inline ULONG operator &(tPacketOffloadRequest a, tPacketOffloadRequest b)
+{
+    return static_cast<ULONG>(a) & static_cast<ULONG>(b);
+}
+
+inline ULONG operator &(ULONG a, tPacketOffloadRequest b)
+{
+    return a & static_cast<ULONG>(b);
+}
 
 // sw offload
 

--- a/NetKVM/Common/sw_offload.cpp
+++ b/NetKVM/Common/sw_offload.cpp
@@ -564,7 +564,7 @@ VerifyTcpChecksum(
         res.xxpCheckSum = static_cast<ULONG>(CompareNetCheckSumOnEndSystem(phcs, saved) ? ppResult::ppresPCSOK : ppResult::ppresCSBad);
         if (res.xxpCheckSum != ppResult::ppresPCSOK || whatToFix)
         {
-            if (whatToFix & pcrFixPHChecksum)
+            if (whatToFix & tPacketOffloadRequest::pcrFixPHChecksum)
             {
                 if (ulDataLength >= (ULONG)(res.ipHeaderSize + sizeof(*pTcpHeader)))
                 {
@@ -582,7 +582,7 @@ VerifyTcpChecksum(
                 if (CompareNetCheckSumOnEndSystem(pTcpHeader->tcp_xsum, saved))
                     res.xxpCheckSum = static_cast<ULONG>(ppResult::ppresCSOK);
 
-                if (!(whatToFix & pcrFixXxpChecksum))
+                if (!(whatToFix & tPacketOffloadRequest::pcrFixXxpChecksum))
                     pTcpHeader->tcp_xsum = saved;
                 else
                     res.fixedXxpCS =
@@ -633,7 +633,7 @@ VerifyUdpChecksum(
     {
         phcs = CalculateIpPseudoHeaderChecksum(pIpHeader, res, xxpHeaderAndPayloadLen);
         res.xxpCheckSum = static_cast<ULONG>(CompareNetCheckSumOnEndSystem(phcs, saved) ? ppResult::ppresPCSOK : ppResult::ppresCSBad);
-        if (whatToFix & pcrFixPHChecksum)
+        if (whatToFix & tPacketOffloadRequest::pcrFixPHChecksum)
         {
             if (ulDataLength >= (ULONG)(res.ipHeaderSize + sizeof(UDPHeader)))
             {
@@ -643,7 +643,7 @@ VerifyUdpChecksum(
             else
                 res.xxpStatus = static_cast<ULONG>(ppResult::ppresXxpIncomplete);
         }
-        else if (res.xxpCheckSum != ppResult::ppresPCSOK || (whatToFix & pcrFixXxpChecksum))
+        else if (res.xxpCheckSum != ppResult::ppresPCSOK || (whatToFix & tPacketOffloadRequest::pcrFixXxpChecksum))
         {
             if (res.xxpFull)
             {
@@ -652,7 +652,7 @@ VerifyUdpChecksum(
                 if (CompareNetCheckSumOnEndSystem(pUdpHeader->udp_xsum, saved))
                     res.xxpCheckSum = static_cast<ULONG>(ppResult::ppresCSOK);
 
-                if (!(whatToFix & pcrFixXxpChecksum))
+                if (!(whatToFix & tPacketOffloadRequest::pcrFixXxpChecksum))
                     pUdpHeader->udp_xsum = saved;
                 else
                     res.fixedXxpCS =
@@ -731,22 +731,24 @@ tTcpIpPacketParsingResult ParaNdis_CheckSumVerify(
 
     if (res.ipStatus == ppResult::ppresIPV4)
     {
-        if (flags & pcrIpChecksum)
-            res = VerifyIpChecksum(&pIpHeader->v4, res, (flags & pcrFixIPChecksum) != 0);
+        if (flags & tPacketOffloadRequest::pcrIpChecksum)
+            res = VerifyIpChecksum(&pIpHeader->v4, res, (flags & tPacketOffloadRequest::pcrFixIPChecksum) != 0);
         if(res.xxpStatus == ppResult::ppresXxpKnown)
         {
             if (res.TcpUdp == ppResult::ppresIsTCP) /* TCP */
             {
-                if(flags & pcrTcpV4Checksum)
+                if(flags & tPacketOffloadRequest::pcrTcpV4Checksum)
                 {
-                    res = VerifyTcpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & (pcrFixPHChecksum | pcrFixTcpV4Checksum));
+                    res = VerifyTcpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & 
+                        (tPacketOffloadRequest::pcrFixPHChecksum | tPacketOffloadRequest::pcrFixTcpV4Checksum));
                 }
             }
             else /* UDP */
             {
-                if (flags & pcrUdpV4Checksum)
+                if (flags & tPacketOffloadRequest::pcrUdpV4Checksum)
                 {
-                    res = VerifyUdpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & (pcrFixPHChecksum | pcrFixUdpV4Checksum));
+                    res = VerifyUdpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & 
+                        (tPacketOffloadRequest::pcrFixPHChecksum | tPacketOffloadRequest::pcrFixUdpV4Checksum));
                 }
             }
         }
@@ -757,16 +759,18 @@ tTcpIpPacketParsingResult ParaNdis_CheckSumVerify(
         {
             if (res.TcpUdp == ppResult::ppresIsTCP) /* TCP */
             {
-                if(flags & pcrTcpV6Checksum)
+                if(flags & tPacketOffloadRequest::pcrTcpV6Checksum)
                 {
-                    res = VerifyTcpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & (pcrFixPHChecksum | pcrFixTcpV6Checksum));
+                    res = VerifyTcpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & 
+                        (tPacketOffloadRequest::pcrFixPHChecksum | tPacketOffloadRequest::pcrFixTcpV6Checksum));
                 }
             }
             else /* UDP */
             {
-                if (flags & pcrUdpV6Checksum)
+                if (flags & tPacketOffloadRequest::pcrUdpV6Checksum)
                 {
-                    res = VerifyUdpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & (pcrFixPHChecksum | pcrFixUdpV6Checksum));
+                    res = VerifyUdpChecksum(pDataPages, ulDataLength, ulStartOffset, res, flags & 
+                        (tPacketOffloadRequest::pcrFixPHChecksum | tPacketOffloadRequest::pcrFixUdpV6Checksum));
                 }
             }
         }

--- a/NetKVM/NetKVM-VS2015.vcxproj.filters
+++ b/NetKVM/NetKVM-VS2015.vcxproj.filters
@@ -106,6 +106,9 @@
     <ClInclude Include="Common\ParaNdis_Protocol.h">
       <Filter>Header Files\Common</Filter>
     </ClInclude>
+    <ClInclude Include="Common\ParaNdis-SM.h">
+      <Filter>Header Files\Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="wlh\Parandis6.rc">
@@ -146,9 +149,6 @@
     <ClCompile Include="Common\ParaNdis_TX.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
-    <ClInclude Include="Common\ParaNdis-SM.h">
-      <Filter>Source Files\Common</Filter>
-    </ClInclude>
     <ClCompile Include="Common\ParaNdis_Util.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>

--- a/NetKVM/wlh/ParaNdis6_Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6_Driver.cpp
@@ -122,7 +122,7 @@ static VOID PostLinkState(PARANDIS_ADAPTER *pContext, NDIS_MEDIA_CONNECT_STATE c
     indication.StatusBuffer = &state;
     indication.StatusBufferSize = sizeof(state);
     DPrintf(0, "Indicating %s\n", ConnectStateName(connectState));
-    ParaNdis_DebugHistory(pContext, hopConnectIndication, NULL, connectState, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopConnectIndication, NULL, connectState, 0, 0);
     NdisMIndicateStatusEx(pContext->MiniportHandle , &indication);
 }
 
@@ -374,9 +374,9 @@ static VOID ParaNdis6_Halt(NDIS_HANDLE miniportAdapterContext, NDIS_HALT_ACTION 
 {
     PARANDIS_ADAPTER *pContext = (PARANDIS_ADAPTER *)miniportAdapterContext;
     DEBUG_ENTRY(0);
-    ParaNdis_DebugHistory(pContext, hopHalt, NULL, 1, haltAction, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopHalt, NULL, 1, haltAction, 0);
     ParaNdis_ProtocolUnregisterAdapter(pContext);
-    ParaNdis_DebugHistory(pContext, hopHalt, NULL, 0, 0, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopHalt, NULL, 0, 0, 0);
     ParaNdis_DebugRegisterMiniport(pContext, FALSE);
     pContext->Destroy(pContext, pContext->MiniportHandle);
     DEBUG_EXIT_STATUS(2, 0);

--- a/NetKVM/wlh/ParaNdis6_Impl.cpp
+++ b/NetKVM/wlh/ParaNdis6_Impl.cpp
@@ -816,7 +816,7 @@ VOID NBLSetRSSInfo(PPARANDIS_ADAPTER pContext, PNET_BUFFER_LIST pNBL, PNET_PACKE
     CNdisRWLockState lockState;
 
     pContext->RSSParameters.rwLock.acquireReadDpr(lockState);
-    if(pContext->RSSParameters.RSSMode != PARANDIS_RSS_DISABLED)
+    if(pContext->RSSParameters.RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED)
     {
         NET_BUFFER_LIST_SET_HASH_TYPE    (pNBL, PacketInfo->RSSHash.Type);
         NET_BUFFER_LIST_SET_HASH_FUNCTION(pNBL, PacketInfo->RSSHash.Function);

--- a/NetKVM/wlh/ParaNdis6_Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6_Oid.cpp
@@ -586,7 +586,7 @@ NDIS_STATUS ParaNdis6_OidRequest(
     ParaNdis_GetOidSupportRules(pNdisRequest->DATA.SET_INFORMATION.Oid, &Rules, OidsDB);
     _oid.ulToDoFlags = Rules.Flags;
 
-    ParaNdis_DebugHistory(pContext, hopOidRequest, NULL, pNdisRequest->DATA.SET_INFORMATION.Oid, pNdisRequest->RequestType, 1);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopOidRequest, NULL, pNdisRequest->DATA.SET_INFORMATION.Oid, pNdisRequest->RequestType, 1);
     DPrintf(Rules.nEntryLevel, "[%s] OID type %d, id 0x%X(%s) of %d\n", __FUNCTION__,
                 pNdisRequest->RequestType,
                 pNdisRequest->DATA.SET_INFORMATION.Oid,
@@ -654,7 +654,7 @@ NDIS_STATUS ParaNdis6_OidRequest(
             status = NDIS_STATUS_NOT_SUPPORTED;
             break;
     }
-    ParaNdis_DebugHistory(pContext, hopOidRequest, NULL, pNdisRequest->DATA.SET_INFORMATION.Oid, status, 0);
+    ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopOidRequest, NULL, pNdisRequest->DATA.SET_INFORMATION.Oid, status, 0);
     if (status != NDIS_STATUS_PENDING)
     {
         DPrintf(((status != NDIS_STATUS_SUCCESS) ? Rules.nExitFailLevel : Rules.nExitOKLevel),
@@ -705,7 +705,7 @@ static void OnSetPowerWorkItem(PVOID  WorkItemContext, NDIS_HANDLE  NdisIoWorkIt
         }
         NdisFreeMemory(pwi, 0, 0);
         NdisFreeIoWorkItem(NdisIoWorkItemHandle);
-        ParaNdis_DebugHistory(pContext, hopOidRequest, NULL, pRequest->DATA.SET_INFORMATION.Oid, status, 2);
+        ParaNdis_DebugHistory(pContext, _etagHistoryLogOperation::hopOidRequest, NULL, pRequest->DATA.SET_INFORMATION.Oid, status, 2);
         NdisMOidRequestComplete(pContext->MiniportHandle, pRequest, status);
     }
 }

--- a/NetKVM/wlh/ParaNdis6_RSS.cpp
+++ b/NetKVM/wlh/ParaNdis6_RSS.cpp
@@ -24,11 +24,11 @@ static VOID ApplySettings(PPARANDIS_RSS_PARAMS RSSParameters,
 
     RSSParameters->RSSMode = NewRSSMode;
 
-    if(NewRSSMode != PARANDIS_RSS_DISABLED)
+    if(NewRSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED)
     {
         RSSParameters->ActiveHashingSettings = *ReceiveHashingSettings;
 
-        if(NewRSSMode == PARANDIS_RSS_FULL)
+        if(NewRSSMode == PARANDIS_RSS_MODE::PARANDIS_RSS_FULL)
         {
             if(RSSParameters->ActiveRSSScalingSettings.CPUIndexMapping != NULL)
                 NdisFreeMemory(RSSParameters->ActiveRSSScalingSettings.CPUIndexMapping, 0, 0);
@@ -201,7 +201,7 @@ static void SetDeviceRSSSettings(PARANDIS_ADAPTER *pContext, bool bForceOff = fa
     UCHAR command = pContext->bRSSSupportedByDevice ?
         VIRTIO_NET_CTRL_MQ_RSS_CONFIG : VIRTIO_NET_CTRL_MQ_HASH_CONFIG;
 
-    if (pContext->RSSParameters.RSSMode == PARANDIS_RSS_DISABLED || bForceOff)
+    if (pContext->RSSParameters.RSSMode == PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED || bForceOff)
     {
         virtio_net_rss_config cfg = {};
         cfg.max_tx_vq = (USHORT)pContext->nPathBundles;
@@ -439,7 +439,7 @@ NDIS_STATUS ParaNdis6_RSSSetParameters( PARANDIS_ADAPTER *pContext,
         return NDIS_STATUS_INVALID_LENGTH;
     }
 
-    if ((RSSParameters->RSSMode == PARANDIS_RSS_HASHING) &&
+    if ((RSSParameters->RSSMode == PARANDIS_RSS_MODE::PARANDIS_RSS_HASHING) &&
         !(Params->Flags & NDIS_RSS_PARAM_FLAG_DISABLE_RSS) &&
         (Params->HashInformation != 0))
     {
@@ -457,7 +457,7 @@ NDIS_STATUS ParaNdis6_RSSSetParameters( PARANDIS_ADAPTER *pContext,
 
     if(Params->Flags & NDIS_RSS_PARAM_FLAG_DISABLE_RSS || (Params->HashInformation == 0))
     {
-        ApplySettings(RSSParameters, PARANDIS_RSS_DISABLED, NULL, NULL);
+        ApplySettings(RSSParameters, PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED, NULL, NULL);
     }
     else
     {
@@ -549,7 +549,7 @@ NDIS_STATUS ParaNdis6_RSSSetParameters( PARANDIS_ADAPTER *pContext,
         }
 
         ApplySettings(RSSParameters,
-                    PARANDIS_RSS_FULL,
+                    PARANDIS_RSS_MODE::PARANDIS_RSS_FULL,
                     &RSSParameters->RSSHashingSettings,
                     &RSSParameters->RSSScalingSettings);
     }
@@ -585,7 +585,7 @@ ULONG ParaNdis6_QueryReceiveHash(const PARANDIS_RSS_PARAMS *RSSParameters,
     RSSHashKeyParameters->ReceiveHashParameters.Header.Size  = NDIS_SIZEOF_RECEIVE_HASH_PARAMETERS_REVISION_1;
     RSSHashKeyParameters->ReceiveHashParameters.HashInformation = RSSParameters->ReceiveHashingSettings.HashInformation;
 
-    if(RSSParameters->RSSMode == PARANDIS_RSS_HASHING)
+    if(RSSParameters->RSSMode == PARANDIS_RSS_MODE::PARANDIS_RSS_HASHING)
         RSSHashKeyParameters->ReceiveHashParameters.Flags = NDIS_RECEIVE_HASH_FLAG_ENABLE_HASH;
 
     RSSHashKeyParameters->ReceiveHashParameters.HashSecretKeySize = RSSParameters->ReceiveHashingSettings.HashSecretKeySize;
@@ -612,7 +612,7 @@ NDIS_STATUS ParaNdis6_RSSSetReceiveHash(PARANDIS_ADAPTER *pContext,
 
     *ParamsBytesRead += sizeof(NDIS_RECEIVE_HASH_PARAMETERS);
 
-    if (RSSParameters->RSSMode == PARANDIS_RSS_FULL)
+    if (RSSParameters->RSSMode == PARANDIS_RSS_MODE::PARANDIS_RSS_FULL)
     {
         //Here we check that originator doesn't try to enable hashing while full RSS is on.
         //Disable hashing abd clear parameters is legitimate operation hovewer
@@ -651,11 +651,11 @@ NDIS_STATUS ParaNdis6_RSSSetReceiveHash(PARANDIS_ADAPTER *pContext,
         *ParamsBytesRead += Params->HashSecretKeySize;
     }
 
-    if(RSSParameters->RSSMode != PARANDIS_RSS_FULL)
+    if(RSSParameters->RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_FULL)
     {
         ApplySettings(RSSParameters,
                 ((Params->Flags & NDIS_RECEIVE_HASH_FLAG_ENABLE_HASH) && (Params->HashInformation != 0))
-                    ? PARANDIS_RSS_HASHING : PARANDIS_RSS_DISABLED,
+                    ? PARANDIS_RSS_MODE::PARANDIS_RSS_HASHING : PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED,
                 &RSSParameters->ReceiveHashingSettings, NULL);
     }
 
@@ -872,7 +872,7 @@ VOID ParaNdis6_RSSAnalyzeReceivedPacket(
 {
     CNdisDispatchReadAutoLock autoLock(RSSParameters->rwLock);
 
-    if(RSSParameters->RSSMode != PARANDIS_RSS_DISABLED)
+    if(RSSParameters->RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_DISABLED)
     {
         RSSCalcHash_Unsafe(RSSParameters, dataBuffer, packetInfo);
     }
@@ -886,7 +886,7 @@ CCHAR ParaNdis6_RSSGetScalingDataForPacket(
     CCHAR targetQueue;
     CNdisDispatchReadAutoLock autoLock(RSSParameters->rwLock);
 
-    if (RSSParameters->RSSMode != PARANDIS_RSS_FULL || 
+    if (RSSParameters->RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_FULL || 
         RSSParameters->ActiveRSSScalingSettings.FirstQueueIndirectionIndex == INVALID_INDIRECTION_INDEX)
     {
         targetQueue = PARANDIS_RECEIVE_UNCLASSIFIED_PACKET;
@@ -920,7 +920,7 @@ CCHAR ParaNdis6_RSSGetCurrentCpuReceiveQueue(PARANDIS_RSS_PARAMS *RSSParameters)
     CCHAR res;
     CNdisDispatchReadAutoLock autoLock(RSSParameters->rwLock);
 
-    if(RSSParameters->RSSMode != PARANDIS_RSS_FULL)
+    if(RSSParameters->RSSMode != PARANDIS_RSS_MODE::PARANDIS_RSS_FULL)
     {
         res = PARANDIS_RECEIVE_NO_QUEUE;
     }


### PR DESCRIPTION
The driver still has CA warning 26812 in *.tmh files, generated by WPP.
There is no way to generate 'enum class' in *.tmh.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>