### PR TITLE
VirtIOFS: RHBZ#1996500: support device unplug/hotplug

### DIFF
--- a/viofs/svc/virtiofs.vcxproj
+++ b/viofs/svc/virtiofs.vcxproj
@@ -101,7 +101,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\WinFsp\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CfgMgr32.lib;netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>winfsp-$(PlatformTarget).dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
@@ -120,7 +120,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CfgMgr32.lib;netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>winfsp-$(PlatformTarget).dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
@@ -139,7 +139,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CfgMgr32.lib;netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>winfsp-$(PlatformTarget).dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
@@ -163,7 +163,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CfgMgr32.lib;netapi32.lib;wtsapi32.lib;setupapi.lib;winfsp-$(PlatformTarget).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\WinFsp\lib</AdditionalLibraryDirectories>
       <DelayLoadDLLs>winfsp-$(PlatformTarget).dll</DelayLoadDLLs>
     </Link>


### PR DESCRIPTION
How to test:

* Use QMP commmand 
`{"execute":"device_add","arguments":{"driver":"vhost-user-fs-pci","id":"fs-pci1","bus":"pci.7","tag":"myfs","queue-size":"1024","chardev":"chr-vu-fs0"}}`
 to add the device. A VirtIO-FS drive should appear in the guest.
* Use 
`{"execute":"device_del","arguments":{"id":"fs-pci1"}}` 
to delete the device. The drive should disappear and something like 
`{"timestamp": {"seconds": 1637196945, "microseconds": 957654}, "event": "DEVICE_DELETED", "data": {"path": "/machine/peripheral/fs-pci1/virtio-backend"}}`
`{"timestamp": {"seconds": 1637196946, "microseconds": 8101}, "event": "DEVICE_DELETED", "data": {"device": "fs-pci1", "path": "/machine/peripheral/fs-pci1"}}`
should be written to QMP.
* Device enable/disable in Device Manager should also work.