### PR TITLE
VirtIOFS: fix pointer dereference in CloseDeviceInterface call

### DIFF
--- a/viofs/svc/virtiofs.c
+++ b/viofs/svc/virtiofs.c
@@ -331,7 +331,7 @@ static VOID VirtFsDevQueryRemove(VIRTFS *VirtFs, HCMNOTIFICATION Notify)
 
     VirtFsStop(VirtFs);
     VirtFsNotificationAsyncUnreg(&VirtFs->DevHandleNotification);
-    CloseDeviceInterface(VirtFs->Device);
+    CloseDeviceInterface(&VirtFs->Device);
 }
 
 DWORD WINAPI DeviceNotificationCallback(HCMNOTIFICATION Notify,
@@ -2636,7 +2636,7 @@ static NTSTATUS SvcStop(FSP_SERVICE *Service)
 
     VirtFsStop(VirtFs);
     VirtFsNotificationUnreg(&VirtFs->DevHandleNotification);
-    CloseDeviceInterface(VirtFs->Device);
+    CloseDeviceInterface(&VirtFs->Device);
     VirtFsNotificationDelete(&VirtFs->DevHandleNotification);
     CloseHandle(VirtFs->EvtDeviceFound);
     CM_Unregister_Notification(VirtFs->DevInterfaceNotification);


### PR DESCRIPTION
This patch fixes service fail at device removal. The problem was introduced in [6dd7cd8d](https://github.com/virtio-win/kvm-guest-drivers-windows/commit/6dd7cd8d88227a788af847b64f97c7900b287b2e).