### PR TITLE
Vioscsi: code cleanup and lun reset hendler

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -546,7 +546,7 @@ ENTER_FN();
     if (dataLen < (sizeof(SRB_IO_CONTROL) + sizeof(FIRMWARE_REQUEST_BLOCK))) {
         srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
-        RhelDbgPrint(TRACE_LEVEL_FATAL,
+        RhelDbgPrint(TRACE_LEVEL_ERROR,
                          " FirmwareRequest Bad Block Length  %ul\n", dataLen);
         return;
     }
@@ -557,7 +557,7 @@ ENTER_FN();
     case FIRMWARE_FUNCTION_GET_INFO: {
         PSTORAGE_FIRMWARE_INFO_V2   firmwareInfo;
         firmwareInfo = (PSTORAGE_FIRMWARE_INFO_V2)((PUCHAR)srbControl + firmwareRequest->DataBufferOffset);
-        RhelDbgPrint(TRACE_LEVEL_FATAL,
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                          " FIRMWARE_FUNCTION_GET_INFO \n");
         if ((firmwareInfo->Version >= STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION_V2) ||
             (firmwareInfo->Size >= sizeof(STORAGE_FIRMWARE_INFO_V2))) {
@@ -585,7 +585,7 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_FATAL,
+            RhelDbgPrint(TRACE_LEVEL_ERROR,
                          " Wrong Version %ul or Size %ul\n", firmwareInfo->Version, firmwareInfo->Size);
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
@@ -595,7 +595,7 @@ ENTER_FN();
     case FIRMWARE_FUNCTION_DOWNLOAD: {
         PSTORAGE_FIRMWARE_DOWNLOAD_V2   firmwareDwnld;
         firmwareDwnld = (PSTORAGE_FIRMWARE_DOWNLOAD_V2)((PUCHAR)srbControl + firmwareRequest->DataBufferOffset);
-        RhelDbgPrint(TRACE_LEVEL_FATAL,
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
             " FIRMWARE_FUNCTION_DOWNLOAD \n");
         if ((firmwareDwnld->Version >= STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2) ||
             (firmwareDwnld->Size >= sizeof(STORAGE_FIRMWARE_DOWNLOAD_V2))) {
@@ -606,7 +606,7 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_FATAL,
+            RhelDbgPrint(TRACE_LEVEL_ERROR,
                 " Wrong Version %ul or Size %ul\n", firmwareDwnld->Version, firmwareDwnld->Size);
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
@@ -624,17 +624,17 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_FATAL,
+            RhelDbgPrint(TRACE_LEVEL_ERROR,
                 " Wrong Version %ul or Size %ul\n", firmwareActivate->Version, firmwareActivate->Size);
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
         }
-        RhelDbgPrint(TRACE_LEVEL_FATAL,
+        RhelDbgPrint(TRACE_LEVEL_VERBOSE,
             " FIRMWARE_FUNCTION_ACTIVATE \n");
     }
     break;
     default:
-        RhelDbgPrint(TRACE_LEVEL_FATAL,
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                      " Unsupported Function %ul\n", firmwareRequest->Function);
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_INVALID_REQUEST);
         break;

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -65,9 +65,6 @@ ENTER_FN_SRB();
 
     if (Srb) {
         if (adaptExt->num_queues > 1) {
-#ifdef USE_CPU_TO_VQ_MAP
-        QueueNumber = adaptExt->cpu_to_vq_map[srbExt->cpu] + VIRTIO_SCSI_REQUEST_QUEUE_0;
-#else // USE_CPU_TO_VQ_MAP
             STARTIO_PERFORMANCE_PARAMETERS param;
             param.Size = sizeof(STARTIO_PERFORMANCE_PARAMETERS);
             status = StorPortGetStartIoPerfParams(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, &param);
@@ -86,7 +83,6 @@ ENTER_FN_SRB();
         srbExt->vq_num = QueueNumber;
         element = &adaptExt->pending_list[QueueNumber - VIRTIO_SCSI_REQUEST_QUEUE_0];
         ExInterlockedInsertTailList(&element->srb_list, &srbExt->list_entry, &element->srb_list_lock);
-#endif // USE_CPU_TO_VQ_MAP
     }
     else {
         QueueNumber = MESSAGE_TO_QUEUE(MessageID);

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -129,15 +129,6 @@ ENTER_FN_SRB();
     if (notify) {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
     }
-#ifdef USE_WORK_ITEM
-#if (NTDDI_VERSION > NTDDI_WIN7)
-    if (adaptExt->num_queues > 1) {
-        if (CHECKFLAG(adaptExt->perfFlags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO)) {
-            ProcessQueue(DeviceExtension, MessageId, FALSE);
-        }
-    }
-#endif
-#endif
 EXIT_FN_SRB();
 }
 
@@ -327,9 +318,6 @@ ENTER_FN();
     }
     if (CHECKBIT(adaptExt->features, VIRTIO_RING_F_INDIRECT_DESC)) {
         guestFeatures |= (1ULL << VIRTIO_RING_F_INDIRECT_DESC);
-        if(!adaptExt->dump_mode) {
-            adaptExt->indirect = TRUE;
-        }
     }
     if (CHECKBIT(adaptExt->features, VIRTIO_SCSI_F_CHANGE)) {
         guestFeatures |= (1ULL << VIRTIO_SCSI_F_CHANGE);
@@ -370,7 +358,7 @@ InitVirtIODevice(
 
 BOOLEAN
 InitHW(
-    IN PVOID DeviceExtension, 
+    IN PVOID DeviceExtension,
     IN PPORT_CONFIGURATION_INFORMATION ConfigInfo
     )
 {
@@ -493,7 +481,7 @@ EXIT_ERR();
 BOOLEAN
 KickEvent(
     IN PVOID DeviceExtension,
-    IN PVirtIOSCSIEventNode EventNode 
+    IN PVirtIOSCSIEventNode EventNode
     )
 {
     PADAPTER_EXTENSION adaptExt;

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -49,8 +49,6 @@
 #define CACHE_LINE_SIZE 64
 #define ROUND_TO_CACHE_LINES(Size)  (((ULONG_PTR)(Size) + CACHE_LINE_SIZE - 1) & ~(CACHE_LINE_SIZE - 1))
 
-
-#if (NTDDI_VERSION > NTDDI_WIN7)
 #include <srbhelper.h>
 
 // Note: SrbGetCdbLength is defined in srbhelper.h
@@ -100,30 +98,6 @@ SrbGetPnpInfo(_In_ PVOID Srb, ULONG* PnPFlags, ULONG* PnPAction) {
 #define SRB_SET_SRB_STATUS(Srb, status) SrbSetSrbStatus(Srb, status)
 #define SRB_GET_SRB_STATUS(Srb, status) status = SrbSetSrbStatus(Srb)
 #define SRB_SET_DATA_TRANSFER_LENGTH(Srb, Len) SrbSetDataTransferLength(Srb, Len)
-#else
-#define PSRB_TYPE PSCSI_REQUEST_BLOCK
-#define PSRB_WMI_DATA PSCSI_WMI_REQUEST_BLOCK
-#define PSTOR_DEVICE_CAPABILITIES_TYPE PSTOR_DEVICE_CAPABILITIES
-#define SRB_EXTENSION(Srb) (PSRB_EXTENSION)Srb->SrbExtension
-#define SRB_FUNCTION(Srb) Srb->Function
-#define SRB_CDB(Srb) (PCDB)&Srb->Cdb[0]
-#define SRB_CDB_LENGTH(Srb) Srb->CdbLength
-#define SRB_FLAGS(Srb) Srb->SrbFlags
-#define SRB_PATH_ID(Srb) Srb->PathId
-#define SRB_TARGET_ID(Srb) Srb->TargetId
-#define SRB_LUN(Srb) Srb->Lun
-#define SRB_DATA_BUFFER(Srb) Srb->DataBuffer
-#define SRB_DATA_TRANSFER_LENGTH(Srb) Srb->DataTransferLength
-#define SRB_LENGTH(Srb) Srb->Length
-#define SRB_WMI_DATA(Srb) (PSCSI_WMI_REQUEST_BLOCK)Srb
-#define SRB_GET_SENSE_INFO(Srb, senseInfoBuffer, senseInfoBufferLen) senseInfoBuffer = Srb->SenseInfoBuffer;senseInfoBufferLen = Srb->SenseInfoBufferLength
-#define SRB_GET_PNP_INFO(Srb, PnPFlags, PnPAction) PnPFlags = ((PSCSI_PNP_REQUEST_BLOCK)Srb)->SrbPnPFlags; PnPAction = ((PSCSI_PNP_REQUEST_BLOCK)Srb)->PnPAction
-#define SRB_SET_SCSI_STATUS(Srb, status) Srb->ScsiStatus = status
-#define SRB_GET_SCSI_STATUS(Srb, status) status = Srb->ScsiStatus
-#define SRB_SET_SRB_STATUS(Srb, status) Srb->SrbStatus = status
-#define SRB_GET_SRB_STATUS(Srb, status) status = Srb->SrbStatus
-#define SRB_SET_DATA_TRANSFER_LENGTH(Srb, Len) Srb->DataTransferLength = Len
-#endif
 
 VOID
 SendSRB(

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -165,7 +165,7 @@ InitVirtIODevice(
 
 BOOLEAN
 InitHW(
-    IN PVOID DeviceExtension, 
+    IN PVOID DeviceExtension,
     IN PPORT_CONFIGURATION_INFORMATION ConfigInfo
     );
 
@@ -179,7 +179,7 @@ LogError(
 BOOLEAN
 KickEvent(
     IN PVOID DeviceExtension,
-    IN PVirtIOSCSIEventNode event 
+    IN PVirtIOSCSIEventNode event
     );
 
 BOOLEAN

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -102,9 +102,7 @@ SrbGetPnpInfo(_In_ PVOID Srb, ULONG* PnPFlags, ULONG* PnPAction) {
 VOID
 SendSRB(
     IN PVOID DeviceExtension,
-    IN PSRB_TYPE Srb,
-    IN BOOLEAN isr,
-    IN ULONG MessageID
+    IN PSRB_TYPE Srb
     );
 
 BOOLEAN
@@ -207,6 +205,12 @@ VioScsiPoolAlloc(
     IN PVOID DeviceExtension,
     IN SIZE_T size
     );
+
+VOID
+CompleteRequest(
+    IN PVOID DeviceExtension,
+    IN PSRB_TYPE Srb
+ );
 
 #if (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
 VOID FirmwareRequest(

--- a/vioscsi/trace.h
+++ b/vioscsi/trace.h
@@ -30,15 +30,14 @@
 #ifndef ___TRACING_H___
 #define ___TRACING_H___
 
-#include <ntddk.h>
-#include <storport.h>
-#include <stdarg.h>
-#include "kdebugprint.h"
-
 //#define DBG 1
 //#define PRINT_DEBUG 1
 //#define COM_DEBUG 1
 
+#include <ntddk.h>
+#include <storport.h>
+#include <stdarg.h>
+#include "kdebugprint.h"
 
 char *DbgGetScsiOpStr(PSCSI_REQUEST_BLOCK Srb);
 
@@ -70,8 +69,11 @@ extern int nVioscsiDebugLevel;
 #define RhelDbgPrint(Level, MSG, ...) \
     if ((!bDebugPrint) || Level > nVioscsiDebugLevel) {} \
     else VirtioDebugPrintProc (MSG, __VA_ARGS__)
+#define VioScsiDbgBreak()\
+    if (KD_DEBUGGER_ENABLED && !KD_DEBUGGER_NOT_PRESENT) DbgBreakPoint();
 #else
 #define RhelDbgPrint(Level, MSG, ...) 
+#define VioScsiDbgBreak()
 #endif
 
 void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING RegistryPath);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -574,9 +574,7 @@ ENTER_FN();
     }
     ConfigInfo->MaxIOsPerLun = adaptExt->queue_depth * adaptExt->num_queues;
     ConfigInfo->InitialLunQueueDepth = ConfigInfo->MaxIOsPerLun;
-    if (ConfigInfo->MaxIOsPerLun * ConfigInfo->MaximumNumberOfTargets > ConfigInfo->MaxNumberOfIO) {
-        ConfigInfo->MaxNumberOfIO = ConfigInfo->MaxIOsPerLun * ConfigInfo->MaximumNumberOfTargets;
-    }
+    ConfigInfo->MaxNumberOfIO = ConfigInfo->MaxIOsPerLun;
 
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " breaks_number = %x  queue_depth = %x\n",
                 ConfigInfo->NumberOfPhysicalBreaks,

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -67,7 +67,6 @@ HW_ADAPTER_CONTROL   VioScsiAdapterControl;
 HW_INTERRUPT         VioScsiInterrupt;
 HW_DPC_ROUTINE       VioScsiCompleteDpcRoutine;
 HW_PASSIVE_INITIALIZE_ROUTINE         VioScsiIoPassiveInitializeRoutine;
-HW_WORKITEM          VioScsiWorkItemCallback;
 HW_MESSAGE_SIGNALED_INTERRUPT_ROUTINE VioScsiMSInterrupt;
 #endif
 
@@ -1424,17 +1423,12 @@ ProcessQueue(
     ULONG               index = MESSAGE_TO_QUEUE(MessageID) - VIRTIO_SCSI_REQUEST_QUEUE_0;
     STOR_LOCK_HANDLE    queueLock = { 0 };
     struct virtqueue    *vq;
-    BOOLEAN             handleResponseInline;
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     LIST_ENTRY          complete_list;
     PSRB_TYPE           Srb = NULL;
     PSRB_EXTENSION      srbExt = NULL;
 ENTER_FN();
-#ifdef USE_WORK_ITEM
-    handleResponseInline = (adaptExt->num_queues == 1);
-#else
-    handleResponseInline = TRUE;
-#endif
+
     vq = adaptExt->vq[VIRTIO_SCSI_REQUEST_QUEUE_0 + index];
     InitializeListHead(&complete_list);
 
@@ -1443,31 +1437,9 @@ ENTER_FN();
     do {
         virtqueue_disable_cb(vq);
         while ((cmd = (PVirtIOSCSICmd)virtqueue_get_buf(vq, &len)) != NULL) {
-            if (handleResponseInline) {
-                Srb = (PSRB_TYPE)(cmd->srb);
-                srbExt = SRB_EXTENSION(Srb);
-                InsertTailList(&complete_list, &srbExt->list_entry);
-            }
-#ifdef USE_WORK_ITEM
-            else {
-#if (NTDDI_VERSION > NTDDI_WIN7)
-                PSRB_TYPE Srb = (PSRB_TYPE)(cmd->srb);
-                PSRB_EXTENSION srbExt = SRB_EXTENSION(Srb);
-                ULONG status = STOR_STATUS_SUCCESS;
-                PSTOR_SLIST_ENTRY Result = NULL;
-                VioScsiVQUnlock(DeviceExtension, MessageID, &queueLock, isr);
-                srbExt->priv = (PVOID)cmd;
-                status = StorPortInterlockedPushEntrySList(DeviceExtension, &adaptExt->srb_list[index], &srbExt->list_entry, &Result);
-                if (status != STOR_STATUS_SUCCESS) {
-                    RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortInterlockedPushEntrySList failed with status 0x%x\n\n", status);
-                }
-                cnt++;
-                VioScsiVQLock(DeviceExtension, MessageID, &queueLock, isr);
-#else
-                NT_ASSERT(0);
-#endif
-            }
-#endif
+            Srb = (PSRB_TYPE)(cmd->srb);
+            srbExt = SRB_EXTENSION(Srb);
+            InsertTailList(&complete_list, &srbExt->list_entry);
         }
     } while (!virtqueue_enable_cb(vq));
 
@@ -1480,25 +1452,6 @@ ENTER_FN();
         HandleResponse(DeviceExtension, &srbExt->cmd);
     }
 
-#ifdef USE_WORK_ITEM
-#if (NTDDI_VERSION > NTDDI_WIN7)
-    if (cnt) {
-       ULONG status = STOR_STATUS_SUCCESS;
-       PVOID Worker = NULL;
-       status = StorPortInitializeWorker(DeviceExtension, &Worker);
-       if (status != STOR_STATUS_SUCCESS) {
-          RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortInitializeWorker failed with status 0x%x\n\n", status);
-//FIXME   VioScsiWorkItemCallback
-          return;
-       }
-       status = StorPortQueueWorkItem(DeviceExtension, &VioScsiWorkItemCallback, Worker, ULongToPtr(MessageID));
-       if (status != STOR_STATUS_SUCCESS) {
-          RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortQueueWorkItem failed with status 0x%x\n\n", status);
-//FIXME   VioScsiWorkItemCallback
-       }
-    }
-#endif
-#endif
 EXIT_FN();
 }
 
@@ -2391,70 +2344,3 @@ ENTER_FN();
 
 EXIT_FN();
 }
-
-#ifdef USE_WORK_ITEM
-#if (NTDDI_VERSION > NTDDI_WIN7)
-VOID
-VioScsiWorkItemCallback(
-    _In_ PVOID DeviceExtension,
-    _In_opt_ PVOID Context,
-    _In_ PVOID Worker
-    )
-{
-    ULONG MessageId = PtrToUlong(Context);
-    ULONG status = STOR_STATUS_SUCCESS;
-    ULONG index = MESSAGE_TO_QUEUE(MessageId) - VIRTIO_SCSI_REQUEST_QUEUE_0;
-    PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    PSTOR_SLIST_ENTRY   listEntryRev, listEntry;
-ENTER_FN();
-    status = StorPortInterlockedFlushSList(DeviceExtension, &adaptExt->srb_list[index], &listEntryRev);
-    if ((status == STOR_STATUS_SUCCESS) && (listEntryRev != NULL)) {
-        KAFFINITY old_affinity, new_affinity;
-        old_affinity = new_affinity = 0;
-#if 1
-        listEntry = listEntryRev;
-#else
-        listEntry = NULL;
-        while (listEntryRev != NULL) {
-            next = listEntryRev->Next;
-            listEntryRev->Next = listEntry;
-            listEntry = listEntryRev;
-            listEntryRev = next;
-        }
-#endif
-        while(listEntry)
-        {
-            PVirtIOSCSICmd  cmd = NULL;
-            PSRB_TYPE Srb = NULL;
-            PSRB_EXTENSION srbExt = NULL;
-            PSTOR_SLIST_ENTRY next = listEntry->Next;
-            srbExt = CONTAINING_RECORD(listEntry,
-                        SRB_EXTENSION, list_entry);
-
-            ASSERT(srExt);
-            Srb = (PSRB_TYPE)(srbExt->Srb);
-            cmd = (PVirtIOSCSICmd)srbExt->priv;
-            ASSERT(cmd);
-            if (new_affinity == 0) {
-                new_affinity = ((KAFFINITY)1) << srbExt->cpu;
-                old_affinity = KeSetSystemAffinityThreadEx(new_affinity);
-            }
-            HandleResponse(DeviceExtension, cmd);
-            listEntry = next;
-        }
-        if (new_affinity != 0) {
-            KeRevertToUserAffinityThreadEx(old_affinity);
-        }
-    }
-    else if (status != STOR_STATUS_SUCCESS) {
-       RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortInterlockedPushEntrySList failed with status 0x%x\n\n", status);
-    }
-
-    status = StorPortFreeWorker(DeviceExtension, Worker);
-    if (status != STOR_STATUS_SUCCESS) {
-       RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortFreeWorker failed with status 0x%x\n\n", status);
-    }
-EXIT_FN();
-}
-#endif
-#endif

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -254,9 +254,6 @@ typedef struct _SRB_EXTENSION {
     PVRING_DESC_ALIAS     pdesc;
     VIO_SG                vio_sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS      desc_alias[VIRTIO_MAX_SG];
-#ifdef USE_CPU_TO_VQ_MAP
-    ULONG                 cpu;
-#endif // USE_CPU_TO_VQ_MAP
 }SRB_EXTENSION, * PSRB_EXTENSION;
 #pragma pack()
 
@@ -317,9 +314,6 @@ typedef struct _ADAPTER_EXTENSION {
     PVirtIOSCSIEventNode  events;
 
     ULONG                 num_queues;
-#ifdef USE_CPU_TO_VQ_MAP
-    UCHAR                 cpu_to_vq_map[MAX_CPU];
-#endif
     REQUEST_LIST          pending_list[MAX_CPU];
     ULONG                 perfFlags;
     PGROUP_AFFINITY       pmsg_affinity;

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -245,9 +245,8 @@ typedef struct _SRB_EXTENSION {
     ULONG                 in;
     ULONG                 Xfer;
     VirtIOSCSICmd         cmd;
-    ULONG                 vq_num;
-    PVIO_SG               psgl;
-    PVRING_DESC_ALIAS     pdesc;
+    PVIO_SG POINTER_ALIGN psgl;
+    PVRING_DESC_ALIAS POINTER_ALIGN pdesc;
     VIO_SG                vio_sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS      desc_alias[VIRTIO_MAX_SG];
 }SRB_EXTENSION, * PSRB_EXTENSION;
@@ -262,7 +261,7 @@ typedef struct {
 
 typedef struct _REQUEST_LIST {
     LIST_ENTRY            srb_list;
-    KSPIN_LOCK            srb_list_lock;
+    ULONG                 srb_cnt;
 } REQUEST_LIST, *PREQUEST_LIST;
 
 typedef struct virtio_bar {
@@ -310,7 +309,7 @@ typedef struct _ADAPTER_EXTENSION {
     PVirtIOSCSIEventNode  events;
 
     ULONG                 num_queues;
-    REQUEST_LIST          pending_list[MAX_CPU];
+    REQUEST_LIST          processing_srbs[MAX_CPU];
     ULONG                 perfFlags;
     PGROUP_AFFINITY       pmsg_affinity;
     BOOLEAN               dpc_ok;
@@ -325,6 +324,7 @@ typedef struct _ADAPTER_EXTENSION {
     UCHAR                 ven_id[8 + 1];
     UCHAR                 prod_id[16 + 1];
     UCHAR                 rev_id[4 + 1];
+    BOOLEAN               reset_in_progress;
 #if (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
     ULONGLONG             fw_ver;
 #endif

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -50,11 +50,7 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #endif
 
 #define PHYS_SEGMENTS           32
-#if (NTDDI_VERSION > NTDDI_WIN7)
 #define MAX_PHYS_SEGMENTS       512
-#else
-#define MAX_PHYS_SEGMENTS       64
-#endif
 #define VIOSCSI_POOL_TAG        'SoiV'
 #define VIRTIO_MAX_SG            (1+1+MAX_PHYS_SEGMENTS+1) //cmd + resp + (MAX_PHYS_SEGMENTS + extra_page)
 


### PR DESCRIPTION
- the legacy pre-Win8 code has been removed
- fix for [Bug 2013976] Add bus reset handler to vioscsi driver