### PR TITLE
adjust the maximum transfer lenght if VIRTIO_BLK_F_SEG_MAX flag is on

### DIFF
--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -592,7 +592,7 @@ RhelGetDiskGeometry(
                           &v, sizeof(v));
         adaptExt->info.size_max = v;
     } else {
-        adaptExt->info.size_max = SECTOR_SIZE;
+        adaptExt->info.size_max = PAGE_SIZE;
     }
 
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_SEG_MAX)) {


### PR DESCRIPTION
Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>

Reported-by: icessspark

for the problem description please visit 
https://github.com/virtio-win/kvm-guest-drivers-windows/issues/692
https://github.com/virtio-win/kvm-guest-drivers-windows/issues/578
and
https://github.com/virtio-win/kvm-guest-drivers-windows/issues/747