### PR TITLE
NetKVM: fix uninitialized variables found by CodeAnalysis

### DIFF
--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -43,7 +43,7 @@ private:
     LIST_ENTRY              m_NetReceiveBuffers;
     UINT                    m_NetNofReceiveBuffers;
 
-    UINT m_nReusedRxBuffersCounter, m_nReusedRxBuffersLimit;
+    UINT m_nReusedRxBuffersCounter, m_nReusedRxBuffersLimit = 0;
 
     bool m_Reinsert = true;
 

--- a/NetKVM/Common/ParaNdis-Util.h
+++ b/NetKVM/Common/ParaNdis-Util.h
@@ -389,7 +389,7 @@ protected:
         template<typename type, typename AnyAccess, typename AnyStrategy>               \
         friend class CNdisList;                                                         \
                                                                                         \
-        LIST_ENTRY m_ListEntry
+        LIST_ENTRY m_ListEntry{}
 
 
 template <typename TEntryType, typename TAccessStrategy, typename TCountingStrategy>

--- a/NetKVM/Common/ParaNdis-VirtQueue.h
+++ b/NetKVM/Common/ParaNdis-VirtQueue.h
@@ -68,7 +68,7 @@ public:
 
 private:
     CNdisSharedMemory m_HeadersBuffer;
-    ULONG m_VirtioHdrSize;
+    ULONG m_VirtioHdrSize = 0;
 
     PVOID m_VlanHeaderVA = nullptr;
     PVOID m_VirtioHeaderVA = nullptr;
@@ -80,7 +80,7 @@ private:
     PHYSICAL_ADDRESS m_EthHeaderPA = PHYSICAL_ADDRESS();
     PHYSICAL_ADDRESS m_IPHeadersPA = PHYSICAL_ADDRESS();
 
-    ULONG m_MaxEthHeadersSize;
+    ULONG m_MaxEthHeadersSize = 0;
 
     CTXHeaders(const CTXHeaders&) = delete;
     CTXHeaders& operator= (const CTXHeaders&) = delete;
@@ -129,12 +129,12 @@ public:
 private:
     CTXHeaders m_Headers;
     CNdisSharedMemory m_IndirectArea;
-    bool m_Indirect;
-    bool m_AnyLayout;
+    bool m_Indirect = false;
+    bool m_AnyLayout = false;
 
-    struct VirtIOBufferDescriptor *m_VirtioSGL;
-    ULONG m_VirtioSGLSize;
-    ULONG m_CurrVirtioSGLEntry;
+    struct VirtIOBufferDescriptor *m_VirtioSGL = nullptr;
+    ULONG m_VirtioSGLSize = 0;
+    ULONG m_CurrVirtioSGLEntry = 0;
 
     ULONG m_UsedBuffersNum = 0;
     CNB *m_NB = nullptr;
@@ -298,8 +298,8 @@ private:
     void ReleaseOneBuffer(CTXDescriptor *TXDescriptor, CRawCNBList& listDone);
     bool PrepareBuffers();
     void FreeBuffers();
-    ULONG m_MaxBuffers;
-    ULONG m_HeaderSize;
+    ULONG m_MaxBuffers = 0;
+    ULONG m_HeaderSize = 0;
 
     void KickQueueOnOverflow();
     void UpdateTXStats(const CNB &NB, CTXDescriptor &Descriptor);
@@ -318,5 +318,5 @@ private:
     bool  m_Killed = false;
 
     //TODO Temporary, must go way
-    PPARANDIS_ADAPTER m_Context;
+    PPARANDIS_ADAPTER m_Context = nullptr;
 };

--- a/NetKVM/Common/ParaNdis_Protocol.cpp
+++ b/NetKVM/Common/ParaNdis_Protocol.cpp
@@ -1426,9 +1426,9 @@ void CProtocolBinding::SetRSS()
     COidWrapperAsync *p = NULL;
     struct RSSSet : public CNdisAllocatable<RSSSet, 'SORP'>
     {
-        NDIS_RECEIVE_SCALE_PARAMETERS rsp;
-        UCHAR key[NDIS_RSS_HASH_SECRET_KEY_MAX_SIZE_REVISION_1];
-        UCHAR indirection[NDIS_RSS_INDIRECTION_TABLE_MAX_SIZE_REVISION_2];
+        NDIS_RECEIVE_SCALE_PARAMETERS rsp{};
+        UCHAR key[NDIS_RSS_HASH_SECRET_KEY_MAX_SIZE_REVISION_1]{};
+        UCHAR indirection[NDIS_RSS_INDIRECTION_TABLE_MAX_SIZE_REVISION_2]{};
     };
     auto current = new (m_Protocol.DriverHandle()) RSSSet;
     bSkip = !current || bSkip;
@@ -1488,7 +1488,7 @@ void CProtocolBinding::SetOffloadEncapsulation()
     COidWrapperAsync *p = NULL;
     struct EncapSet : public CNdisAllocatable<EncapSet, 'EORP'>
     {
-        NDIS_OFFLOAD_ENCAPSULATION e;
+        NDIS_OFFLOAD_ENCAPSULATION e{};
     };
     auto current = new (m_Protocol.DriverHandle()) EncapSet;
     bSkip = !current || bSkip;
@@ -1552,7 +1552,7 @@ void CProtocolBinding::SetOffloadParameters()
     COidWrapperAsync *p = NULL;
     struct OffloadParam : public CNdisAllocatable<OffloadParam, 'EORP'>
     {
-        NDIS_OFFLOAD_PARAMETERS o;
+        NDIS_OFFLOAD_PARAMETERS o{};
     };
     auto current = new (m_Protocol.DriverHandle()) OffloadParam;
     bSkip = !current || bSkip;

--- a/NetKVM/Common/ethernetutils.h
+++ b/NetKVM/Common/ethernetutils.h
@@ -205,8 +205,8 @@ typedef struct _IPv6NSMOverEthernetPacket {
 
 // This struct is used for calculating the checksum
 typedef struct _ICMPv6PseudoHeader {
-    ipv6_address source_address;
-    ipv6_address destination_address;
+    ipv6_address source_address{};
+    ipv6_address destination_address{};
     UINT32 icmpv6_length;
     UINT16 zeropad0 = 0;
     UINT8 zeropad1 = 0;


### PR DESCRIPTION
Fix uninitialized class/structure members found by CodeAnalysis (C26495). Most of the warnings were produced by uninitialized `LIST_ENTRY m_ListEntry`. For now, all of C26495 warnings have gone.