### PR TITLE
VIOSOCK: Fix VIOSockReadDequeueCb

### DIFF
--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1320,7 +1320,11 @@ VIOSockReadDequeueCb(
 
     status = WdfIoQueueRetrieveNextRequest(pSocket->ReadQueue, &ReadRequest);
     if (!NT_SUCCESS(status))
+    {
+        InterlockedExchange(&lInProgress, 0);
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_READ, "The read queue is empty, exiting from VIOSockReadDequeueCb\n");
         return FALSE;
+    }
 
     pRequest = GetRequestRxContext(ReadRequest);
 


### PR DESCRIPTION
The `VIOSockReadDequeueCb` routine is responsible for removing requests from socket's Read queue and their processing (e.g. filling their buffers with incoming data and completing them). At most one instance of this routine can be running at a time, which is ensured by interlocked operations on the `lInProgress` variable. However, not all return paths were covered -- if the Read queue was empty, the routine would just return without unlocking the variable. Such behavior pretty much ruins chance of getting the recv() call right.

This fix unlocks the `lInProgress` also on this forgotten return path, inlucing emission of a trace event.