### PR TITLE
Fix buffer overrun in viostor when VM is configured to have more disk queues than number of CPUs.

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -626,9 +626,10 @@ ENTER_FN();
 
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " pmsg_affinity = %p\n",adaptExt->pmsg_affinity);
     if (!adaptExt->dump_mode && (adaptExt->num_queues > 1) && (adaptExt->pmsg_affinity == NULL)) {
+        adaptExt->num_affinity = adaptExt->num_queues + 3;
         ULONG Status =
         StorPortAllocatePool(DeviceExtension,
-                             sizeof(GROUP_AFFINITY) * ((ULONGLONG)adaptExt->num_queues + 3),
+                             sizeof(GROUP_AFFINITY) * (ULONGLONG)adaptExt->num_affinity,
                              VIOSCSI_POOL_TAG,
                              (PVOID*)&adaptExt->pmsg_affinity);
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " pmsg_affinity = %p Status = %lu\n",adaptExt->pmsg_affinity, Status);
@@ -802,6 +803,7 @@ ENTER_FN();
                     adaptExt->perfFlags |= STOR_PERF_INTERRUPT_MESSAGE_RANGES;
                     perfData.FirstRedirectionMessageNumber = 3;
                     perfData.LastRedirectionMessageNumber = perfData.FirstRedirectionMessageNumber + adaptExt->num_queues - 1;
+                    ASSERT(perfData.LastRedirectionMessageNumber < adaptExt->num_affinity);
                     if ((adaptExt->pmsg_affinity != NULL) && CHECKFLAG(perfData.Flags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
                         RtlZeroMemory((PCHAR)adaptExt->pmsg_affinity, sizeof (GROUP_AFFINITY) * ((ULONGLONG)adaptExt->num_queues + 3));
                         adaptExt->perfFlags |= STOR_PERF_ADV_CONFIG_LOCALITY;

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -312,6 +312,7 @@ typedef struct _ADAPTER_EXTENSION {
     REQUEST_LIST          processing_srbs[MAX_CPU];
     ULONG                 perfFlags;
     PGROUP_AFFINITY       pmsg_affinity;
+    ULONG                 num_affinity;
     BOOLEAN               dpc_ok;
     PSTOR_DPC             dpc;
     ULONG                 max_physical_breaks;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -572,9 +572,10 @@ VirtIoFindAdapter(
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Pool area at %p, size = %d\n", adaptExt->poolAllocationVa, adaptExt->poolAllocationSize);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " pmsg_affinity = %p\n",adaptExt->pmsg_affinity);
     if (!adaptExt->dump_mode && (adaptExt->num_queues > 1) && (adaptExt->pmsg_affinity == NULL)) {
+        adaptExt->num_affinity = adaptExt->num_queues + 1;
         ULONG Status =
         StorPortAllocatePool(DeviceExtension,
-                             sizeof(GROUP_AFFINITY) * ((ULONGLONG)adaptExt->num_queues + 1),
+                             sizeof(GROUP_AFFINITY) * (ULONGLONG)adaptExt->num_affinity,
                              VIOBLK_POOL_TAG,
                              (PVOID*)&adaptExt->pmsg_affinity);
         RhelDbgPrint(TRACE_LEVEL_FATAL, " pmsg_affinity = %p Status = %lu\n",adaptExt->pmsg_affinity, Status);
@@ -791,7 +792,8 @@ VirtIoHwInitialize(
                 if (CHECKFLAG(perfData.Flags, STOR_PERF_INTERRUPT_MESSAGE_RANGES)) {
                     adaptExt->perfFlags |= STOR_PERF_INTERRUPT_MESSAGE_RANGES;
                     perfData.FirstRedirectionMessageNumber = 1;
-                    perfData.LastRedirectionMessageNumber = adaptExt->msix_vectors - 1;
+                    perfData.LastRedirectionMessageNumber = perfData.FirstRedirectionMessageNumber + adaptExt->num_queues - 1;
+                    ASSERT(perfData.lastRedirectionMessageNumber < adaptExt->num_affinity);
                 }
                 if (CHECKFLAG(perfData.Flags, STOR_PERF_CONCURRENT_CHANNELS)) {
                     adaptExt->perfFlags |= STOR_PERF_CONCURRENT_CHANNELS;

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -243,6 +243,7 @@ typedef struct _ADAPTER_EXTENSION {
     BOOLEAN               removed;
     ULONG                 max_tx_length;
     PGROUP_AFFINITY       pmsg_affinity;
+    ULONG                 num_affinity;
     STOR_ADDR_BTL8        device_address;
     blk_discard_write_zeroes blk_discard[16];
     REQUEST_LIST          processing_srbs[MAX_CPU];


### PR DESCRIPTION
The memory buffer length viostor allocates to store the group
affinity mask is based on the num_queues but the last redirection
message number is based on msix_vectors. If msix_vectors is greater
than num_queues, storport will write beyond the end of the allocated
buffer which causes non-paged pool corruption. This change fixes
the explained problem.

1. Set last redirection message number based on num_queues in viostor.
2. Add a field num_affinity in ADAPTER_EXTENSION to store the group
affinity array length.
3. Add assertion in vioscsi and viostor to ensure that last redirection
message number is less than num_affinity.

Signed-off-by: Hao Xiang <hao.xiang@bytedance.com>