### PR TITLE
balloon: fix C28170 warning for 'StatInitializeWorkItem'

### DIFF
--- a/Balloon/sys/memstat.c
+++ b/Balloon/sys/memstat.c
@@ -196,6 +196,8 @@ NTSTATUS StatInitializeWorkItem(
     WDF_WORKITEM_CONFIG     workitemConfig;
     PDEVICE_CONTEXT devCtx = GetDeviceContext(Device);
 
+    PAGED_CODE();
+
     RtlZeroMemory(Counters, sizeof(Counters));
 
     WDF_OBJECT_ATTRIBUTES_INIT(&attributes);


### PR DESCRIPTION
warning C28170: The function 'StatInitializeWorkItem' has been declared to be
in a paged segment, but neither PAGED_CODE nor PAGED_CODE_LOCKED was found:
This warning is not emitted for functions that are __forceinline.

This warning makes Static Tools Logo Test to fail due to the warning marked as
'Must Fix'.

Signed-off-by: Sergey Bykov <sergey.bykov@nutanix.com>