### PR TITLE
RHBZ#2062572: use 'hiprio' VQ for FORGET/BATCH_FORGET/INTERRUPT only

### DIFF
--- a/viofs/pci/viofs.c
+++ b/viofs/pci/viofs.c
@@ -119,14 +119,17 @@ NTSTATUS VirtFsEvtDeviceAdd(IN WDFDRIVER Driver,
     interruptConfig.EvtInterruptEnable = VirtFsEvtInterruptEnable;
     interruptConfig.EvtInterruptDisable = VirtFsEvtInterruptDisable;
 
-    status = WdfInterruptCreate(device, &interruptConfig,
-        WDF_NO_OBJECT_ATTRIBUTES, &context->WdfInterrupt);
-
-    if (!NT_SUCCESS(status))
+    for (ULONG idx = 0; idx < ARRAYSIZE(context->WdfInterrupt); idx++)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
-            "WdfInterruptCreate failed: %!STATUS!", status);
-        return status;
+        status = WdfInterruptCreate(device, &interruptConfig,
+            WDF_NO_OBJECT_ATTRIBUTES, &context->WdfInterrupt[idx]);
+
+        if (!NT_SUCCESS(status))
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT,
+                "WdfInterruptCreate #%ul failed: %!STATUS!", idx, status);
+            return status;
+        }
     }
 
     WDF_OBJECT_ATTRIBUTES_INIT(&attributes);

--- a/viofs/pci/viofs.h
+++ b/viofs/pci/viofs.h
@@ -47,6 +47,12 @@
 
 #define MAX_FILE_SYSTEM_NAME 36
 
+enum {
+    VQ_TYPE_HIPRIO = 0,
+    VQ_TYPE_REQUEST = 1,
+    VQ_TYPE_MAX = 2
+};
+
 typedef struct _VIRTIO_FS_CONFIG
 {
     CHAR Tag[MAX_FILE_SYSTEM_NAME];
@@ -79,10 +85,10 @@ void FreeVirtFsRequest(IN PVIRTIO_FS_REQUEST Request);
 typedef struct _DEVICE_CONTEXT {
 
     VIRTIO_WDF_DRIVER   VDevice;
-    UINT32              RequestQueues;
+    UINT32              NumQueues;
     struct virtqueue    **VirtQueues;
 
-    WDFINTERRUPT        WdfInterrupt;
+    WDFINTERRUPT        WdfInterrupt[VQ_TYPE_MAX];
     WDFSPINLOCK         *VirtQueueLocks;
 
     WDFLOOKASIDE        RequestsLookaside;

--- a/viofs/pci/viofs.inf
+++ b/viofs/pci/viofs.inf
@@ -56,7 +56,7 @@ viofs.sys
 HKR,Interrupt Management,,0x00000010
 HKR,Interrupt Management\MessageSignaledInterruptProperties,,0x00000010
 HKR,Interrupt Management\MessageSignaledInterruptProperties,MSISupported,0x00010001,1
-HKR,Interrupt Management\MessageSignaledInterruptProperties,MessageNumberLimit,0x00010001,1
+HKR,Interrupt Management\MessageSignaledInterruptProperties,MessageNumberLimit,0x00010001,2
 
 ; --------------------
 ; Service Installation


### PR DESCRIPTION
Before this patch all FUSE requests were made through 'hiprio' VQ.

To conform VirtIO specification, only FUSE_FORGET, FUSE_BATCH_FORGET, FUSE_INTERRUPT are submitted to 'hiprio' VQ. Other FUSE messages are submitted to first 'request' VQ.

The rest of 'request' VQs are still unused, but may be utilized in future:
- MessageNumber = 0 corresponds to 'hiprio' VQ
- MessageNumber = 1 corresponds to all of the 'request' VQs (although only one is used for now)