### PR TITLE
vioscsi: fix MaximumTransferLength off-by-one and max_sectors handling

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -233,6 +233,7 @@ GetScsiConfig(
 ENTER_FN();
 
     adaptExt->features = virtio_get_features(&adaptExt->vdev);
+    adaptExt->indirect = CHECKBIT(adaptExt->features, VIRTIO_RING_F_INDIRECT_DESC);
 
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, seg_max),
                       &adaptExt->scsi_config.seg_max, sizeof(adaptExt->scsi_config.seg_max));


### PR DESCRIPTION
vioscsi: fix MaximumTransferLength off-by-one and max_sectors handling

This change fixes MaximumTransferLength and max_sectors handling as
described in #498 and #735.

- Changed initialization of seg_max to SCSI_MINIMUM_PHYSICAL_BREAKS. This
  gets immediately overwritten anyways; however, this seems like the most
  sane value to initialize this to, rather than MAX_PHYS_SEGMENTS.
- Squashed adaptExt->dump_mode branching into one set of if/then, which allows
  for adaptExt->indirect to be set immediately before it is evaluated.
- Moved adaptExt->indirect configuration to GetScsiConfig.
- Readded initialization of ConfigInfo->MaximumTransferLength to
  SP_UNINITIALIZED_VALUE. This immediately gets overwritten; however, it
  makes it clear what the starting point is (unlimited) so that we can
  intentionally *decrease* the value *down* from there.
- Initialized ConfigInfo->NumberOfPhysicalBreaks to
  SCSI_MINIMUM_PHYSICAL_BREAKS (i.e. 16), so we have a starting point to
  intentionally *increase* the value *up* from there.
- Calculate ConfigInfo->MaximumTransferLength using
  adaptExt->max_physical_breaks instead of ConfigInfo->NumberOfPhysicalBreaks,
  which fixes an off-by-one error that causes IO to slightly be larger than
  a platform might before (e.g. 2MB+4K max size vs 2MB IO max size when using
  512 segments).
- Respect max_sectors, such that max_sectors will have the final say in the
  maximum IO size. Note: If the user intentionally restricted the max IO size
  using the PhysicalBreaks registry key, it may be smaller than max_sectors.
- Changed name of VioScsiReadRegistry to reflect what its true purpose is,
  which is to read PhysicalBreaks key.

Fixes: #498 vioscsi (generic/block): does not work with xhci hosts that accept only read/write of 512 blocks
Fixes: #617 ConfigInfo->NumberOfPhysicalBreaks should be dependent on adaptExt->scsi_config.seg_max advertised by qemu
Fixes: #735 vioscsi IO sizes too large, causing BSOD on boot

Signed-off-by: Jon Kohler <jon@nutanix.com>