### PR TITLE
VirtIOFS: RHBZ#2024518: limit FUSE_READ out buffer size by max_pages

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -1588,7 +1588,7 @@ static NTSTATUS Read(FSP_FILE_SYSTEM *FileSystem, PVOID FileContext0,
     read_in.read.lock_owner = 0;
     read_in.read.flags = 0;
 
-    FUSE_HEADER_INIT(&read_in.hdr, FUSE_READ, FileContext->NodeId, Length);
+    FUSE_HEADER_INIT(&read_in.hdr, FUSE_READ, FileContext->NodeId, sizeof(read_in.read));
 
     Status = VirtFsFuseRequest(VirtFs->Device, &read_in, sizeof(read_in),
         read_out, sizeof(*read_out) + Length);


### PR DESCRIPTION
Host buffer size is limited, so FUSE_READ buffer must be also limited.
FUSE_INIT output has `max_pages` field (FUSE_MAX_PAGES flag) which can be used to set max buffer size.