### PR TITLE
pvpanic: Support pvpanic PCI driver

### DIFF
--- a/pvpanic/PVPanic Package/PVPanic Package.vcxproj
+++ b/pvpanic/PVPanic Package/PVPanic Package.vcxproj
@@ -116,6 +116,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Inf Include="..\pvpanic\pvpanic-pci.inf" />
     <Inf Include="..\pvpanic\pvpanic.inf" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/pvpanic/pvpanic/bugcheck.c
+++ b/pvpanic/pvpanic/bugcheck.c
@@ -41,8 +41,10 @@ VOID PVPanicOnBugCheck(IN PVOID Buffer, IN ULONG Length)
     //Trigger the PVPANIC_PANICKED event if the crash dump isn't enabled,
     if ((Buffer != NULL) && (Length == sizeof(PVOID)) && !bEmitCrashLoadedEvent)
     {
-        PUCHAR PortAddress = (PUCHAR)Buffer;
-        WRITE_PORT_UCHAR(PortAddress, (UCHAR)(PVPANIC_PANICKED));
+        if (BusType & PVPANIC_PCI)
+            *(PUCHAR)Buffer = (UCHAR)(PVPANIC_PANICKED);
+        else
+            WRITE_PORT_UCHAR((PUCHAR)Buffer, (UCHAR)(PVPANIC_PANICKED));
     }
 }
 
