### PR TITLE
NetKVM: add DmaRemappingCompatible to INF

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -209,6 +209,7 @@ ErrorControl    = 1 ;%SERVICE_ERROR_NORMAL%
 ServiceBinary   = %12%\netkvm.sys
 LoadOrderGroup  = NDIS
 AddReg          = TextModeFlags.Reg
+AddReg          = DmaRemappingCompatible.Reg
 
 [kvmnet6.EventLog]
 AddReg = kvmnet6.AddEventLog.Reg
@@ -221,6 +222,9 @@ HKR, , TypesSupported,   0x00010001, 7
 HKR,,TextModeFlags,0x00010001, 0x0001
 HKR,Parameters,DisableMSI,,"0"
 HKR,Parameters,EarlyDebug,,"3"
+
+[DmaRemappingCompatible.Reg]
+HKR,Parameters,DmaRemappingCompatible,0x00010001,1
 
 [SourceDisksNames]
 1 = %DiskId1%,,,""


### PR DESCRIPTION
Indicate that the driver is fully compatible with DMA remapping.

INF tested with 
* Windows HLK 2022 (InfVerifHLK.dll, 10.0.20348.1)
* Windows HLK 1607 (InfVerifHLK.dll, 10.0.14393.4)
* Windows HCK 2.1 (InfTest.exe, 6.3.9600.17298)
