### PR TITLE
Revert "NetKVM: add DmaRemappingCompatible to INF"

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -210,7 +210,6 @@ ErrorControl    = 1 ;%SERVICE_ERROR_NORMAL%
 ServiceBinary   = %12%\netkvm.sys
 LoadOrderGroup  = NDIS
 AddReg          = TextModeFlags.Reg
-AddReg          = DmaRemappingCompatible.Reg
 
 [kvmnet6.EventLog]
 AddReg = kvmnet6.AddEventLog.Reg
@@ -223,9 +222,6 @@ HKR, , TypesSupported,   0x00010001, 7
 HKR,,TextModeFlags,0x00010001, 0x0001
 HKR,Parameters,DisableMSI,,"0"
 HKR,Parameters,EarlyDebug,,"3"
-
-[DmaRemappingCompatible.Reg]
-HKR,Parameters,DmaRemappingCompatible,0x00010001,1
 
 [SourceDisksNames]
 1 = %DiskId1%,,,""


### PR DESCRIPTION
This reverts commit 2a56978d5c9a7e60060d4ba4ebea7db34f4b1183.

RX and TX packet corruption occurs when IO-MMU is enabled along with vhost=on.