### PR TITLE
RHBZ#2063722: don't set O_RDWR/O_WRONLY as flags for FUSE_OPENDIR

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -1450,12 +1450,8 @@ static NTSTATUS Open(FSP_FILE_SYSTEM *FileSystem, PWSTR FileName,
             (FileContext->IsDirectory == TRUE) ? FUSE_OPENDIR : FUSE_OPEN,
             lookup_out.entry.nodeid, sizeof(open_in.open));
 
-        open_in.open.flags = AccessToUnixFlags(GrantedAccess);
-
-        if (FileContext->IsDirectory == TRUE)
-        {
-            open_in.open.flags |= O_DIRECTORY;
-        }
+        open_in.open.flags = FileContext->IsDirectory ?
+            (O_RDONLY | O_DIRECTORY) : AccessToUnixFlags(GrantedAccess);
 
         Status = VirtFsFuseRequest(VirtFs->Device, &open_in, sizeof(open_in),
             &open_out, sizeof(open_out));


### PR DESCRIPTION
Flags O_RDWR and O_WRONLY along with O_DIRECTORY cause EISDIR on the host during open(...). Actually, there is no need to involve write access when performing Create/Open of a directory. So, pass just O_RDONLY.