### PR TITLE
[vioscsi] limit NumberOfPhysicalBreaks and MaximumTransferLength according to max_sectors

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -485,9 +485,13 @@ ENTER_FN();
             VioScsiReadRegistry(DeviceExtension);
         }
         ConfigInfo->NumberOfPhysicalBreaks = adaptExt->max_physical_breaks + 1;
+        if (adaptExt->scsi_config.max_sectors > 0 && adaptExt->scsi_config.max_sectors != 0xFFFF) {
+            ConfigInfo->NumberOfPhysicalBreaks = min (ConfigInfo->NumberOfPhysicalBreaks, adaptExt->scsi_config.max_sectors);
+            adaptExt->max_physical_breaks = ConfigInfo->NumberOfPhysicalBreaks - 1;
+        }
     }
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " NumberOfPhysicalBreaks %d\n", ConfigInfo->NumberOfPhysicalBreaks);
-    ConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;
+    ConfigInfo->MaximumTransferLength = ConfigInfo->NumberOfPhysicalBreaks * PAGE_SIZE;
 
     num_cpus = KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
     max_cpus = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);


### PR DESCRIPTION
Bugfix for Bug 2022656 - vioscsi:  Windows will fail to format a partition to NTFS with vioscsi+scsi-block
Please visit the following links for more information:
    https://github.com/virtio-win/kvm-guest-drivers-windows/pull/502
    https://github.com/virtio-win/kvm-guest-drivers-windows/pull/640
    https://github.com/virtio-win/kvm-guest-drivers-windows/issues/657
