### PR TITLE
VirtIO-FS: initial case insensitive support

### DIFF
--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -96,3 +96,16 @@ static DWORD RegistryGetVal(PCWSTR SubKey, PCWSTR ValueName, std::wstring& Value
 
     return Status;
 }
+
+static bool FileNameIgnoreCaseCompare(PCWSTR a, const char *b, uint32_t b_len)
+{
+    WCHAR wide_b[MAX_PATH];
+
+    int wide_b_len = MultiByteToWideChar(CP_UTF8, 0, b, b_len, wide_b, MAX_PATH);
+    if (wide_b_len == 0)
+    {
+        return false;
+    }
+
+    return (CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, a, -1, wide_b, wide_b_len) == CSTR_EQUAL);
+}

--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -40,3 +40,4 @@ public:
     }
 };
 
+#define SCOPE_EXIT(x, action, ...) scope_exit x##_se([x, __VA_ARGS__] action);

--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Daynix Computing Ltd.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+template <typename EF>
+class scope_exit
+{
+    EF exit_func;
+
+public:
+    scope_exit(EF&& exit_func) : exit_func{ exit_func } {};
+    ~scope_exit()
+    {
+        exit_func();
+    }
+};
+

--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -47,7 +47,8 @@ public:
 
 #define SCOPE_EXIT(x, action, ...) scope_exit x##_se([x, __VA_ARGS__] action);
 
-static DWORD RegistryGetVal(PCWSTR SubKey, PCWSTR ValueName, DWORD& Value)
+template<typename T>
+static DWORD RegistryGetVal(PCWSTR SubKey, PCWSTR ValueName, T& Value)
 {
     LSTATUS Status;
     DWORD Val;

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -52,6 +52,7 @@
 
 #include "virtiofs.h"
 #include "fusereq.h"
+#include "utils.h"
 
 #define FS_SERVICE_NAME TEXT("VirtIO-FS")
 #define FS_SERVICE_REGKEY   TEXT("Software\\") FS_SERVICE_NAME
@@ -148,19 +149,6 @@ VIRTFS::VIRTFS(ULONG DebugFlags, const std::wstring& MountPoint)
     : DebugFlags{ DebugFlags }, MountPoint{ MountPoint }, Tag{ Tag }
 {
 }
-
-template <typename EF>
-class scope_exit
-{
-    EF exit_func;
-
-public:
-    scope_exit(EF&& exit_func) : exit_func{ exit_func } {};
-    ~scope_exit()
-    {
-        exit_func();
-    }
-};
 
 static NTSTATUS SetBasicInfo(FSP_FILE_SYSTEM *FileSystem, PVOID FileContext0,
     UINT32 FileAttributes, UINT64 CreationTime, UINT64 LastAccessTime,

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -2644,63 +2644,12 @@ usage:
     return STATUS_UNSUCCESSFUL;
 }
 
-static DWORD VirtFsRegistryGetDword(PCWSTR ValueName, DWORD& Value)
-{
-    LSTATUS Status;
-    DWORD Val;
-    DWORD ValSize = sizeof(Val);
-
-    Status = RegGetValue(HKEY_LOCAL_MACHINE, FS_SERVICE_REGKEY, ValueName,
-        RRF_RT_REG_DWORD, NULL, &Val, &ValSize);
-    if (Status == ERROR_SUCCESS)
-    {
-        Value = Val;
-    }
-
-    return Status;
-}
-
-static DWORD VirtFsRegistryGetString(PCWSTR ValueName, std::wstring& Str)
-{
-    LSTATUS Status;
-    DWORD BufSize = 0;
-    PWSTR Buf;
-
-    // Determine required buffer size
-    Status = RegGetValue(HKEY_LOCAL_MACHINE, FS_SERVICE_REGKEY, ValueName,
-        RRF_RT_REG_SZ, NULL, NULL, &BufSize);
-    if (Status != ERROR_SUCCESS)
-    {
-        return Status;
-    }
-
-    try
-    {
-        Buf = new WCHAR[BufSize];
-    }
-    catch (std::bad_alloc)
-    {
-        return ERROR_NO_SYSTEM_RESOURCES;
-    }
-
-    Status = RegGetValue(HKEY_LOCAL_MACHINE, FS_SERVICE_REGKEY, ValueName,
-        RRF_RT_REG_SZ, NULL, Buf, &BufSize);
-    if (Status == ERROR_SUCCESS)
-    {
-        Str.assign(Buf);
-    }
-
-    delete[] Buf;
-
-    return Status;
-}
-
 static VOID ParseRegistry(ULONG& DebugFlags, std::wstring& DebugLogFile,
     std::wstring& MountPoint)
 {
-    VirtFsRegistryGetDword(L"DebugFlags", DebugFlags);
-    VirtFsRegistryGetString(L"DebugLogFile", DebugLogFile);
-    VirtFsRegistryGetString(L"MountPoint", MountPoint);
+    RegistryGetVal(FS_SERVICE_REGKEY, L"DebugFlags", DebugFlags);
+    RegistryGetVal(FS_SERVICE_REGKEY, L"DebugLogFile", DebugLogFile);
+    RegistryGetVal(FS_SERVICE_REGKEY, L"MountPoint", MountPoint);
 }
 
 static NTSTATUS DebugLogSet(const std::wstring& DebugLogFile)

--- a/viofs/svc/virtiofs.vcxproj
+++ b/viofs/svc/virtiofs.vcxproj
@@ -175,6 +175,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fusereq.h" />
+    <ClInclude Include="utils.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\Tools\Driver.Common.targets" />


### PR DESCRIPTION
When `LOOKUP` or `UNLINK`/`RMDIR` or `RENAME`/`RENAME2` request is required, the service tries to send it with exact filename (as usual). If the request result is not success, the service sends `OPEN` and `READDIR` requests to parent directory and tries to find target name among parent directory entries by case-insensitive comparisons and perform `LOOKUP`/`UNLINK`/`RMDIR`/`RENAME`/`RENAME2` on it and then `RELEASE` parent directory.

Add `-i` option and registry key `CaseInsensitive`.

Example:
```
$ ls Z:\
Hello.txt  Привет.txt
$ cat HELLO.txt
Hello
$ cat ПРИВЕТ.txt
Привет
```
