### PR TITLE
RHBZ#2075862: VirtIO-FS: make the service stoppable

### DIFF
--- a/viofs/svc/fusereq.h
+++ b/viofs/svc/fusereq.h
@@ -287,3 +287,13 @@ typedef struct
     struct fuse_out_header  hdr;
 
 } FUSE_FORGET_OUT, * PFUSE_FORGET_OUT;
+
+typedef struct
+{
+    struct fuse_in_header   hdr;
+} FUSE_DESTROY_IN;
+
+typedef struct
+{
+    struct fuse_out_header  hdr;
+} FUSE_DESTROY_OUT;

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -279,13 +279,14 @@ static DWORD VirtFsRegDevHandleNotification(VIRTFS *VirtFs)
 
 VOID VIRTFS::Stop()
 {
-    FspFileSystemStopDispatcher(FileSystem);
-
-    if (FileSystem != NULL)
+    if (FileSystem == NULL)
     {
-        FspFileSystemDelete(FileSystem);
-        FileSystem = NULL;
+        return;
     }
+
+    FspFileSystemStopDispatcher(FileSystem);
+    FspFileSystemDelete(FileSystem);
+    FileSystem = NULL;
 
     LookupMap.clear();
 

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -2919,7 +2919,8 @@ int wmain(int argc, wchar_t **argv)
         return FspWin32FromNtStatus(Result);
     }
     FspServiceAllowConsoleMode(Service);
-    FspServiceAcceptControl(Service, SERVICE_ACCEPT_SESSIONCHANGE);
+    FspServiceAcceptControl(Service, SERVICE_ACCEPT_SESSIONCHANGE |
+        SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN);
     Result = FspServiceLoop(Service);
     ExitCode = FspServiceGetExitCode(Service);
     FspServiceDelete(Service);


### PR DESCRIPTION
Now service can be stopped by Service Manager, because it handles `SERVICE_CONTROL_STOP` and `SERVICE_CONTROL_SHUTDOWN`.

Besides of that, the service submits `FUSE_DESTROY` request to end FUSE session at service stop and device remove.