### PR TITLE
[viostor] don't return SRB_STATUS_SUCCESS for unsupported control codes

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -919,7 +919,7 @@ VirtIoStartIo(
         case SRB_FUNCTION_IO_CONTROL: {
             PVOID           srbDataBuffer = SRB_DATA_BUFFER(Srb);
             PSRB_IO_CONTROL srbControl = (PSRB_IO_CONTROL)srbDataBuffer;
-            UCHAR srbStatus = SRB_STATUS_SUCCESS;
+            UCHAR srbStatus = SRB_STATUS_INVALID_REQUEST;
             switch (srbControl->ControlCode) {
 #if (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
             case IOCTL_SCSI_MINIPORT_FIRMWARE:


### PR DESCRIPTION
On windows, we can use wmic.exe to retrieve disk serial number, full
command line is "wmic path win32_physicalmedia get serialNumber".

The command will random fail if driver returns SRB_STATUS_SUCCESS for
unsupport control codes. (In this case, the ctlcodes are SMART_GET_VERSION,
SMART_SEND_DRIVE_COMMAND, SMART_RCV_DRIVE_DATA, currently none of them
are supported by viostor)

"wmic path win32_physicalmedia get serialNumber" works as follow:

1. Call DeviceIOControlFile with SMART related ioctl codes;

2. If ioctl succeeded, parse ioctl buffer to check smart version and
   get serial number. (The driver returns SRB_STATUS_SUCCESS for these
   ioctl codes, but doesn't fill the output buffer with correct SAMRT data,
   so the output buffer contains random bytes, when caller trying to parse
   data in output buffer, the result is unpredictable)

3. If failed to parsing SMART data, one of the following will happen:
   a. print a error message like "invalid content" then exit immediately;
   b. turn to IOCTL_STORAGE_QUERY_PROPERTY,  serial number returned by this
      ioctl was from SCSIOP_INQUIRY, and it's what we actually expect;

4. If no error occurred when parsing the random data, it will get a wrong
   serial number, maybe empty, or some unrecognized characters;

5. If SAMRT ioctl failed, it will turn to IOCTL_STORAGE_QUERY_PROPERTY, and
   will not try to parse SMART data in output buffer.

In order to make sure wmic/wmiprvse can get correct serial number, this patch
modify default status SRB_STATUS_SUCCESS to SRB_STATUS_INVALID_REQUEST for
unsupported I/O control codes.

In fact, if we only want to fix the disk serial number, we just need to let SMART
related I/O control codes fail, but according to MSDN:

1. Whether a miniport driver handles SRB_FUNCTION_IO_CONTROL requests depends
   on whether the HBA is to provide dedicated support for a user-mode application.

2. All system-defined, required device I/O control requests sent to NT-based
   operating system storage class drivers are mapped to SRBs with the Function
   member set to SRB_FUNCTION_EXECUTE_SCSI, not to SRB_FUNCTION_IO_CONTROL.

So it's reasonable to fail all unsupported ioctl codes with SRB_STATUS_INVALID_REQUEST.

Signed-off-by: junjiehua <junjiehua@tencent.com>
Reviewed-by: yongduan <yongduan@tencent.com>