### PR TITLE
NetKVM: Fix dropping IPv6 IPsec packets.

### DIFF
--- a/NetKVM/Common/sw_offload.cpp
+++ b/NetKVM/Common/sw_offload.cpp
@@ -955,6 +955,8 @@ BOOLEAN AnalyzeIP6Hdr(
         case PROTOCOL_UDP:
             __fallthrough;
         case IP6_HDR_FRAGMENT:
+            __fallthrough;
+        case IP6_HDR_ESP:
             return TRUE;
         case IP6_HDR_DESTINATION:
             {
@@ -986,8 +988,6 @@ BOOLEAN AnalyzeIP6Hdr(
             }
             break;
         case IP6_HDR_HOP_BY_HOP:
-            __fallthrough;
-        case IP6_HDR_ESP:
             __fallthrough;
         case IP6_HDR_AUTHENTICATION:
             __fallthrough;


### PR DESCRIPTION
IPv6 ESP header is treated as usual header(TCP, UDP etc.) by this change.

ESP header should not be treated like other extension headers.
Because it does not start with 'Next Header' field and next header is encrypted.
So base version of NetKVM drops IPv6 ESP(IPsec) packet as malformed packet.