### PR TITLE
FWCfg64: RHBZ#2035659: zero minidump buffer and check output

### DIFF
--- a/fwcfg64/driver.h
+++ b/fwcfg64/driver.h
@@ -24,6 +24,8 @@
     #define DUMP_HDR_OFFSET_BUGCHECK_PARAM1 0x2c
 #endif
 
+#define MINIDUMP_BUFFER_SIZE 0x40000
+
 #define ROUND_UP(x, n) (((x) + (n) - 1) & (-(n)))
 
 #pragma pack(push, 1)


### PR DESCRIPTION
We cannot rely on KeCapturePersistentThreadState when passing uninitialized buffer.
