### PR TITLE
RHBZ#2112559: VirtIO-FS: align group rights to owner rights

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -80,6 +80,7 @@
 #define SafeHeapFree(p) if (p != NULL) { HeapFree(GetProcessHeap(), 0, p); }
 
 #define ReadAndExecute(x) ((x) | (((x) & 0444) >> 2))
+#define GroupAsOwner(x) (((x) & ~0070) | (((x) & 0700) >> 3))
 
 typedef struct
 {
@@ -1130,7 +1131,7 @@ static NTSTATUS GetFileInfoInternal(VIRTFS *VirtFs,
         {
             Status = FspPosixMapPermissionsToSecurityDescriptor(
                 VirtFs->LocalUid, VirtFs->LocalGid,
-                ReadAndExecute(attr->mode), SecurityDescriptor);
+                GroupAsOwner(ReadAndExecute(attr->mode)), SecurityDescriptor);
         }
     }
 
@@ -1306,7 +1307,7 @@ static NTSTATUS GetSecurityByName(FSP_FILE_SYSTEM *FileSystem, PWSTR FileName,
         }
 
         Status = FspPosixMapPermissionsToSecurityDescriptor(VirtFs->LocalUid,
-            VirtFs->LocalGid, ReadAndExecute(attr->mode), &Security);
+            VirtFs->LocalGid, GroupAsOwner(ReadAndExecute(attr->mode)), &Security);
 
         if (NT_SUCCESS(Status))
         {


### PR DESCRIPTION
In `e3e722c` both owner and group on guest side were set to `Everyone`. But when converting POSIX mode to Windows security descriptor WinFSP can restrict owner's rights to group's rights if owner's rights are more permissive. Thereby, some previosly working configurations (e.g. shared directory with `0700` rights) were broken. So, evelate group rights when converting to security descriptor.