### PR TITLE
VirtIO-FS: use indirect VirtIO descriptors for large SG-lists

### DIFF
--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -30,6 +30,8 @@
 #include "viofs.h"
 #include "ioctl.tmh"
 
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
 EVT_WDF_REQUEST_CANCEL VirtFsEvtRequestCancel;
 
 static inline int GetVirtQueueIndex(IN PDEVICE_CONTEXT Context,
@@ -48,8 +50,8 @@ static SIZE_T GetRequiredScatterGatherSize(IN PVIRTIO_FS_REQUEST Request)
 {
     SIZE_T n;
     
-    n = ((Request->InputBufferLength / PAGE_SIZE) + 1) + 
-        ((Request->OutputBufferLength / PAGE_SIZE) + 1);
+    n = DIV_ROUND_UP(Request->InputBufferLength, PAGE_SIZE) +
+        DIV_ROUND_UP(Request->OutputBufferLength, PAGE_SIZE);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_IOCTL, "Required SG Size: %Iu", n);
 

--- a/viofs/pci/power.c
+++ b/viofs/pci/power.c
@@ -79,19 +79,14 @@ NTSTATUS VirtFsEvtDevicePrepareHardware(IN WDFDEVICE Device,
     // #1 - request queue
     context->NumQueues = 2;
 
-    context->VirtQueues = ExAllocatePoolUninitialized(NonPagedPool,
-        context->NumQueues * sizeof(struct virtqueue*),
+    context->VirtQueues = ExAllocatePoolZero(NonPagedPool,
+        context->NumQueues * sizeof(struct virtqueue *),
         VIRT_FS_MEMORY_TAG);
 
-    if (context->VirtQueues != NULL)
-    {
-        RtlZeroMemory(context->VirtQueues,
-            context->NumQueues * sizeof(struct virtqueue*));
-    }
-    else
+    if (context->VirtQueues == NULL)
     {
         TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
-            "Failed to allocate request queues");
+            "Failed to allocate queues");
 
         status = STATUS_INSUFFICIENT_RESOURCES;
     }

--- a/viofs/pci/viofs.h
+++ b/viofs/pci/viofs.h
@@ -47,6 +47,11 @@
 
 #define MAX_FILE_SYSTEM_NAME 36
 
+#define VIRT_FS_INDIRECT_AREA_PAGES 2
+#define VIRT_FS_INDIRECT_PAGE_CAPACITY 256
+#define VIRT_FS_INDIRECT_AREA_CAPACITY (VIRT_FS_INDIRECT_AREA_PAGES * \
+                                        VIRT_FS_INDIRECT_PAGE_CAPACITY)
+
 enum {
     VQ_TYPE_HIPRIO = 0,
     VQ_TYPE_REQUEST = 1,
@@ -87,6 +92,9 @@ typedef struct _DEVICE_CONTEXT {
     VIRTIO_WDF_DRIVER   VDevice;
     UINT32              NumQueues;
     struct virtqueue    **VirtQueues;
+    BOOLEAN             UseIndirect;
+    PVOID               IndirectVA;
+    PHYSICAL_ADDRESS    IndirectPA;
 
     WDFINTERRUPT        WdfInterrupt[VQ_TYPE_MAX];
     WDFSPINLOCK         *VirtQueueLocks;


### PR DESCRIPTION
Typical large VirtIO-FS request is 1MiB + 2 pages, which is too much for default queue-size=128. Use of 2 pages indirect area allows to process request of up to 2MiB.