### PR TITLE
[viostor] don't return SRB_STATUS_SUCCESS for unsupport control codes

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -791,7 +791,7 @@ VirtIoHwInitialize(
                 if (CHECKFLAG(perfData.Flags, STOR_PERF_INTERRUPT_MESSAGE_RANGES)) {
                     adaptExt->perfFlags |= STOR_PERF_INTERRUPT_MESSAGE_RANGES;
                     perfData.FirstRedirectionMessageNumber = 1;
-                    perfData.LastRedirectionMessageNumber = adaptExt->msix_vectors - 1;
+                    perfData.LastRedirectionMessageNumber = adaptExt->num_queues - 1;
                 }
                 if (CHECKFLAG(perfData.Flags, STOR_PERF_CONCURRENT_CHANNELS)) {
                     adaptExt->perfFlags |= STOR_PERF_CONCURRENT_CHANNELS;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -919,7 +919,7 @@ VirtIoStartIo(
         case SRB_FUNCTION_IO_CONTROL: {
             PVOID           srbDataBuffer = SRB_DATA_BUFFER(Srb);
             PSRB_IO_CONTROL srbControl = (PSRB_IO_CONTROL)srbDataBuffer;
-            UCHAR srbStatus = SRB_STATUS_SUCCESS;
+            UCHAR srbStatus = SRB_STATUS_INVALID_REQUEST;
             switch (srbControl->ControlCode) {
 #if (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
             case IOCTL_SCSI_MINIPORT_FIRMWARE:


### PR DESCRIPTION
Some users use wmic.exe to retrieve disk serial number, full command line is
"wmic path win32_physicalmedia get serialNumber".

The command will random fail if viostor driver return SRB_STATUS_SUCCESS for
unsupport control codes. (In this case, the ctlcode is SMART_GET_VERSION,
SMART_SEND_DRIVE_COMMAND, or SMART_RCV_DRIVE_DATA, currently none of them
are supported, but viostor return STATUS_SUCCESS for these ioctl codes)

The workflow of "wmic path win32_physicalmedia get serialNumber" is:
1. call DeviceIOControlFile with ctlcode set to SMART_GET_VERSION/SMART_RCV_DRIVE_DATA;
2. if ioctl succeeded, parse ioctl buffer to check smart version and get serial number;
3. if ioctl failed or error occurred when parsing smart data in output buffer,
   use IOCTL_STORAGE_QUERY_PROPERTY to get serial number.
   IOCTL_STORAGE_QUERY_PROPERTY corresponding to SCSIOP_INQUIRY, what we actually expect.

Signed-off-by: junjiehua <junjiehua@tencent.com>