### PR TITLE
Revert "netkvm: do not complete packets in sending path"

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -424,22 +424,11 @@ void CParaNdisTX::NBLMappingDone(CNBL *NBLHolder)
     if (NBLHolder->MappingSucceeded() && m_VirtQueue.Alive())
     {
         m_SendQueue.Enqueue(NBLHolder);
-        // do not do anything if there is dpc processing for this TX
-        if (m_DpcWaiting) {
-            return;
-        }
 
-#if defined(ENABLE_COMPLETE_FROM_SEND)
-        DoPendingTasks(NBLHolder);
-#else
-        CRawCNBList  nbToFree;
-        CRawCNBLList completedNBLs;
+        if (m_DpcWaiting == 0)
         {
-            TDPCSpinLocker LockedContext(m_Lock);
-            SendMapped(false, completedNBLs);
+            DoPendingTasks(NBLHolder);
         }
-        PostProcessPendingTask(nbToFree, completedNBLs);
-#endif
     }
     else
     {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2067167
https://bugzilla.redhat.com/show_bug.cgi?id=2063594

This reverts commit 5fcd9ea620559e440ba4841b3a190fa6f9a22f15.
Mentioned commit was intended to solve the problem
https://bugzilla.redhat.com/show_bug.cgi?id=1972487

But during later tests it was found that the commit has triggered
other problems in perf6 and mpe tests
We revert the commit and continue the investigation

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>