@@ -56,9 +58,13 @@ VOID PVPanicOnDumpBugCheck(
     UNREFERENCED_PARAMETER(Length);
 
     //Trigger the PVPANIC_CRASHLOADED event before the crash dump.
-    if ((PvPanicPortAddress != NULL) && (Reason == KbCallbackDumpIo) && !bEmitCrashLoadedEvent)
+    if ((PvPanicPortOrMemAddress != NULL) && (Reason == KbCallbackDumpIo) && !bEmitCrashLoadedEvent)
     {
-        WRITE_PORT_UCHAR(PvPanicPortAddress, (UCHAR)(PVPANIC_CRASHLOADED));
+        if (BusType & PVPANIC_PCI)
+            *PvPanicPortOrMemAddress = (UCHAR)(PVPANIC_CRASHLOADED);
+        else
+            WRITE_PORT_UCHAR(PvPanicPortOrMemAddress, (UCHAR)(PVPANIC_CRASHLOADED));
+
         bEmitCrashLoadedEvent = TRUE;
     }
     //Deregister BugCheckReasonCallback after PVPANIC_CRASHLOADED is triggered.
@@ -66,7 +72,7 @@ VOID PVPanicOnDumpBugCheck(
         KeDeregisterBugCheckReasonCallback(Record);
 }
 
-VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress)
+VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress, PUCHAR Component)
 {
     BOOLEAN bBugCheck;
 
@@ -76,7 +82,7 @@ VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress)
     if (SupportedFeature & PVPANIC_PANICKED)
     {
         bBugCheck = KeRegisterBugCheckCallback(&CallbackRecord, PVPanicOnBugCheck,
-                    (PVOID)PortAddress, sizeof(PVOID), (PUCHAR)("PVPanic"));
+                    (PVOID)PortAddress, sizeof(PVOID), Component);
         if (!bBugCheck)
         {
             TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,
@@ -87,7 +93,7 @@ VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress)
     if (SupportedFeature & PVPANIC_CRASHLOADED)
     {
         bBugCheck = KeRegisterBugCheckReasonCallback(&DumpCallbackRecord,
-                    PVPanicOnDumpBugCheck, KbCallbackDumpIo, (PUCHAR)("PVPanic"));
+                    PVPanicOnDumpBugCheck, KbCallbackDumpIo, Component);
         if (!bBugCheck)
         {
             TraceEvents(TRACE_LEVEL_ERROR, DBG_POWER,

--- a/pvpanic/pvpanic/pvpanic.c
+++ b/pvpanic/pvpanic/pvpanic.c
@@ -66,6 +66,9 @@ NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject,
     }
     else
     {
+        PvPanicPortOrMemAddress = NULL;
+        BusType = 0;
+        SupportedFeature = 0;
         TraceEvents(TRACE_LEVEL_VERBOSE, DBG_INIT, "<-- %!FUNC!");
     }
 
@@ -88,10 +91,6 @@ NTSTATUS PVPanicEvtDeviceAdd(IN WDFDRIVER Driver,
     PAGED_CODE();
 
     WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&pnpPowerCallbacks);
-
-    PvPanicPortAddress = NULL;
-    bEmitCrashLoadedEvent = FALSE;
-    SupportedFeature = 0;
 
     pnpPowerCallbacks.EvtDevicePrepareHardware = PVPanicEvtDevicePrepareHardware;
     pnpPowerCallbacks.EvtDeviceReleaseHardware = PVPanicEvtDeviceReleaseHardware;

--- a/pvpanic/pvpanic/pvpanic.h
+++ b/pvpanic/pvpanic/pvpanic.h
@@ -40,8 +40,17 @@
 #define PVPANIC_PANICKED        (1 << PVPANIC_F_PANICKED)
 #define PVPANIC_CRASHLOADED     (1 << PVPANIC_F_CRASHLOADED)
 
-PUCHAR PvPanicPortAddress;
+// The bit of supported bus type.
+#define PVPANIC_F_ISA      0
+#define PVPANIC_F_PCI      1
+
+// The bus type value.
+#define PVPANIC_ISA        (1 << PVPANIC_F_ISA)
+#define PVPANIC_PCI        (1 << PVPANIC_F_PCI)
+
+PUCHAR PvPanicPortOrMemAddress;
 BOOLEAN bEmitCrashLoadedEvent;
+UCHAR   BusType;
 UCHAR   SupportedFeature;
 
 typedef struct _DEVICE_CONTEXT {
@@ -50,6 +59,8 @@ typedef struct _DEVICE_CONTEXT {
     PVOID               IoBaseAddress;
     ULONG               IoRange;
     BOOLEAN             MappedPort;
+    PVOID               MemBaseAddress;
+    ULONG               MemRange;
 
 } DEVICE_CONTEXT, *PDEVICE_CONTEXT;
 
@@ -63,7 +74,7 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext);
 // Bug check callback registration functions.
 //
 
-VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress);
+VOID PVPanicRegisterBugCheckCallback(IN PVOID PortAddress, PUCHAR Component);
 VOID PVPanicDeregisterBugCheckCallback();
 
 //


### PR DESCRIPTION
As we know, QEMU supports PCI pvpanic. Also, Linux has implemented
its pvpanic PCI driver. However, the pvpanic PCI driver has been
missing on Windows side.

This patch implements supporting pvpanic PCI driver for Windows.
Both ISA and PCI pvpanic drivers share the same set of driver
source code, as well as same driver binary(.sys). But they have
separate INF file since the ID of ISA and PCI device are different.

QEMU options for pvpanic PCI device
   -device pvpanic-pci

Since the pvpanic driver is being deployed for just sending the
panic event to notify the crash of the guest. It is not necessary
to support multiple pvpanic devices in one guest. Since ISA and
PCI device share the same driver, one of the driver will fail
to be loaded if both ISA and PCI device exist in the same guest.
However, this doesn't affect the crash event notification since
the loaded driver always works as expected.

In case of supporting the co-existence of ISA and PCI panic devices,
two implementations are available.
1. Split the code and build out separate driver binaries
2. Share the same code but split the variables and callback
   functions for ISA and PCI driver
However, these implementations are more complicated. These may be
implemented in future if required.

Signed-off-by: Annie Li <annie.li@oracle.com>
Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
Reviewed-by: Mihai Carabas <mihai.carabas@oracle.com>