### PR TITLE
pvpanic: Support pvpanic PCI driver

### DIFF
--- a/pvpanic/PVPanic Package/PVPanic Package.vcxproj
+++ b/pvpanic/PVPanic Package/PVPanic Package.vcxproj
@@ -116,6 +116,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Inf Include="..\pvpanic\pvpanic-pci.inf" />
     <Inf Include="..\pvpanic\pvpanic.inf" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/pvpanic/pvpanic/pvpanic-pci.inf
+++ b/pvpanic/pvpanic/pvpanic-pci.inf
@@ -1,0 +1,91 @@
+;/*++
+;
+;INX_COPYRIGHT_1
+;INX_COPYRIGHT_2
+;
+;Module Name:
+;    pvpanic-pci.inf
+;
+;Abstract:
+;
+;Installation Notes:
+;    Using Devcon: Type "devcon install pvpanic-pci.inf PCI\VEN_1B36&DEV_0011&SUBSYS_11001AF4&REV_01" to install
+;
+;--*/
+
+[Version]
+Signature       = "$WINDOWS NT$"
+Class           = System
+ClassGuid       = {4d36e97d-e325-11ce-bfc1-08002be10318}
+Provider        = %VENDOR%
+DriverVer=01/01/2008,0.0.0.1 ; this line will be replaced with stampinf
+CatalogFile     = pvpanic.cat
+PnpLockdown     = 1
+
+[DestinationDirs]
+DefaultDestDir = 12
+PVPanic_Device_CoInstaller_CopyFiles = 11
+
+[SourceDisksNames]
+1 = %DiskName%,,,""
+
+[SourceDisksFiles]
+pvpanic.sys = 1,,
+WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll=1 ; make sure the number matches with SourceDisksNames
+
+; ---------------
+; Install Section
+; ---------------
+
+[Manufacturer]
+%VENDOR% = PVPanic,NT$ARCH$
+
+[PVPanic.NT$ARCH$]
+%PVPanic.DeviceDesc% = PVPanic_Device, PCI\VEN_1B36&DEV_0011&SUBSYS_11001AF4&REV_01
+
+[PVPanic_Device.NT]
+CopyFiles = PVPanic_CopyFiles
+
+[PVPanic_CopyFiles]
+pvpanic.sys
+
+; --------------------
+; Service Installation
+; --------------------
+
+[PVPanic_Device.NT.Services]
+AddService = PVPanic,0x00000002,PVPanic_Service_Install
+
+[PVPanic_Service_Install]
+DisplayName    = %PVPanic.Service%
+ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
+StartType      = 3               ; SERVICE_DEMAND_START
+ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
+ServiceBinary  = %12%\pvpanic.sys
+LoadOrderGroup = Extended Base
+
+; ----------------
+; WDF Installation
+; ----------------
+
+[PVPanic_Device.NT.CoInstallers]
+AddReg=PVPanic_Device_CoInstaller_AddReg
+CopyFiles=PVPanic_Device_CoInstaller_CopyFiles
+
+[PVPanic_Device_CoInstaller_AddReg]
+HKR,,CoInstallers32,0x00010000, "WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll,WdfCoInstaller"
+
+[PVPanic_Device_CoInstaller_CopyFiles]
+WdfCoInstaller$KMDFCOINSTALLERVERSION$.dll
+
+[PVPanic_Device.NT.Wdf]
+KmdfService = PVPanic, PVPanic_wdfsect
+
+[PVPanic_wdfsect]
+KmdfLibraryVersion = $KMDFVERSION$
+
+[Strings]
+VENDOR = "INX_COMPANY"
+DiskName            = "INX_PREFIX_QEMUQEMU PVPanic Installation Disk"
+PVPanic.DeviceDesc  = "INX_PREFIX_QEMUQEMU PVPanic PCI Device"
+PVPanic.Service     = "INX_PREFIX_QEMUQEMU PVPanic PCI Driver Service"

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -66,6 +66,10 @@ NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject,
     }
     else
     {
+        PvPanicPortOrMemAddress = NULL;
+        bEmitCrashLoadedEvent = FALSE;
+        bIsPCI = FALSE;
+        SupportedFeature = 0;
         TraceEvents(TRACE_LEVEL_VERBOSE, DBG_INIT, "<-- %!FUNC!");
     }
 
@@ -88,10 +92,6 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
     PAGED_CODE();
 
     WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&pnpPowerCallbacks);
-
-    PvPanicPortAddress = NULL;
-    bEmitCrashLoadedEvent = FALSE;
-    SupportedFeature = 0;
 
     pnpPowerCallbacks.EvtDevicePrepareHardware = PVPanicEvtDevicePrepareHardware;
     pnpPowerCallbacks.EvtDeviceReleaseHardware = PVPanicEvtDeviceReleaseHardware;

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -40,8 +40,9 @@
 #define PVPANIC_PANICKED        (1 << PVPANIC_F_PANICKED)
 #define PVPANIC_CRASHLOADED     (1 << PVPANIC_F_CRASHLOADED)
 
-PUCHAR PvPanicPortAddress;
+PUCHAR PvPanicPortOrMemAddress;
 BOOLEAN bEmitCrashLoadedEvent;
+BOOLEAN bIsPCI;
 UCHAR   SupportedFeature;
 
 typedef struct _DEVICE_CONTEXT {
@@ -50,6 +51,8 @@ typedef struct _DEVICE_CONTEXT {
     PVOID               IoBaseAddress;
     ULONG               IoRange;
     BOOLEAN             MappedPort;
+    PVOID               MemBaseAddress;
+    ULONG               MemRange;
 
 } DEVICE_CONTEXT, *PDEVICE_CONTEXT;
 
@@ -63,7 +66,7 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 // Bug check callback registration functions.
 //
 
-VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress);
+VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress, PUCHAR Component);
 VOID PVPanicDeregisterBugCheckCallback();
 
 //


### PR DESCRIPTION
As we know, QEMU supports PCI pvpanic. Also, Linux has implemented
its pvpanic PCI driver. However, the pvpanic PCI driver has been
missing on Windows side.

This patch implements supporting pvpanic PCI driver for Windows.
Both ISA and PCI pvpanic drivers share the same set of driver
source code, as well as same driver binary(.sys). But they have
separate INF file since the ID of ISA and PCI device are different.

QEMU options for pvpanic PCI device
   -device pvpanic-pci

Since the pvpanic driver is being deployed for just sending the
panic event to notify the crash of the guest. It is not necessary
to support multiple pvpanic devices in one guest. Since ISA and
PCI device share the same driver, one of the driver will fail
to be loaded if both ISA and PCI device exist in the same guest.
However, this doesn't affect the crash event notification since
the loaded driver always works as expected.

In case of supporting the co-existence of ISA and PCI pvpanic
devices, two implementations are available.
1. Split the code and build out separate driver binaries
2. Share the same code but split the variables and callback
   functions for ISA and PCI driver
However, these implementations are more complicated. These may be
implemented in future if required.

Signed-off-by: Annie Li <annie.li@oracle.com>
Reviewed-by: Darren Kenny <darren.kenny@oracle.com>