### PR TITLE
VirtIORNG: add DmaRemappingCompatible to INF

### DIFF
--- a/viorng/viorng/viorng.inf
+++ b/viorng/viorng/viorng.inf
@@ -78,6 +78,10 @@ StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %12%\viorng.sys
 LoadOrderGroup = Extended Base
+AddReg         = DmaRemappingCompatible.Reg
+
+[DmaRemappingCompatible.Reg]
+HKR,Parameters,DmaRemappingCompatible,0x00010001,1
 
 ; -------------------------
 ; RNG Provider Installation


### PR DESCRIPTION
Indicate that the driver is fully compatible with DMA remapping.