### PR TITLE
Winsock Kernel (WSK) Interface for the VIOSOCK Driver

### DIFF
--- a/buildAll.bat
+++ b/buildAll.bat
@@ -28,6 +28,8 @@ call tools\build.bat viosock\sys\viosock.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat viosock\wsk\wsk.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
+call tools\build.bat viosock\viosock-wsk-test\viosock-wsk-test.vcxproj "Win11_SDV" %*
+if errorlevel 1 goto :fail
 call tools\build.bat viofs\pci\viofs.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat vioinput\hidpassthrough\hidpassthrough.vcxproj "Win11_SDV" %*

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -26,6 +26,8 @@ call tools\build.bat vioserial\sys\vioser.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat viosock\sys\viosock.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
+call tools\build.bat viosock\wsk\wsk.vcxproj "Win11_SDV" %*
+if errorlevel 1 goto :fail
 call tools\build.bat viofs\pci\viofs.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat vioinput\hidpassthrough\hidpassthrough.vcxproj "Win11_SDV" %*

--- a/viosock/buildAll.bat
+++ b/viosock/buildAll.bat
@@ -6,3 +6,5 @@ if errorlevel 1 goto :eof
 call ..\tools\build.bat sys\viosock.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :eof
 call ..\tools\build.bat wsk\wsk.vcxproj "Win11_SDV" %*
+if errorlevel 1 goto :eof
+call ..\tools\build.bat viosock-wsk-test\viosock-wsk-test.vcxproj "Win11_SDV" %*

--- a/viosock/buildAll.bat
+++ b/viosock/buildAll.bat
@@ -4,3 +4,5 @@ if errorlevel 1 goto :eof
 call ..\tools\build.bat viosock.sln "Win10 Win11" %*
 if errorlevel 1 goto :eof
 call ..\tools\build.bat sys\viosock.vcxproj "Win11_SDV" %*
+if errorlevel 1 goto :eof
+call ..\tools\build.bat wsk\wsk.vcxproj "Win11_SDV" %*

--- a/viosock/cleanAll.bat
+++ b/viosock/cleanAll.bat
@@ -17,6 +17,10 @@ pushd wsk
 call cleanAll.bat
 popd
 
+pushd viosock-wsk-test
+call cleanAll.bat
+popd
+
 pushd viosock-test
 call cleanAll.bat
 popd

--- a/viosock/cleanAll.bat
+++ b/viosock/cleanAll.bat
@@ -13,6 +13,10 @@ pushd sys
 call cleanAll.bat
 popd
 
+pushd wsk
+call cleanAll.bat
+popd
+
 pushd viosock-test
 call cleanAll.bat
 popd

--- a/viosock/inc/debug-utils.h
+++ b/viosock/inc/debug-utils.h
@@ -1,0 +1,83 @@
+/*
+ * Exports definition for virtio socket WSK interface
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __DEBUG_UTILS_H__
+#define __DEBUG_UTILS_H__
+
+
+
+#if defined(DBG) || defined(_DEBUG)
+
+#define DEBUG_ENTER_FUNCTION(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_TRACE_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ "(" Format ")\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __VA_ARGS__)
+
+#define DEBUG_ENTER_FUNCTION_NO_ARGS() \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_TRACE_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ "()\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql())
+
+#define DEBUG_EXIT_FUNCTION(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_TRACE_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ "(-):" Format "\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __VA_ARGS__)
+
+#define DEBUG_EXIT_FUNCTION_VOID() \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_TRACE_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ "(-)\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql())
+
+#else
+
+#define DEBUG_ENTER_FUNCTION(Format, ...)   do { } while (FALSE)
+
+#define DEBUG_ENTER_FUNCTION_NO_ARGS()  do { } while (FALSE)
+
+#define DEBUG_EXIT_FUNCTION(Format, ...)    do { } while (FALSE)
+
+#define DEBUG_EXIT_FUNCTION_VOID()      do { } while (FALSE)
+
+#endif
+
+
+#define DEBUG_ERROR(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_ERROR_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ " (" __FILE__ ":%u): ERROR: " Format "\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __LINE__, __VA_ARGS__)
+
+#define DEBUG_WARNING(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_WARNING_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ " (" __FILE__ ":%u): WARNING: " Format "\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __LINE__, __VA_ARGS__)
+
+#define DEBUG_TRACE(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_TRACE_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ " (" __FILE__ ":%u): TRACE: " Format "\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __LINE__, __VA_ARGS__)
+
+#define DEBUG_INFO(Format, ...) \
+    DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_INFO_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ ": INFO: " Format "\n", \
+        PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __VA_ARGS__)
+
+
+#endif

--- a/viosock/inc/debug-utils.h
+++ b/viosock/inc/debug-utils.h
@@ -31,6 +31,12 @@
 #define __DEBUG_UTILS_H__
 
 
+#include <Evntrace.h>
+#include "wpp-trace.h"
+#include "..\..\virtio\kdebugprint.h"
+
+#ifndef EVENT_TRACING
+
 
 #if defined(DBG) || defined(_DEBUG)
 
@@ -79,5 +85,7 @@
     DbgPrintEx(DPFLTR_DEFAULT_ID, DPFLTR_INFO_LEVEL, "[0x%x:0x%x:%u]: " __FUNCTION__ ": INFO: " Format "\n", \
         PtrToUlong(PsGetCurrentProcessId()), PtrToUlong(PsGetCurrentThreadId()), KeGetCurrentIrql(), __VA_ARGS__)
 
+
+#endif
 
 #endif

--- a/viosock/inc/vio_wsk.h
+++ b/viosock/inc/vio_wsk.h
@@ -70,6 +70,22 @@ VioWskQueryProviderCharacteristics(
     _Out_ PWSK_PROVIDER_CHARACTERISTICS WskProviderCharacteristics
 );
 
+_Must_inspect_result_
+NTSTATUS
+VioWskModuleInit(
+    _In_ PDRIVER_OBJECT     DriverObject,
+    _In_ PUNICODE_STRING    RegistryPath,
+    _In_opt_ PDEVICE_OBJECT DeviceObject
+);
+
+VOID
+VioWskModuleFinit(
+    VOID
+);
+
+
+
+
 #ifdef  __cplusplus
 }
 #endif

--- a/viosock/viosock-wsk-test/LICENSE
+++ b/viosock/viosock-wsk-test/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2019 Virtuozzo, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/viosock/viosock-wsk-test/cleanAll.bat
+++ b/viosock/viosock-wsk-test/cleanAll.bat
@@ -1,0 +1,2 @@
+@echo off
+call ..\..\Tools\clean.bat

--- a/viosock/viosock-wsk-test/test-messages.c
+++ b/viosock/viosock-wsk-test/test-messages.c
@@ -30,6 +30,9 @@
 #include <bcrypt.h>
 #include "..\inc\debug-utils.h"
 #include "test-messages.h"
+#ifdef EVENT_TRACING
+#include "test-messages.tmh"
+#endif
 
 
 static ULONG _randSeed;

--- a/viosock/viosock-wsk-test/test-messages.c
+++ b/viosock/viosock-wsk-test/test-messages.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2023 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <ntifs.h>
+#include <wsk.h>
+#include <bcrypt.h>
+#include "..\inc\debug-utils.h"
+#include "test-messages.h"
+
+
+static ULONG _randSeed;
+
+
+NTSTATUS
+VioWskMessageGenerate(
+	_In_opt_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_Out_ PWSK_BUF WskBuffer,
+	_Out_ PVOID* FlatBuffer
+)
+{
+	PMDL mdl = NULL;
+	PVOID buffer = NULL;
+	SIZE_T bufferSize = 0;
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	DEBUG_ENTER_FUNCTION("SHA256Handle=0x%p; WskBuffer=0x%p", SHA256Handle, WskBuffer);
+
+	Status = STATUS_SUCCESS;
+	bufferSize = VIOWSK_MSG_SIZE;
+	buffer = ExAllocatePoolUninitialized(NonPagedPool, bufferSize, VIOWSK_TEST_MSG_TAG);
+	if (!buffer) {
+		Status = STATUS_INSUFFICIENT_RESOURCES;
+		goto Exit;
+	}
+
+	if (SHA256Handle) {
+		for (SIZE_T i = 0; i < (VIOWSK_MSG_SIZE - 32) / sizeof(ULONG); ++i)
+			((PULONG)buffer)[i] = RtlRandomEx(&_randSeed);
+
+		Status = BCryptHashData(SHA256Handle, (PUCHAR)buffer, VIOWSK_MSG_SIZE - 32, 0);
+		if (!NT_SUCCESS(Status))
+			goto FreeBuffer;
+
+		Status = BCryptFinishHash(SHA256Handle, (PUCHAR)buffer + VIOWSK_MSG_SIZE - 32, 32, 0);
+		if (!NT_SUCCESS(Status))
+			goto FreeBuffer;
+	}
+
+	WskBuffer->Length = VIOWSK_MSG_SIZE;
+	WskBuffer->Offset = 0;
+	mdl = IoAllocateMdl(buffer, VIOWSK_MSG_SIZE, FALSE, FALSE, NULL);
+	if (!mdl) {
+		Status = STATUS_INSUFFICIENT_RESOURCES;
+		goto FreeBuffer;
+	}
+
+	MmBuildMdlForNonPagedPool(mdl);
+	WskBuffer->Mdl = mdl;
+	*FlatBuffer = buffer;
+	buffer = NULL;
+FreeBuffer:
+	if (buffer)
+		ExFreePoolWithTag(buffer, VIOWSK_TEST_MSG_TAG);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x, *FlatBuffer=0x%p", Status, *FlatBuffer);
+	return Status;
+}
+
+
+NTSTATUS
+VIoWskMessageVerify(
+	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ const WSK_BUF* WskBuf,
+	_Out_ PBOOLEAN Verified
+)
+{
+	ULONG offset = 0;
+	SIZE_T remainingLength = 0;
+	PVOID buffer = NULL;
+	unsigned char digest[32];
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	DEBUG_ENTER_FUNCTION("SHA256Handle=0x%p; WskBuffer=0x%p; Verified=0x%p", SHA256Handle, WskBuf, Verified);
+
+	Status = STATUS_SUCCESS;
+	buffer = ExAllocatePoolUninitialized(NonPagedPool, WskBuf->Length, VIOWSK_TEST_MSG_TAG);
+	if (!buffer) {
+		Status = STATUS_INSUFFICIENT_RESOURCES;
+		goto Exit;
+	}
+
+	offset = WskBuf->Offset;
+	remainingLength = WskBuf->Length;
+	for (PMDL mdl = WskBuf->Mdl; mdl != NULL; mdl = mdl->Next) {
+		SIZE_T mdlSize = 0;
+		PVOID mdlBuffer = NULL;
+
+		mdlBuffer = MmGetSystemAddressForMdlSafe(mdl, NormalPagePriority);
+		if (!mdlBuffer) {
+			Status = STATUS_INSUFFICIENT_RESOURCES;
+			break;
+		}
+
+		mdlSize = MmGetMdlByteCount(mdl) - offset;
+		if (mdlSize > remainingLength)
+			mdlSize = remainingLength;
+
+		memcpy((unsigned char*)buffer + (WskBuf->Length - remainingLength), (unsigned char*)mdlBuffer + offset, mdlSize);
+		offset = 0;
+		remainingLength -= mdlSize;
+	}
+
+	if (!NT_SUCCESS(Status))
+		goto FreeBuffer;
+
+	Status = BCryptHashData(SHA256Handle, (PUCHAR)buffer, (ULONG)(WskBuf->Length - sizeof(digest)), 0);
+	if (!NT_SUCCESS(Status))
+		goto FreeBuffer;
+
+	Status = BCryptFinishHash(SHA256Handle, digest, sizeof(digest), 0);
+	if (!NT_SUCCESS(Status))
+		goto FreeBuffer;
+
+	*Verified = (memcmp((unsigned char*)buffer + WskBuf->Length - sizeof(digest), digest, sizeof(digest)) == 0);
+FreeBuffer:
+	ExFreePoolWithTag(buffer, VIOWSK_TEST_MSG_TAG);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x, *Verified=%u", Status, *Verified);
+	return Status;
+}
+
+
+NTSTATUS
+VIoWskMessageVerifyBuffer(
+	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ const void* Buffer,
+	_Out_ PBOOLEAN Verified
+)
+{
+	unsigned char digest[32];
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	DEBUG_ENTER_FUNCTION("SHA256Handle=0x%p; Buffer=0x%p; Verified=0x%p", SHA256Handle, Buffer, Verified);
+
+	Status = BCryptHashData(SHA256Handle, (PUCHAR)Buffer, VIOWSK_MSG_SIZE - sizeof(digest), 0);
+	if (!NT_SUCCESS(Status))
+		goto Exit;
+
+	Status = BCryptFinishHash(SHA256Handle, digest, sizeof(digest), 0);
+	if (!NT_SUCCESS(Status))
+		goto Exit;
+
+	*Verified = (memcmp((unsigned char*)Buffer + VIOWSK_MSG_SIZE - sizeof(digest), digest, sizeof(digest)) == 0);
+
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x, *Verified=%u", Status, *Verified);
+	return Status;
+}
+
+
+void
+VioWskMessageAdvance(
+	_Inout_ PWSK_BUF WskBuffer,
+	_In_ SIZE_T Length
+)
+{
+	PMDL currentMdl = NULL;
+	ULONG advanceAmount = 0;
+	DEBUG_ENTER_FUNCTION("WskBuffer=0x%p; Length=%Iu", WskBuffer, Length);
+
+	currentMdl = WskBuffer->Mdl;
+	while (WskBuffer->Length > 0 && Length > 0) {
+		advanceAmount = MmGetMdlByteCount(WskBuffer->Mdl) - WskBuffer->Offset;
+		if (advanceAmount > Length)
+			advanceAmount = (ULONG)Length;
+		
+		WskBuffer->Offset += advanceAmount;
+		if (WskBuffer->Offset == MmGetMdlByteCount(currentMdl)) {
+			WskBuffer->Mdl = WskBuffer->Mdl->Next;
+			WskBuffer->Offset = 0;
+			IoFreeMdl(currentMdl);
+			currentMdl = WskBuffer->Mdl;
+		}
+
+		WskBuffer->Length -= advanceAmount;
+		Length -= advanceAmount;
+	}
+
+	DEBUG_EXIT_FUNCTION_VOID();
+	return;
+}
+
+void
+VioWskMessageFree(
+	_In_ PWSK_BUF WskBuffer,
+	_In_opt_ PVOID FlatBuffer
+)
+{
+	PMDL mdl = NULL;
+	DEBUG_ENTER_FUNCTION("WskBuffer=0x%p; FlatBuffer=0x%p", WskBuffer, FlatBuffer);
+
+	mdl = WskBuffer->Mdl;
+	while (mdl != NULL) {
+		mdl = mdl->Next;
+		IoFreeMdl(WskBuffer->Mdl);
+		WskBuffer->Mdl = mdl;
+	}
+
+	if (FlatBuffer)
+		ExFreePoolWithTag(FlatBuffer, VIOWSK_TEST_MSG_TAG);
+
+	DEBUG_EXIT_FUNCTION_VOID();
+	return;
+}

--- a/viosock/viosock-wsk-test/test-messages.h
+++ b/viosock/viosock-wsk-test/test-messages.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __VIOWSK_TEST_MESSAGES_H__
+#define __VIOWSK_TEST_MESSAGES_H__
+
+
+#include <ntifs.h>
+#include <wsk.h>
+#include <bcrypt.h>
+
+
+
+#define VIOWSK_TEST_MSG_TAG					(ULONG)'MKSW'
+
+#define VIOWSK_MSG_SIZE						64
+
+NTSTATUS
+VioWskMessageGenerate(
+	_In_opt_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_Out_ PWSK_BUF WskBuffer,
+	_Out_ PVOID* FlatBuffer
+);
+
+NTSTATUS
+VIoWskMessageVerify(
+	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ const WSK_BUF* WskBuf,
+	_Out_ PBOOLEAN Verified
+);
+
+NTSTATUS
+VIoWskMessageVerifyBuffer(
+	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ const void* Buffer,
+	_Out_ PBOOLEAN Verified
+);
+
+void
+VioWskMessageAdvance(
+	_Inout_ PWSK_BUF WskBuffer,
+	_In_ SIZE_T Length
+);
+
+void
+VioWskMessageFree(
+	_In_ PWSK_BUF WskBuffer,
+	_In_opt_ PVOID FlatBuffer
+);
+
+
+
+
+#endif

--- a/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj
+++ b/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Win10 Release|Win32">
+      <Configuration>Win10 Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Win10 Release|x64">
+      <Configuration>Win10 Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Win10 Release|ARM64">
+      <Configuration>Win10 Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}</ProjectGuid>
+    <TemplateGuid>{dd38f7fc-d7bd-488b-9242-7d8754cde80d}</TemplateGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration>Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <RootNamespace>viosock_wsk_test</RootNamespace>
+    <ProjectName>viosockwsk-test</ProjectName>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <EnableInf2cat>false</EnableInf2cat>
+    <OutDir>objfre_win10_x86\i386\</OutDir>
+    <IntDir>objfre_win10_x86\i386\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <EnableInf2cat>false</EnableInf2cat>
+    <OutDir>objfre_win10_amd64\amd64\</OutDir>
+    <IntDir>objfre_win10_amd64\amd64\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <OutDir>objfre_win10_arm64\arm64\</OutDir>
+    <IntDir>objfre_win10_arm64\arm64\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
+    <Link>
+      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
+    <Link>
+      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">
+    <Link>
+      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <FilesToPackage Include="$(TargetPath)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test-messages.c" />
+    <ClCompile Include="viosockwsk-test.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\wsk\wsk.vcxproj">
+      <Project>{96fdd976-0035-4e24-a61b-e93bed675101}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="test-messages.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj
+++ b/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj
@@ -13,6 +13,18 @@
       <Configuration>Win10 Release</Configuration>
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Win11 Release|ARM64">
+      <Configuration>Win11 Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Win11 Release|Win32">
+      <Configuration>Win11 Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Win11 Release|x64">
+      <Configuration>Win11 Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}</ProjectGuid>
@@ -34,6 +46,14 @@
     <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -42,7 +62,23 @@
     <DriverType>WDM</DriverType>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
@@ -64,31 +100,111 @@
     <OutDir>objfre_win10_x86\i386\</OutDir>
     <IntDir>objfre_win10_x86\i386\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <EnableInf2cat>false</EnableInf2cat>
+    <OutDir>objfre_win11_x86\i386\</OutDir>
+    <IntDir>objfre_win11_x86\i386\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <EnableInf2cat>false</EnableInf2cat>
     <OutDir>objfre_win10_amd64\amd64\</OutDir>
     <IntDir>objfre_win10_amd64\amd64\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <EnableInf2cat>false</EnableInf2cat>
+    <OutDir>objfre_win11_amd64\amd64\</OutDir>
+    <IntDir>objfre_win11_amd64\amd64\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <OutDir>objfre_win10_arm64\arm64\</OutDir>
     <IntDir>objfre_win10_arm64\arm64\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <OutDir>objfre_win11_arm64\arm64\</OutDir>
+    <IntDir>objfre_win11_arm64\arm64\</IntDir>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
     <Link>
-      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_X86_=1;i386=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">
+    <Link>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_X86_=1;i386=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
     <Link>
-      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">
+    <Link>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">
     <Link>
-      <AdditionalDependencies>cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_ARM64_;ARM64;_USE_DECLSPECS_FOR_SAL=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">
+    <Link>
+      <AdditionalDependencies>Ntstrsafe.lib;cng.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib</AdditionalDependencies>
+    </Link>
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppScanConfigurationData>wpp-trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWskTest;_ARM64_;ARM64;_USE_DECLSPECS_FOR_SAL=1;STD_CALL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
@@ -104,6 +220,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="test-messages.h" />
+    <ClInclude Include="wpp-trace.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj.filters
+++ b/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="viosockwsk-test.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-messages.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="test-messages.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj.filters
+++ b/viosock/viosock-wsk-test/viosock-wsk-test.vcxproj.filters
@@ -26,5 +26,8 @@
     <ClInclude Include="test-messages.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wpp-trace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/viosock/viosock-wsk-test/viosockwsk-test.c
+++ b/viosock/viosock-wsk-test/viosockwsk-test.c
@@ -52,7 +52,9 @@
 #include "..\inc\vio_sockets.h"
 #include "..\sys\public.h"
 #include "test-messages.h"
-
+#ifdef EVENT_TRACING
+#include "viosockwsk-test.tmh"
+#endif
 
 
 #define LISTEN_PORT_MIN				1337
@@ -797,6 +799,7 @@ DriverUnload(
 	VioWskDeregister(&_vioWskRegistration);
 	VioWskModuleFinit();
 	IoDeleteDevice(_shutdownDeviceObject);
+	WPP_CLEANUP(DriverObject);
 
 	DEBUG_EXIT_FUNCTION_VOID();
 	return;
@@ -813,6 +816,7 @@ DriverEntry(
 	NTSTATUS Status = STATUS_UNSUCCESSFUL;
 	DEBUG_ENTER_FUNCTION("DriverObject=0x%p; RegistryPath=\"%wZ\"", DriverObject, RegistryPath);
 
+	WPP_INIT_TRACING(DriverObject, RegistryPath);
 	Status = IoCreateDevice(DriverObject, 0, NULL, FILE_DEVICE_UNKNOWN, 0, FALSE, &Device);
 	if (!NT_SUCCESS(Status))
 		goto Exit;
@@ -865,6 +869,11 @@ DeleteDevice:
 	if (Device)
 		IoDeleteDevice(Device);
 Exit:
+	if (!NT_SUCCESS(Status))
+	{
+		WPP_CLEANUP(DriverObject);
+	}
+
 	DEBUG_EXIT_FUNCTION("0x%x", Status);
 	return Status;
 }

--- a/viosock/viosock-wsk-test/viosockwsk-test.c
+++ b/viosock/viosock-wsk-test/viosockwsk-test.c
@@ -1,0 +1,870 @@
+/*
+ * Copyright (c) 2023 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/** This driver shows how to use the WSK interface for the Virtio Socket Driver.
+    The driver creates four client and four server threads. Servers listen
+	on predefined ports, clients are randomly connecting to them and exchanging
+	serveral messages. Messages are 64 bytes and consist of 32 byte long sequence of
+	random bytes plus SHA256 hash of this sequence (to check that the message was transferred
+	intact).
+
+	Things worth of noting:
+	- the WSK interface is implemented in the viosockwsk library that is linked to the test driver,
+	- the library needs to be initialized via VioWskModuleInit and finalized through VioWskModuleFinit,
+	- a device object can be optionally provided to VioWskModuleInit; the library uses it as parent for
+	  internal workitems and other objects,
+	- server threads perform accept() (WskAccept) in non-blocking mode in order to be able to correctly
+	  terminate themselves when the driver is being unloaded (the socket driver does not support accept cancellation),
+    - the driver runs its tests infinitely (results can be observer via WPP Tracing) until it gets unloaded.
+*/
+
+#include <ntifs.h>
+#include <ntstrsafe.h>
+#include <ntintsafe.h>
+#include <wsk.h>
+#include <bcrypt.h>
+#include "..\inc\debug-utils.h"
+#include "..\inc\vio_wsk.h"
+#include "..\inc\vio_sockets.h"
+#include "..\sys\public.h"
+#include "test-messages.h"
+
+
+
+#define LISTEN_PORT_MIN				1337
+#define LISTEN_PORT_MAX				1340
+#define SERVER_THREAD_COUNT			((LISTEN_PORT_MAX) - (LISTEN_PORT_MIN) + 1)
+#define CLIENT_THREAD_COUNT			16
+
+#define VIOWSK_TEST_TAG				(ULONG)'TKSW'
+
+static volatile LONG _readyThreads;
+static volatile LONG _terminate;
+static PETHREAD _clientThreads[CLIENT_THREAD_COUNT];
+static PETHREAD _serverThreads[SERVER_THREAD_COUNT];
+static KEVENT _initEvent;
+static PDEVICE_OBJECT _shutdownDeviceObject = NULL;
+static WSK_REGISTRATION _vioWskRegistration;
+static WSK_PROVIDER_NPI _vioWskProviderNPI;
+static WSK_CLIENT_NPI _vioWskClientNPI =  {
+	NULL,
+	NULL,
+};
+
+
+static
+NTSTATUS
+_GeneralIrpComplete(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP           Irp,
+    _In_ PVOID          Context
+)
+{
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("DeviceObject=0x%p; Irp=0x%p; Context=0x%p", DeviceObject, Irp, Context);
+
+	UNREFERENCED_PARAMETER(DeviceObject);
+	UNREFERENCED_PARAMETER(Irp);
+
+    KeSetEvent((PKEVENT)Context, IO_NO_INCREMENT, FALSE);
+    status = STATUS_MORE_PROCESSING_REQUIRED;
+
+    DEBUG_EXIT_FUNCTION("0x%x", status);
+    return status;
+}
+
+
+#define WSK_SYNCHRONOUS_CALL(aIrp, aEvent, aCall, aIosb) do {	\
+    IoSetCompletionRoutine((aIrp), _GeneralIrpComplete, (aEvent), TRUE, TRUE, TRUE);	\
+    (aIosb)->Status = (aCall);	\
+    if ((aIosb)->Status == STATUS_PENDING) \
+    {	\
+        NTSTATUS __waitResult = STATUS_TIMEOUT;	\
+        LARGE_INTEGER __timeout;	\
+        \
+        __timeout.QuadPart = -10000000;	\
+        do \
+        {	\
+            __waitResult = KeWaitForSingleObject((aEvent), Executive, KernelMode, FALSE, &__timeout); \
+            if (__waitResult == STATUS_TIMEOUT &&	\
+                InterlockedCompareExchange(&_terminate, 1, 1)) \
+            {	\
+                IoCancelIrp((aIrp));	\
+                break;	\
+            }	\
+        } while (__waitResult != STATUS_WAIT_0);	\
+        \
+        KeWaitForSingleObject((aEvent), Executive, KernelMode, FALSE, NULL);	\
+        (aIosb)->Status = (aIrp)->IoStatus.Status;	\
+    }	\
+    \
+    ASSERT((aIosb)->Status == (aIrp)->IoStatus.Status);	\
+    (aIosb)->Information = (aIrp)->IoStatus.Information;	\
+    KeResetEvent((aEvent));	\
+    IoReuseIrp((aIrp), STATUS_UNSUCCESSFUL);	\
+} while (FALSE)	\
+
+
+static
+NTSTATUS
+_TestSocket(
+    _In_ PWSK_SOCKET Socket,
+    _In_ PIRP        Irp,
+    _In_ BOOLEAN     Server
+)
+{
+    KEVENT event;
+    IO_STATUS_BLOCK iosb;
+	WSK_BUF msg;
+    PVOID msgFlat = NULL;
+    WSK_BUF recvMsg;
+    PVOID recvFlat = NULL;
+    ULONG hashObjectSize = 0;
+    ULONG returnedLength = 0;
+    void *hashObject = NULL;
+    BCRYPT_HASH_HANDLE hashHandle = NULL;
+    BOOLEAN verified = FALSE;
+    BCRYPT_ALG_HANDLE sha256Handle = NULL;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p; Server=%u", Socket, Irp, Server);
+
+    KeInitializeEvent(&event, NotificationEvent, FALSE);
+    iosb.Status = BCryptOpenAlgorithmProvider(&sha256Handle, BCRYPT_SHA256_ALGORITHM, NULL, BCRYPT_PROV_DISPATCH);
+    if (!NT_SUCCESS(iosb.Status))
+    {
+        DEBUG_ERROR("Unable to open SHA256 provider: 0x%x", iosb.Status);
+        goto Exit;
+    }
+
+    iosb.Status = BCryptGetProperty(sha256Handle, BCRYPT_OBJECT_LENGTH, (PUCHAR)&hashObjectSize, sizeof(hashObjectSize), &returnedLength, 0);
+    if (!NT_SUCCESS(iosb.Status))
+    {
+        DEBUG_ERROR("BCryptGetProperty: 0x%x", iosb.Status);
+        goto CloseProvider;
+    }
+
+    hashObject = ExAllocatePoolUninitialized(NonPagedPool, hashObjectSize, VIOWSK_TEST_TAG);
+	if (!hashObject)
+    {
+        iosb.Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto CloseProvider;
+    }
+	
+	for (size_t i = 0; i < 16; ++i)
+    {
+        if (!NT_SUCCESS(iosb.Status))
+            break;
+
+        iosb.Status = VioWskMessageGenerate(NULL, &recvMsg, &recvFlat);
+        if (!NT_SUCCESS(iosb.Status))
+        {
+            DEBUG_ERROR("VioWskMessageGenerate: 0x%x", iosb.Status);
+            continue;
+        }
+
+        iosb.Status = BCryptCreateHash(sha256Handle, &hashHandle, hashObject, hashObjectSize, NULL, 0, 0);
+        if (!NT_SUCCESS(iosb.Status))
+        {
+            DEBUG_ERROR("BCryptCreateHash: 0x%x", iosb.Status);
+            goto FreeRecvMessage;
+        }
+
+        iosb.Status = VioWskMessageGenerate(hashHandle, &msg, &msgFlat);
+        BCryptDestroyHash(hashObject);
+        if (!NT_SUCCESS(iosb.Status))
+        {
+            DEBUG_ERROR("Unable to generate test message: 0x%x", iosb.Status);
+            goto FreeRecvMessage;
+        }
+
+        iosb.Status = BCryptCreateHash(sha256Handle, &hashHandle, hashObject, hashObjectSize, NULL, 0, 0);
+        if (!NT_SUCCESS(iosb.Status))
+        {
+            DEBUG_ERROR("BCryptCreateHash: 0x%x", iosb.Status);
+            goto FreeMessage;
+        }
+
+        iosb.Status = VIoWskMessageVerify(hashHandle, &msg, &verified);
+        BCryptDestroyHash(hashObject);
+        if (!NT_SUCCESS(iosb.Status) || !verified)
+        {
+             if (!verified)
+             {
+                 iosb.Status = STATUS_UNSUCCESSFUL;
+                 DEBUG_ERROR("Generated test message is invalid: 0x%x", iosb.Status);
+             } else {
+                 DEBUG_ERROR("Unable to verify test message: 0x%x", iosb.Status);
+             }
+
+             goto FreeMessage;
+        }
+
+		if (!Server)
+		{
+			while (NT_SUCCESS(iosb.Status) && msg.Length > 0)
+			{
+				WSK_SYNCHRONOUS_CALL(Irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)Socket->Dispatch)->WskSend(Socket, &msg, 0, Irp), &iosb);
+				if (iosb.Status == STATUS_CANT_WAIT)
+				{
+					LARGE_INTEGER timeout;
+
+					iosb.Status = STATUS_SUCCESS;
+					DEBUG_WARNING("Cannot wait for receive, sleeping\n");
+					timeout.QuadPart = -10000000;
+					KeDelayExecutionThread(KernelMode, FALSE, &timeout);
+					continue;
+				}
+
+				if (!NT_SUCCESS(iosb.Status) || iosb.Information != msg.Length)
+				{
+					DEBUG_ERROR("Unable to send the test message: 0x%x (%Iu sent, %Iu requested)\n", iosb.Status, iosb.Information, msg.Length);
+					goto FreeMessage;
+				}
+
+				DEBUG_INFO("%Iu bytes sent (0x%x)\n", iosb.Information, iosb.Status);
+				VioWskMessageAdvance(&msg, iosb.Information);
+			}
+		}
+
+		while (NT_SUCCESS(iosb.Status) && recvMsg.Length > 0)
+		{
+			WSK_SYNCHRONOUS_CALL(Irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)Socket->Dispatch)->WskReceive(Socket, &recvMsg, 0, Irp), &iosb);
+			if (iosb.Status == STATUS_CANT_WAIT) 
+			{
+				LARGE_INTEGER timeout;
+
+				iosb.Status = STATUS_SUCCESS;
+				DEBUG_WARNING("Cannot wait for receive, sleeping\n");
+				timeout.QuadPart = -10000000;
+				KeDelayExecutionThread(KernelMode, FALSE, &timeout);
+				continue;
+			}
+			
+			if (!NT_SUCCESS(iosb.Status) || recvMsg.Length != iosb.Information)
+			{
+				DEBUG_ERROR("Unable to receive the tes message: 0x%x (%Iu bytes length, %Iu bytes received)", iosb.Status, recvMsg.Length, iosb.Information);
+				goto FreeMessage;
+			}
+
+			DEBUG_INFO("%Iu bytes received (0x%x)\n", iosb.Information, iosb.Status);
+			VioWskMessageAdvance(&recvMsg, iosb.Information);
+		}
+
+		iosb.Status = BCryptCreateHash(sha256Handle, &hashHandle, hashObject, hashObjectSize, NULL, 0, 0);
+		if (!NT_SUCCESS(iosb.Status))
+		{
+			DEBUG_ERROR("BCryptCreateHash: 0x%x", iosb.Status);
+			goto SendMessage;
+		}
+
+		iosb.Status = VIoWskMessageVerifyBuffer(hashHandle, recvFlat, &verified);
+		BCryptDestroyHash(hashObject);
+		if (!NT_SUCCESS(iosb.Status) || !verified)
+		{
+			if (!verified)
+				iosb.Status = STATUS_UNSUCCESSFUL;
+
+			DEBUG_ERROR("Unable to verify test message: 0x%x", iosb.Status);
+			goto SendMessage;
+		}
+
+	SendMessage:
+		if (Server)
+		{
+			while (NT_SUCCESS(iosb.Status) && msg.Length > 0)
+			{
+				WSK_SYNCHRONOUS_CALL(Irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)Socket->Dispatch)->WskSend(Socket, &msg, 0, Irp), &iosb);
+				if (iosb.Status == STATUS_CANT_WAIT)
+				{
+					LARGE_INTEGER timeout;
+
+					iosb.Status = STATUS_SUCCESS;
+					DEBUG_WARNING("Cannot wait for receive, sleeping\n");
+					timeout.QuadPart = -10000000;
+					KeDelayExecutionThread(KernelMode, FALSE, &timeout);
+					continue;
+				}
+
+				if (!NT_SUCCESS(iosb.Status) || iosb.Information != msg.Length)
+				{
+					DEBUG_ERROR("Unable to send the test message: 0x%x (%Iu sent, %Iu requested)\n", iosb.Status, iosb.Information, msg.Length);
+					goto FreeMessage;
+				}
+
+				DEBUG_INFO("%Iu bytes sent (0x%x)\n", iosb.Information, iosb.Status);
+				VioWskMessageAdvance(&msg, iosb.Information);
+			}
+		}
+	FreeMessage:
+		VioWskMessageFree(&msg, msgFlat);
+	FreeRecvMessage:
+		VioWskMessageFree(&recvMsg, recvFlat);
+	}
+
+	if (Server)
+	{
+		DEBUG_INFO("Server thread test finished\n");
+	}
+
+	ExFreePoolWithTag(hashObject, VIOWSK_TEST_TAG);
+CloseProvider:
+	BCryptCloseAlgorithmProvider(sha256Handle, 0);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x", iosb.Status);
+	return iosb.Status;
+}
+
+
+typedef struct _TEST_THREAD_CONTEXT {
+	LIST_ENTRY Entry;
+	PKSPIN_LOCK ListLock;
+	PETHREAD Thread;
+	PIRP Irp;
+	PWSK_SOCKET Socket;
+	volatile LONG Terminated;
+} TEST_THREAD_CONTEXT, *PTEST_THREAD_CONTEXT;
+
+static
+NTSTATUS
+_SocketTestThreadCreate(
+    _In_ PWSK_SOCKET Socket,
+    _In_ PLIST_ENTRY ListHead,
+    _In_ PKSPIN_LOCK ListLock
+);
+
+static
+void
+_TestThreadRoutine(
+    _In_ PVOID Context
+)
+{
+    KIRQL irql;
+    KEVENT event;
+    IO_STATUS_BLOCK iosb;
+    BOOLEAN isActive = FALSE;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PTEST_THREAD_CONTEXT ctx = (PTEST_THREAD_CONTEXT)Context;
+    DEBUG_ENTER_FUNCTION("Context=0x%p", Context);
+
+    Status = _TestSocket(ctx->Socket, ctx->Irp, TRUE);
+	KeAcquireSpinLock(ctx->ListLock, &irql);
+    if (!IsListEmpty(&ctx->Entry))
+	{
+        RemoveEntryList(&ctx->Entry);
+        isActive = TRUE;
+    }
+
+    KeReleaseSpinLock(ctx->ListLock, irql);
+    if (isActive)
+    {
+        memset(&iosb, 0, sizeof(iosb));
+        KeInitializeEvent(&event, NotificationEvent, FALSE);
+		WSK_SYNCHRONOUS_CALL(ctx->Irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)ctx->Socket->Dispatch)->WskDisconnect(ctx->Socket, NULL, 0, ctx->Irp), &iosb);
+		if (iosb.Status == STATUS_CONNECTION_INVALID)
+			iosb.Status = STATUS_SUCCESS;
+		
+		if (!NT_SUCCESS(iosb.Status))
+		{
+			DEBUG_ERROR("Unable to disconnect the server socket: 0x%x", iosb.Status);
+		}
+
+		WSK_SYNCHRONOUS_CALL(ctx->Irp, &event, ((PWSK_PROVIDER_BASIC_DISPATCH)ctx->Socket->Dispatch)->WskCloseSocket(ctx->Socket, ctx->Irp), &iosb);
+        if (!NT_SUCCESS(iosb.Status))
+        {
+            DEBUG_ERROR("Unable to close the server socket: 0x%x", iosb.Status);
+        }
+
+        ObDereferenceObject(ctx->Thread);
+        IoFreeIrp(ctx->Irp);
+        ExFreePoolWithTag(ctx, VIOWSK_TEST_TAG);
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return;
+}
+
+
+static
+void
+_ServerThreadRoutine(
+	_In_opt_ PVOID Context
+)
+{
+	KIRQL irql;
+	KEVENT event;
+	ULONG nonBlocking = 0;
+	PIRP irp = NULL;
+	SOCKADDR_VM listenAddress;
+	DECLARE_UNICODE_STRING_SIZE(listenHost, 16);
+	DECLARE_UNICODE_STRING_SIZE(listenPort, 16);
+	PADDRINFOEXW addrInfo = NULL;
+	PWSK_SOCKET serverSocket = NULL;
+	IO_STATUS_BLOCK iosb;
+	KSPIN_LOCK threadListLock;
+	LIST_ENTRY threadListHead;
+	DEBUG_ENTER_FUNCTION("Context=0x%p", Context);
+
+	if (InterlockedIncrement(&_readyThreads) == (CLIENT_THREAD_COUNT + SERVER_THREAD_COUNT))
+		KeSetEvent(&_initEvent, IO_NO_INCREMENT, FALSE);
+	
+	irp = IoAllocateIrp(1, FALSE);
+	if (!irp) {
+		iosb.Status = STATUS_INSUFFICIENT_RESOURCES;
+		DEBUG_ERROR("Unable to allocate IRP: 0x%x", iosb.Status);
+		goto Exit;
+	}
+
+	KeInitializeEvent(&event, NotificationEvent, FALSE);
+	WSK_SYNCHRONOUS_CALL(irp, &event, _vioWskProviderNPI.Dispatch->WskSocket(_vioWskProviderNPI.Client, AF_VSOCK, SOCK_STREAM, 0, WSK_FLAG_LISTEN_SOCKET, NULL, NULL, NULL, NULL, NULL, irp), &iosb);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to create server socket: 0x%x", iosb.Status);
+		goto FreeIrp;
+	}
+
+	serverSocket = (PWSK_SOCKET)iosb.Information;
+	iosb.Status = RtlUnicodeStringPrintf(&listenHost, L"%u", (ULONG)VMADDR_CID_ANY);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to prepare server address hos: 0x%x", iosb.Status);
+		goto CloseSocket;
+	}
+
+	iosb.Status = RtlUnicodeStringPrintf(&listenPort, L"%Iu", LISTEN_PORT_MIN + (SIZE_T)Context);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to prepare server address port: 0x%x", iosb.Status);
+		goto CloseSocket;
+	}
+
+	WSK_SYNCHRONOUS_CALL(irp, &event, _vioWskProviderNPI.Dispatch->WskGetAddressInfo(_vioWskProviderNPI.Client, &listenHost, &listenPort, 0, NULL, NULL, &addrInfo, NULL, NULL, irp), &iosb);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to translate the listen address: 0x%x", iosb.Status);
+		goto CloseSocket;
+	}
+
+	listenAddress = *(PSOCKADDR_VM)addrInfo->ai_addr;
+	_vioWskProviderNPI.Dispatch->WskFreeAddressInfo(_vioWskProviderNPI.Client, addrInfo);
+
+	WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_LISTEN_DISPATCH)serverSocket->Dispatch)->WskBind(serverSocket, (PSOCKADDR)&listenAddress, 0, irp), &iosb);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to bind: 0x%x", iosb.Status);
+		goto CloseSocket;
+	}
+
+	nonBlocking = TRUE;
+	WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_LISTEN_DISPATCH)serverSocket->Dispatch)->WskControlSocket(serverSocket, WskIoctl, FIONBIO, 0, sizeof(nonBlocking), &nonBlocking, 0, NULL, NULL, irp), &iosb);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to be nonblocking: 0x%x", iosb.Status);
+		goto CloseSocket;
+	}
+
+	nonBlocking = FALSE;
+	InitializeListHead(&threadListHead);
+	KeInitializeSpinLock(&threadListLock);
+	while (!InterlockedCompareExchange(&_terminate, 1, 1)) {
+		PWSK_SOCKET clientSocket = NULL;
+		SOCKADDR_VM localAddr;
+		SOCKADDR_VM remoteAddr;
+		LARGE_INTEGER timeout;
+
+		timeout.QuadPart = -10000000;
+		WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_LISTEN_DISPATCH)serverSocket->Dispatch)->WskAccept(serverSocket, WSK_FLAG_CONNECTION_SOCKET, NULL, NULL, (PSOCKADDR)&localAddr, (PSOCKADDR)&remoteAddr, irp), &iosb);
+		if (iosb.Status == STATUS_CANT_WAIT) {
+			KeDelayExecutionThread(KernelMode, FALSE, &timeout);
+			continue;
+		}
+		
+		if (!NT_SUCCESS(iosb.Status)) {
+			DEBUG_ERROR("Unable to accept: 0x%x", iosb.Status);
+			break;
+		}
+		
+		clientSocket = (PWSK_SOCKET)iosb.Information;
+		WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_LISTEN_DISPATCH)clientSocket->Dispatch)->WskControlSocket(clientSocket, WskIoctl, FIONBIO, 0, sizeof(nonBlocking), &nonBlocking, 0, NULL, NULL, irp), &iosb);
+		if (!NT_SUCCESS(iosb.Status)) {
+			DEBUG_ERROR("Unable to be blocking: 0x%x", iosb.Status);
+		}
+
+		if (NT_SUCCESS(iosb.Status)) {
+			WSK_SYNCHRONOUS_CALL(irp, &event, _vioWskProviderNPI.Dispatch->WskGetNameInfo(_vioWskProviderNPI.Client, (PSOCKADDR)&localAddr, sizeof(localAddr), &listenHost, &listenPort, 0, NULL, NULL, irp), &iosb);
+			if (NT_SUCCESS(iosb.Status)) {
+				DEBUG_INFO("Accepted connection:");
+				DEBUG_INFO("  Local: %wZ:%wZ", &listenHost, &listenPort);
+				WSK_SYNCHRONOUS_CALL(irp, &event, _vioWskProviderNPI.Dispatch->WskGetNameInfo(_vioWskProviderNPI.Client, (PSOCKADDR)&remoteAddr, sizeof(remoteAddr), &listenHost, &listenPort, 0, NULL, NULL, irp), &iosb);
+				if (!NT_SUCCESS(iosb.Status)) {
+					DEBUG_ERROR("Unable to get client address strings: 0x%x", iosb.Status);
+				}
+			}
+		}
+
+		if (NT_SUCCESS(iosb.Status)) {
+			DEBUG_INFO("  Remote: %wZ:%wZ", &listenHost, &listenPort);
+			iosb.Status = _SocketTestThreadCreate(clientSocket, &threadListHead, &threadListLock);
+			if (!NT_SUCCESS(iosb.Status)) {
+				DEBUG_ERROR("Socket test thread failed to create: 0x%x", iosb.Status);
+			}
+		}
+
+		if (!NT_SUCCESS(iosb.Status)) {
+			WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_BASIC_DISPATCH)clientSocket->Dispatch)->WskCloseSocket(clientSocket, irp), &iosb);
+			break;
+		}
+	}
+
+	KeAcquireSpinLock(&threadListLock, &irql);
+	while (!IsListEmpty(&threadListHead))
+	{
+		PTEST_THREAD_CONTEXT ctx = CONTAINING_RECORD(threadListHead.Flink, TEST_THREAD_CONTEXT, Entry);
+	
+		RemoveEntryList(&ctx->Entry);
+		InitializeListHead(&ctx->Entry);
+		KeReleaseSpinLock(&threadListLock, irql);
+		InterlockedExchange(&ctx->Terminated, 1);
+		KeWaitForSingleObject(ctx->Thread, Executive, KernelMode, FALSE, NULL);
+		ObDereferenceObject(ctx->Thread);
+		WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_BASIC_DISPATCH)ctx->Socket->Dispatch)->WskCloseSocket(ctx->Socket, irp), &iosb);
+		IoFreeIrp(ctx->Irp);
+		ExFreePoolWithTag(ctx, VIOWSK_TEST_TAG);
+		KeAcquireSpinLock(&threadListLock, &irql);
+	}
+
+	KeReleaseSpinLock(&threadListLock, irql);
+CloseSocket:
+	WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_BASIC_DISPATCH)serverSocket->Dispatch)->WskCloseSocket(serverSocket, irp), &iosb);
+	if (!NT_SUCCESS(iosb.Status)) {
+		DEBUG_ERROR("Unable to close the server socket: 0x%x", iosb.Status);
+	}
+FreeIrp:
+	IoFreeIrp(irp);
+Exit:
+	InterlockedExchange(&_terminate, 1);
+
+	DEBUG_EXIT_FUNCTION("0x%x", iosb.Status);
+	return;
+}
+
+
+static
+void
+_ClientThreadRoutine(
+	_In_opt_ PVOID Context
+)
+{
+	KEVENT event;
+	PIRP irp = NULL;
+	LARGE_INTEGER timeSeed;
+	LARGE_INTEGER timeout;
+	IO_STATUS_BLOCK iosb;
+	SOCKADDR_VM localAddr;
+	SOCKADDR_VM remoteAddr;
+	PWSK_SOCKET socket = NULL;
+	DEBUG_ENTER_FUNCTION("Context=0x%p", Context);
+
+	UNREFERENCED_PARAMETER(Context);
+
+	iosb.Status = STATUS_SUCCESS;
+	if (InterlockedIncrement(&_readyThreads) == (CLIENT_THREAD_COUNT + SERVER_THREAD_COUNT))
+		KeSetEvent(&_initEvent, IO_NO_INCREMENT, FALSE);
+
+	irp = IoAllocateIrp(1, FALSE);
+	if (!irp) {
+		iosb.Status = STATUS_INSUFFICIENT_RESOURCES;
+		DEBUG_ERROR("Failed to allocate IRP: 0x%x", iosb.Status);
+		goto Exit;
+	}
+
+	timeout.QuadPart = -10000000;
+	KeQuerySystemTime(&timeSeed);
+	KeInitializeEvent(&event, NotificationEvent, FALSE);
+	while (!InterlockedCompareExchange(&_terminate, 1, 1)) {
+		memset(&localAddr, 0, sizeof(localAddr));
+		localAddr.svm_family = AF_VSOCK;
+		localAddr.svm_cid = (UINT)VMADDR_CID_ANY;
+		localAddr.svm_port = (UINT)VMADDR_PORT_ANY;
+		memset(&remoteAddr, 0, sizeof(remoteAddr));
+		remoteAddr.svm_family = AF_VSOCK;
+		remoteAddr.svm_cid = (UINT)VMADDR_CID_ANY;
+		remoteAddr.svm_port = LISTEN_PORT_MIN + (RtlRandomEx(&timeSeed.LowPart) % (SERVER_THREAD_COUNT));
+		WSK_SYNCHRONOUS_CALL(irp, &event, _vioWskProviderNPI.Dispatch->WskSocket(_vioWskProviderNPI.Client, AF_VSOCK, SOCK_STREAM, 0, WSK_FLAG_CONNECTION_SOCKET, NULL, NULL, NULL, NULL, NULL, irp), &iosb);
+		if (!NT_SUCCESS(iosb.Status)) {
+			DEBUG_ERROR("Unable to create client socket: 0x%x", iosb.Status);
+			break;
+		}
+
+		socket = (PWSK_SOCKET)iosb.Information;
+		WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)socket->Dispatch)->WskBind(socket, (PSOCKADDR)&localAddr, 0, irp), &iosb);
+		if (NT_SUCCESS(iosb.Status))
+        {
+            WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)socket->Dispatch)->WskConnect(socket, (PSOCKADDR)&remoteAddr, 0, irp), &iosb);
+        }
+
+        if (NT_SUCCESS(iosb.Status)) {
+			iosb.Status = _TestSocket(socket, irp, FALSE);
+			if (!NT_SUCCESS(iosb.Status)) {
+				DEBUG_ERROR("Client socket test failed: 0x%x", iosb.Status);
+			}
+			
+			WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)socket->Dispatch)->WskDisconnect(socket, NULL, 0, irp), &iosb);
+			if (iosb.Status == STATUS_CONNECTION_INVALID)
+				iosb.Status = STATUS_SUCCESS;
+
+			if (!NT_SUCCESS(iosb.Status)) {
+				DEBUG_ERROR("Client socket disconnect failed: 0x%x", iosb.Status);
+			}
+		} else {
+			DEBUG_ERROR("Unable to connect to the server: 0x%x", iosb.Status);
+		}
+
+		WSK_SYNCHRONOUS_CALL(irp, &event, ((PWSK_PROVIDER_CONNECTION_DISPATCH)socket->Dispatch)->WskCloseSocket(socket, irp), &iosb);
+		if (!NT_SUCCESS(iosb.Status)) {
+			DEBUG_ERROR("Unable to close the client socket: 0x%x", iosb.Status);
+		}
+
+		DEBUG_INFO("Client thread test finished\n");
+		KeDelayExecutionThread(KernelMode, FALSE, &timeout);
+	}
+
+	IoFreeIrp(irp);
+Exit:
+	InterlockedExchange(&_terminate, 1);
+
+	DEBUG_EXIT_FUNCTION("0x%x", iosb.Status);
+	return;
+}
+
+
+static
+void
+_DestroyThreadGroup(
+	_In_ PETHREAD* ObjectArray,
+	_In_ SIZE_T Count
+)
+{
+	DEBUG_ENTER_FUNCTION("ObjectArray=0x%p; Count=%Iu", ObjectArray, Count);
+
+	InterlockedExchange(&_terminate, 1);
+	for (SIZE_T i = 0; i < Count; ++i) {
+		KeWaitForSingleObject(ObjectArray[i], Executive, KernelMode, FALSE, NULL);
+		ObDereferenceObject(ObjectArray[i]);
+	}
+
+	DEBUG_EXIT_FUNCTION_VOID();
+	return;
+}
+
+
+static
+NTSTATUS
+_CreateThreadGroup(
+	_In_ SIZE_T Count,
+	_In_ PKSTART_ROUTINE Routine,
+	_Out_ PETHREAD *ObjectArray
+)
+{
+	CLIENT_ID clientId;
+	OBJECT_ATTRIBUTES oa;
+	HANDLE hThread = NULL;
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+#pragma warning(push)
+#pragma warning (disable : 4152)
+	DEBUG_ENTER_FUNCTION("Count=%Iu; Routine=0x%p; ObjectArray=0x%p", Count, Routine, ObjectArray);
+#pragma warning (pop)
+
+	InitializeObjectAttributes(&oa, NULL, OBJ_KERNEL_HANDLE, NULL, NULL);
+	for (SIZE_T i = 0; i < Count; ++i) {
+		Status = PsCreateSystemThread(&hThread, SYNCHRONIZE, &oa, NULL, &clientId, Routine, (PVOID)i);
+		if (NT_SUCCESS(Status)) {
+			Status = ObReferenceObjectByHandle(hThread, SYNCHRONIZE, *PsThreadType, KernelMode, ObjectArray + i, NULL);
+			ZwClose(hThread);
+		}
+
+		if (!NT_SUCCESS(Status)) {
+			_DestroyThreadGroup(ObjectArray, i);
+			break;
+		}
+	}
+
+	DEBUG_EXIT_FUNCTION("0x%x", Status);
+	return Status;
+}
+
+
+static
+NTSTATUS
+_SocketTestThreadCreate(
+	_In_ PWSK_SOCKET Socket,
+	_In_ PLIST_ENTRY ListHead,
+	_In_ PKSPIN_LOCK ListLock
+)
+{
+	KIRQL irql;
+	CLIENT_ID clientId;
+	OBJECT_ATTRIBUTES oa;
+	HANDLE hThread = NULL;
+	PTEST_THREAD_CONTEXT ctx = NULL;
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	DEBUG_ENTER_FUNCTION("Socket=0x%p; ListHead=0x%p; ListLock=0x%p", Socket, ListHead, ListLock);
+
+	ctx = ExAllocatePoolUninitialized(NonPagedPool, sizeof(TEST_THREAD_CONTEXT), VIOWSK_TEST_TAG);
+	if (!ctx) {
+		Status = STATUS_INSUFFICIENT_RESOURCES;
+		goto Exit;
+	}
+
+	InterlockedExchange(&ctx->Terminated, 0);
+	InitializeListHead(&ctx->Entry);
+	ctx->ListLock = ListLock;
+	ctx->Socket = Socket;
+	ctx->Irp = IoAllocateIrp(1, FALSE);
+	if (!ctx->Irp) {
+		Status = STATUS_INSUFFICIENT_RESOURCES;
+		goto FreeCtx;
+	}
+
+	KeAcquireSpinLock(ListLock, &irql);
+	InsertTailList(ListHead, &ctx->Entry);
+	KeReleaseSpinLock(ListLock, irql);
+	InitializeObjectAttributes(&oa, NULL, OBJ_KERNEL_HANDLE, NULL, NULL);
+	Status = PsCreateSystemThread(&hThread, SYNCHRONIZE, &oa, NULL, &clientId, _TestThreadRoutine, ctx);
+	if (!NT_SUCCESS(Status))
+		goto FreeIrp;;
+
+	Status = ObReferenceObjectByHandle(hThread, SYNCHRONIZE, *PsThreadType, KernelMode, &ctx->Thread, NULL);
+	if (!NT_SUCCESS(Status)) {
+		InterlockedExchange(&ctx->Terminated, 1);
+		ZwWaitForSingleObject(hThread, FALSE, NULL);
+		goto CloseThread;
+	}
+
+	ctx = NULL;
+CloseThread:
+	ZwClose(hThread);
+	hThread = NULL;
+FreeIrp:
+	if (hThread)
+	{
+		KeAcquireSpinLock(ListLock, &irql);
+		RemoveEntryList(&ctx->Entry);
+		InitializeListHead(&ctx->Entry);
+		KeReleaseSpinLock(ListLock, irql);
+	}
+
+	if (ctx && ctx->Irp)
+		IoFreeIrp(ctx->Irp);
+FreeCtx:
+	if (ctx)
+		ExFreePoolWithTag(ctx, VIOWSK_TEST_TAG);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x", Status);
+	return Status;
+}
+
+
+static
+void
+DriverUnload(
+	_In_ PDRIVER_OBJECT DriverObject
+)
+{
+	DEBUG_ENTER_FUNCTION("DriverObject=0x%p", DriverObject);
+
+	UNREFERENCED_PARAMETER(DriverObject);
+
+	_DestroyThreadGroup(_clientThreads, sizeof(_clientThreads) / sizeof(_clientThreads[0]));
+	_DestroyThreadGroup(_serverThreads, sizeof(_serverThreads) / sizeof(_serverThreads[0]));
+	VioWskReleaseProviderNPI(&_vioWskRegistration);
+	VioWskDeregister(&_vioWskRegistration);
+	VioWskModuleFinit();
+	IoDeleteDevice(_shutdownDeviceObject);
+
+	DEBUG_EXIT_FUNCTION_VOID();
+	return;
+}
+
+
+NTSTATUS
+DriverEntry(
+	_In_ PDRIVER_OBJECT DriverObject,
+	_In_ PUNICODE_STRING RegistryPath
+)
+{
+	PDEVICE_OBJECT Device = NULL;
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	DEBUG_ENTER_FUNCTION("DriverObject=0x%p; RegistryPath=\"%wZ\"", DriverObject, RegistryPath);
+
+	Status = IoCreateDevice(DriverObject, 0, NULL, FILE_DEVICE_UNKNOWN, 0, FALSE, &Device);
+	if (!NT_SUCCESS(Status))
+		goto Exit;
+
+	Status = VioWskModuleInit(DriverObject, RegistryPath, Device);
+	if (!NT_SUCCESS(Status))
+		goto DeleteDevice;
+
+	Status = VioWskRegister(&_vioWskClientNPI, &_vioWskRegistration);
+	if (!NT_SUCCESS(Status))
+		goto VioWskFinit;
+
+	Status = VioWskCaptureProviderNPI(&_vioWskRegistration, WSK_INFINITE_WAIT, &_vioWskProviderNPI);
+	if (!NT_SUCCESS(Status))
+		goto VioWskDeregister;
+
+	KeInitializeEvent(&_initEvent, NotificationEvent, FALSE);
+	Status = _CreateThreadGroup(sizeof(_serverThreads) / sizeof(_serverThreads[0]), _ServerThreadRoutine, _serverThreads);
+	if (!NT_SUCCESS(Status))
+		goto VIoWskReleaseNPI;
+
+	Status = _CreateThreadGroup(sizeof(_clientThreads) / sizeof(_clientThreads[0]), _ClientThreadRoutine, _clientThreads);
+	if (!NT_SUCCESS(Status))
+		goto DestroyServers;
+
+	KeWaitForSingleObject(&_initEvent, Executive, KernelMode, FALSE, NULL);
+	if (_terminate) {
+		Status = STATUS_UNSUCCESSFUL;
+		goto DestroyClients;
+	}
+
+	DriverObject->DriverUnload = DriverUnload;
+	_shutdownDeviceObject = (PDEVICE_OBJECT)InterlockedExchangePointer(&Device, NULL);
+DestroyClients:
+	if (!NT_SUCCESS(Status))
+		_DestroyThreadGroup(_clientThreads, sizeof(_clientThreads) / sizeof(_clientThreads[0]));
+DestroyServers:
+	if (!NT_SUCCESS(Status))
+		_DestroyThreadGroup(_serverThreads, sizeof(_serverThreads) / sizeof(_serverThreads[0]));
+VIoWskReleaseNPI:
+	if (!NT_SUCCESS(Status))
+		VioWskReleaseProviderNPI(&_vioWskRegistration);
+VioWskDeregister:
+	if (!NT_SUCCESS(Status))
+		VioWskDeregister(&_vioWskRegistration);
+VioWskFinit:
+	if (!NT_SUCCESS(Status))
+		VioWskModuleFinit();
+DeleteDevice:
+	if (Device)
+		IoDeleteDevice(Device);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x", Status);
+	return Status;
+}

--- a/viosock/viosock-wsk-test/wpp-trace.h
+++ b/viosock/viosock-wsk-test/wpp-trace.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+
+#define EVENT_TRACING
+
+#if !defined(EVENT_TRACING)
+
+#if !defined(TRACE_LEVEL_NONE)
+  #define TRACE_LEVEL_NONE        0
+  #define TRACE_LEVEL_CRITICAL    1
+  #define TRACE_LEVEL_FATAL       1
+  #define TRACE_LEVEL_ERROR       2
+  #define TRACE_LEVEL_WARNING     3
+  #define TRACE_LEVEL_INFORMATION 4
+  #define TRACE_LEVEL_VERBOSE     5
+  #define TRACE_LEVEL_RESERVED6   6
+  #define TRACE_LEVEL_RESERVED7   7
+  #define TRACE_LEVEL_RESERVED8   8
+  #define TRACE_LEVEL_RESERVED9   9
+#endif
+
+
+//
+// Define Debug Flags
+//
+#define DBG_VIOWSK                0x00000001
+
+#define DBG_TEST                  0x00000001
+
+#define WPP_INIT_TRACING(a,b)
+#define WPP_CLEANUP(DriverObject)
+
+#else
+#define WPP_CHECK_FOR_NULL_STRING
+
+//
+// Define the tracing flags.
+//
+// Tracing GUID - C2D7F82F-CE5F-4408-8A37-8B9FE2B3D52E
+//
+
+// {13b9cfb4-b962-4b43-b59d-92242fab52e3}
+// {46e3298a-70b1-49c6-b9fd-8691980b7adf}
+#define WPP_CONTROL_GUIDS \
+    WPP_DEFINE_CONTROL_GUID(WskTraceGuid,(13b9cfb4,b962,4b43,b59d,92242fab52e3), \
+        WPP_DEFINE_BIT(DBG_VIOWSK)             /* bit  0 = 0x00000001 */ \
+        ) \
+    WPP_DEFINE_CONTROL_GUID(WskTestTraceGuid,(46e3298a,70b1,49c6,b9fd,8691980b7adf), \
+        WPP_DEFINE_BIT(DBG_TEST)             /* bit  0 = 0x00000001 */ \
+        )
+
+
+#define WPP_FLAG_LEVEL_LOGGER(flag, level) \
+    WPP_LEVEL_LOGGER(flag)
+
+#define WPP_FLAG_LEVEL_ENABLED(flag, level) \
+    (WPP_LEVEL_ENABLED(flag) && WPP_CONTROL(WPP_BIT_ ## flag).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) \
+    WPP_LEVEL_LOGGER(flags)
+
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) \
+    (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+ //
+ // This comment block is scanned by the trace preprocessor to define our
+ // Trace function.
+ //
+ // begin_wpp config
+ //
+ // USEPREFIX(DEBUG_ENTER_FUNCTION, "%!STDPREFIX! %!FUNC!(");
+ // USESUFFIX(DEBUG_ENTER_FUNCTION, ")");
+ // USEPREFIX(DEBUG_ENTER_FUNCTION_NO_ARGS, "%!STDPREFIX! %!FUNC!()");
+ // USEPREFIX(DEBUG_EXIT_FUNCTION, "%!STDPREFIX! %!FUNC!(-)");
+ // USEPREFIX(DEBUG_EXIT_FUNCTION_VOID, "%!STDPREFIX! %!FUNC!");
+ // USESUFFIX(DEBUG_EXIT_FUNCTION_VOID, "(-)");
+ // 
+ // FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
+ // FUNC DEBUG_ENTER_FUNCTION{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_TEST}(MSG, ...);
+ // FUNC DEBUG_ENTER_FUNCTION_NO_ARGS{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_TEST}();
+ // FUNC DEBUG_EXIT_FUNCTION{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_TEST}(MSG, ...);
+ // FUNC DEBUG_EXIT_FUNCTION_VOID{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_TEST}();
+ // FUNC DEBUG_ERROR{LEVEL=TRACE_LEVEL_ERROR, FLAGS=DBG_TEST}(MSG, ...);
+ // FUNC DEBUG_WARNING{LEVEL=TRACE_LEVEL_WARNING, FLAGS=DBG_TEST}(MSG, ...);
+ // FUNC DEBUG_TRACE{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_TEST}(MSG, ...);
+ // FUNC DEBUG_INFO{LEVEL=TRACE_LEVEL_INFORMATION, FLAGS=DBG_TEST}(MSG, ...);
+ //
+ // end_wpp
+ //
+
+#endif

--- a/viosock/viosock.sln
+++ b/viosock/viosock.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34316.72
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "VirtioLib", "..\VirtIO\VirtioLib.vcxproj", "{01D87C47-437A-4A16-8FD9-33FA5C99339E}"
 EndProject
@@ -43,6 +43,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ViosockPackage", "ViosockPa
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "viosockwsk", "wsk\wsk.vcxproj", "{96FDD976-0035-4E24-A61B-E93BED675101}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "viosockwsk-test", "viosock-wsk-test\viosock-wsk-test.vcxproj", "{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,6 +154,24 @@ Global
 		{96FDD976-0035-4E24-A61B-E93BED675101}.Win11 Release|x64.Build.0 = Win11 Release|x64
 		{96FDD976-0035-4E24-A61B-E93BED675101}.Win11 Release|x64.Deploy.0 = Win11 Release|x64
 		{96FDD976-0035-4E24-A61B-E93BED675101}.Win11 Release|x86.ActiveCfg = Win11 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|ARM64.ActiveCfg = Win10 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|ARM64.Build.0 = Win10 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|ARM64.Deploy.0 = Win10 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x64.ActiveCfg = Win10 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x64.Build.0 = Win10 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x64.Deploy.0 = Win10 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x86.ActiveCfg = Win10 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x86.Build.0 = Win10 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win10 Release|x86.Deploy.0 = Win10 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|ARM64.ActiveCfg = Win11 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|ARM64.Build.0 = Win11 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|ARM64.Deploy.0 = Win11 Release|ARM64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x64.ActiveCfg = Win11 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x64.Build.0 = Win11 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x64.Deploy.0 = Win11 Release|x64
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x86.ActiveCfg = Win11 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x86.Build.0 = Win11 Release|Win32
+		{A2A7AFFC-BEFE-4066-A1DD-23242FAFAD70}.Win11 Release|x86.Deploy.0 = Win11 Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/viosock/wsk/LICENSE
+++ b/viosock/wsk/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2019 Virtuozzo, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/viosock/wsk/precomp.h
+++ b/viosock/wsk/precomp.h
@@ -26,6 +26,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
 #include <stddef.h>
 #include <stdarg.h>
 #include <ntifs.h>
@@ -39,5 +40,6 @@
 #include <ntintsafe.h>
 #include <wsk.h>
 
+#include "..\inc\debug-utils.h"
 #include "..\sys\public.h"
 #include "..\inc\vio_sockets.h"

--- a/viosock/wsk/provider.c
+++ b/viosock/wsk/provider.c
@@ -29,9 +29,14 @@
 
 #include "precomp.h"
 #include "viowsk.h"
+#include "..\inc\debug-utils.h"
+#include "wsk-utils.h"
 #include "..\inc\vio_wsk.h"
 
 #ifdef ALLOC_PRAGMA
+#pragma alloc_text (PAGE, VioWskGetAddressInfo)
+#pragma alloc_text (PAGE, VioWskFreeAddressInfo)
+#pragma alloc_text (PAGE, VioWskGetNameInfo)
 #endif
 
 static
@@ -233,6 +238,7 @@ VioWskControlClient(
     return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
 }
 
+_At_(*Result, __drv_allocatesMem(Mem))
 NTSTATUS
 WSKAPI
 VioWskGetAddressInfo(
@@ -242,25 +248,82 @@ VioWskGetAddressInfo(
     _In_opt_ ULONG            NameSpace,
     _In_opt_ GUID            *Provider,
     _In_opt_ PADDRINFOEXW     Hints,
-    _Outptr_ PADDRINFOEXW *Result,
+    _Outptr_ PADDRINFOEXW    *Result,
     _In_opt_ PEPROCESS        OwningProcess,
     _In_opt_ PETHREAD         OwningThread,
     _Inout_ PIRP              Irp
-    )
+)
 {
+    ULONG Cid = 0;
+    ULONG Port = 0;
+    ULONG_PTR SizeReturned = 0;
+    PADDRINFOEXW AddrInfo = NULL;
+    PSOCKADDR_VM VMAddr = NULL;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; NodeName=\"%wZ\"; ServiceName=\"%wZ\"; NameSpace=%u; Provider=0x%p; Hints=0x%p; Result=0x%p; OwningProcess=0x%p; OwningThread=0x%p; Irp=0x%p", Client, NodeName, ServiceName, NameSpace, Provider, Hints, Result, OwningProcess, OwningThread, Irp);
+
+    PAGED_CODE();
     UNREFERENCED_PARAMETER(Client);
-    UNREFERENCED_PARAMETER(NodeName);
-    UNREFERENCED_PARAMETER(ServiceName);
     UNREFERENCED_PARAMETER(NameSpace);
     UNREFERENCED_PARAMETER(Provider);
     UNREFERENCED_PARAMETER(Hints);
-    UNREFERENCED_PARAMETER(Result);
     UNREFERENCED_PARAMETER(OwningProcess);
     UNREFERENCED_PARAMETER(OwningThread);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = STATUS_SUCCESS;
+    if (NodeName)
+    {
+        Status = VioWskStringToAddressPart(NodeName, &Cid);
+        if (!NT_SUCCESS(Status))
+            goto CompleteIrp;
+    }
+
+    if (ServiceName)
+    {
+        Status = VioWskStringToAddressPart(ServiceName, &Port);
+        if (!NT_SUCCESS(Status))
+            goto CompleteIrp;
+    }
+
+    VMAddr = ExAllocatePoolUninitialized(NonPagedPool, sizeof(SOCKADDR_VM), VIOSOCK_WSK_MEMORY_TAG);
+    if (!VMAddr)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto CompleteIrp;
+    }
+
+    memset(VMAddr, 0, sizeof(SOCKADDR_VM));
+    VMAddr->svm_family = AF_VSOCK;
+    VMAddr->svm_cid = Cid;
+    VMAddr->svm_port = Port;
+    AddrInfo = ExAllocatePoolUninitialized(PagedPool, sizeof(ADDRINFOEXW), VIOSOCK_WSK_MEMORY_TAG);
+    if (!AddrInfo)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto FreeVMAddr;
+	}
+
+    memset(AddrInfo, 0, sizeof(ADDRINFOEXW));
+    AddrInfo->ai_family = AF_VSOCK;
+    AddrInfo->ai_socktype = SOCK_STREAM;
+    AddrInfo->ai_addr = (struct sockaddr*)VMAddr;
+    AddrInfo->ai_addrlen = sizeof(SOCKADDR_VM);
+    *Result = AddrInfo;
+    SizeReturned = sizeof(ADDRINFOEXW);
+    VMAddr = NULL;
+
+FreeVMAddr:
+    if (VMAddr)
+        ExFreePoolWithTag(VMAddr, VIOSOCK_WSK_MEMORY_TAG);
+CompleteIrp:
+    if (Irp)
+        VioWskIrpComplete(NULL, Irp, Status, SizeReturned);
+
+    DEBUG_EXIT_FUNCTION("0x%x, *Result=0x%p", Status, *Result);
+    return Status;
 }
 
+_At_(AddrInfo, __drv_freesMem(Mem))
 VOID
 WSKAPI
 VioWskFreeAddressInfo(
@@ -268,9 +331,23 @@ VioWskFreeAddressInfo(
     _In_ PADDRINFOEXW AddrInfo
     )
 {
-    UNREFERENCED_PARAMETER(Client);
-    UNREFERENCED_PARAMETER(AddrInfo);
 
+    PADDRINFOEXW Prev = NULL;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; AddrInfo=0x%p", Client, AddrInfo);
+
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(Client);
+
+    while (AddrInfo != NULL)
+    {
+        Prev = AddrInfo;
+        AddrInfo = AddrInfo->ai_next;
+        ExFreePoolWithTag(Prev->ai_addr, VIOSOCK_WSK_MEMORY_TAG);
+        ExFreePoolWithTag(Prev, VIOSOCK_WSK_MEMORY_TAG);
+    }
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
 }
 
 NTSTATUS
@@ -285,16 +362,43 @@ VioWskGetNameInfo(
     _In_opt_ PEPROCESS        OwningProcess,
     _In_opt_ PETHREAD         OwningThread,
     _Inout_ PIRP              Irp
-    )
+)
 {
+    PSOCKADDR_VM VMAddr = NULL;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; SockAddr=0x%p; SockAddrLength=%u; NodeName=0x%p; ServiceName=0x%p; Flags=0x%x; OwningProcess=0x%p; OwningThread=0x%p; Irp=0x%p", Client, SockAddr, SockAddrLength, NodeName, ServiceName, Flags, OwningProcess, OwningThread, Irp);
+
+    PAGED_CODE();
     UNREFERENCED_PARAMETER(Client);
-    UNREFERENCED_PARAMETER(NodeName);
-    UNREFERENCED_PARAMETER(ServiceName);
-    UNREFERENCED_PARAMETER(SockAddr);
-    UNREFERENCED_PARAMETER(SockAddrLength);
     UNREFERENCED_PARAMETER(Flags);
     UNREFERENCED_PARAMETER(OwningProcess);
     UNREFERENCED_PARAMETER(OwningThread);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = STATUS_SUCCESS;
+    VMAddr = (PSOCKADDR_VM)SockAddr;
+    if ((NodeName == NULL && ServiceName == NULL) ||
+        SockAddrLength != sizeof(SOCKADDR_VM) ||
+        VMAddr->svm_family != AF_VSOCK) {
+        Status = STATUS_INVALID_PARAMETER;
+        goto CompleteIrp;
+    }
+
+    if (NodeName != NULL) {
+        Status = VioWskAddressPartToString(VMAddr->svm_cid, NodeName);
+        if (!NT_SUCCESS(Status))
+            goto CompleteIrp;
+    }
+
+    if (ServiceName != NULL) {
+        Status = VioWskAddressPartToString(VMAddr->svm_port, ServiceName);
+        if (!NT_SUCCESS(Status))
+            goto CompleteIrp;
+    }
+
+CompleteIrp:
+    if (Irp)
+        Status = VioWskIrpComplete(NULL, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x, Nodename=\"%wZ\", Servicename=\"%wZ\"", Status, NodeName, ServiceName);
+    return Status;
 }

--- a/viosock/wsk/provider.c
+++ b/viosock/wsk/provider.c
@@ -34,6 +34,10 @@
 #include "viowsk-internal.h"
 #include "wsk-workitem.h"
 #include "..\inc\vio_wsk.h"
+#ifdef EVENT_TRACING
+#include "provider.tmh"
+#endif
+
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (PAGE, VioWskGetAddressInfo)
@@ -61,7 +65,7 @@ VioWskSocket(
 	PWSK_WORKITEM WorkItem = NULL;
 	PVIOWSK_SOCKET pSocket = NULL;
 	NTSTATUS Status = STATUS_UNSUCCESSFUL;
-	DEBUG_ENTER_FUNCTION("Client=0x%p; AddressFamily=%u; SocketType=%u; Protocol=%u; Flags=0x%x; SocketContext=0x%p; Dispatch=0x%p; OwningProcess=0x%p; OwningThread=0x%p; SecurityDescriptor=0x%p; Irp=0x%p", Client, AddressFamily, SocketType, Protocol, Flags, SocketContext, Dispatch, OwningProcess, OwningThread, SecurityDescriptor, Irp);
+    DEBUG_ENTER_FUNCTION("Client=0x%p; AddressFamily=%u; SocketType=%u; Protocol=%u; Flags=0x%x; SocketContext=0x%p; Dispatch=0x%p; OwningProcess=0x%p; OwningThread=0x%p; SecurityDescriptor=0x%p; Irp=0x%p", Client, AddressFamily, SocketType, Protocol, Flags, SocketContext, Dispatch, OwningProcess, OwningThread, SecurityDescriptor, Irp);
 
 	_At_((void*)Irp->IoStatus.Information, __drv_allocatesMem(Mem))
 
@@ -151,7 +155,7 @@ VioWskControlClient(
 )
 {
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
-    DEBUG_ENTER_FUNCTION("Client=0x%p; ControlCode=0x%x; InputSize=%zu; InputBuffer=0x%p; OutputSize=%zu; OutputBuffer=0x%p; OutputSizeReturned=0x%p; Irp=0x%p", Client, ControlCode, InputSize, InputBuffer, OutputSize, OutputBuffer, OutputSizeReturned, Irp);
+    DEBUG_ENTER_FUNCTION("Client=0x%p; ControlCode=0x%x; InputSize=%Iu; InputBuffer=0x%p; OutputSize=%Iu; OutputBuffer=0x%p; OutputSizeReturned=0x%p; Irp=0x%p", Client, ControlCode, InputSize, InputBuffer, OutputSize, OutputBuffer, OutputSizeReturned, Irp);
 
     UNREFERENCED_PARAMETER(Client);
     UNREFERENCED_PARAMETER(ControlCode);

--- a/viosock/wsk/provider.c
+++ b/viosock/wsk/provider.c
@@ -150,6 +150,9 @@ VioWskControlClient(
     _Inout_opt_ PIRP                    Irp
 )
 {
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; ControlCode=0x%x; InputSize=%zu; InputBuffer=0x%p; OutputSize=%zu; OutputBuffer=0x%p; OutputSizeReturned=0x%p; Irp=0x%p", Client, ControlCode, InputSize, InputBuffer, OutputSize, OutputBuffer, OutputSizeReturned, Irp);
+
     UNREFERENCED_PARAMETER(Client);
     UNREFERENCED_PARAMETER(ControlCode);
     UNREFERENCED_PARAMETER(InputSize);
@@ -158,7 +161,14 @@ VioWskControlClient(
     UNREFERENCED_PARAMETER(OutputBuffer);
     UNREFERENCED_PARAMETER(OutputSizeReturned);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = STATUS_NOT_IMPLEMENTED;
+    if (Irp)
+    {
+        VioWskIrpComplete(NULL, Irp, Status, 0);
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 _At_(*Result, __drv_allocatesMem(Mem))

--- a/viosock/wsk/socket-internal.c
+++ b/viosock/wsk/socket-internal.c
@@ -1,0 +1,260 @@
+/*
+ * Exports definition for virtio socket WSK interface
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "precomp.h"
+#include "viowsk.h"
+#include "..\inc\debug-utils.h"
+#include "wsk-utils.h"
+#include "viowsk-internal.h"
+
+#ifdef ALLOC_PRAGMA
+#pragma alloc_text (PAGE, VioWskSocketInternal)
+#pragma alloc_text (PAGE, VioWskCloseSocketInternal)
+#endif
+
+
+_Must_inspect_result_
+static
+NTSTATUS
+_VioSocketCreate(
+    _In_ PWSK_CLIENT              Client,
+    _In_opt_ PVIOWSK_SOCKET       ListenSocket,
+    _In_ ULONG                    SocketType,
+    _Out_ PHANDLE                 SocketFileHandle,
+    _Out_ PFILE_OBJECT           *SocketFileObject
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_REG_CONTEXT pContext = NULL;
+    PWSK_REGISTRATION reg = NULL;
+    HANDLE hFile = NULL;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    IO_STATUS_BLOCK Iosb = { 0 };
+    VIRTIO_VSOCK_PARAMS SockParams = { 0 };
+    UCHAR EaBuffer[sizeof(FILE_FULL_EA_INFORMATION) + sizeof(SockParams)] = { 0 };
+    PFILE_FULL_EA_INFORMATION pEaBuffer = (PFILE_FULL_EA_INFORMATION)EaBuffer;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; ListenSocket=0x%p; Sockettype=%u; SocketFileHandle=0x%p; SocketFileObject=0x%p", Client, ListenSocket, SocketType, SocketFileHandle, SocketFileObject);
+
+    PAGED_CODE();
+    reg = (PWSK_REGISTRATION)Client;
+    pContext = (PVIOWSK_REG_CONTEXT)reg->ReservedRegistrationContext;
+    RtlSecureZeroMemory(&SockParams, sizeof(SockParams));
+    if (ListenSocket != NULL)
+        SockParams.Socket = (ULONGLONG)ListenSocket->FileHandle;
+
+    SockParams.Type = SocketType;
+    pEaBuffer->EaNameLength = sizeof(FILE_FULL_EA_INFORMATION) -
+        FIELD_OFFSET(FILE_FULL_EA_INFORMATION, EaName) - sizeof(UCHAR);
+    pEaBuffer->EaValueLength = sizeof(SockParams);
+    RtlCopyMemory(&EaBuffer[sizeof(FILE_FULL_EA_INFORMATION)], &SockParams, sizeof(SockParams));
+
+    InitializeObjectAttributes(&ObjectAttributes, &pContext->VIOSockLinkName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    Status = ZwCreateFile(&hFile, FILE_GENERIC_READ | FILE_GENERIC_WRITE, &ObjectAttributes, &Iosb, 0, 0,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, FILE_OPEN, FILE_NON_DIRECTORY_FILE, pEaBuffer,
+        pEaBuffer ? sizeof(EaBuffer) : 0);
+
+    if (NT_SUCCESS(Status))
+    {
+        Status = ObReferenceObjectByHandle(hFile, FILE_GENERIC_READ | FILE_GENERIC_WRITE, *IoFileObjectType, KernelMode, (PVOID*)SocketFileObject, NULL);
+        if (NT_SUCCESS(Status))
+            *SocketFileHandle = hFile;
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x, *SocketFileHandle=0x%p, *SocketFileObject=0x%p", Status, *SocketFileHandle, *SocketFileObject);
+    return Status;
+}
+
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketInternal(
+    _In_ PWSK_CLIENT              Client,
+    _In_opt_ PVIOWSK_SOCKET       ListenSocket,
+    _In_ ULONG                    Flags,
+    _In_opt_ PVOID                SocketContext,
+    _In_opt_ CONST VOID* Dispatch,
+    _In_opt_ PEPROCESS            OwningProcess,
+    _In_opt_ PETHREAD             OwningThread,
+    _In_opt_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Out_ PVIOWSK_SOCKET* pNewSocket
+)
+{
+    PWSK_CLIENT_LISTEN_DISPATCH pListenDispatch = NULL;
+    PWSK_CLIENT_CONNECTION_DISPATCH pConnectionDispatch = NULL;
+    PVIOWSK_SOCKET pSocket = NULL;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVOID pProviderDispatch = NULL;
+    SIZE_T ProviderDispatchSize = 0;
+    VIRTIO_VSOCK_CONFIG SocketConfig;
+    PIRP ConfigIrp = NULL;
+    KEVENT ConfigEvent;
+    IO_STATUS_BLOCK ConfigIosb;
+    DEBUG_ENTER_FUNCTION("Client=0x%p; ListenSocket=0x%p; Flags=0x%x; SocketContext=0x%p; Dispatch=0x%p; OwningProcess=0x%p; OwningThread=0x%p; SecurityDescriptor=0x%p; pNewSocket=0x%p", Client, ListenSocket, Flags, SocketContext, Dispatch, OwningProcess, OwningThread, SecurityDescriptor, pNewSocket);
+
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(OwningProcess);
+    UNREFERENCED_PARAMETER(OwningThread);
+    UNREFERENCED_PARAMETER(SecurityDescriptor);
+
+    *pNewSocket = NULL;
+    Status = STATUS_SUCCESS;
+
+    switch (Flags)
+    {
+    case WSK_FLAG_BASIC_SOCKET:
+        pProviderDispatch = &gBasicDispatch;
+        ProviderDispatchSize = sizeof(gBasicDispatch);
+        break;
+    case WSK_FLAG_LISTEN_SOCKET:
+        pListenDispatch = (PWSK_CLIENT_LISTEN_DISPATCH)Dispatch;
+        pProviderDispatch = &gListenDispatch;
+        ProviderDispatchSize = sizeof(gListenDispatch);
+        break;
+    case WSK_FLAG_CONNECTION_SOCKET:
+        pConnectionDispatch = (PWSK_CLIENT_CONNECTION_DISPATCH)Dispatch;
+        pProviderDispatch = &gConnectionDispatch;
+        ProviderDispatchSize = sizeof(gConnectionDispatch);
+        break;
+    case WSK_FLAG_DATAGRAM_SOCKET:
+        Status = STATUS_NOT_SUPPORTED;
+        break;
+#if (NTDDI_VERSION >= NTDDI_WIN10_RS2)
+    case WSK_FLAG_STREAM_SOCKET:
+        if (Dispatch)
+        {
+            pListenDispatch = (PWSK_CLIENT_LISTEN_DISPATCH)((PWSK_CLIENT_STREAM_DISPATCH)Dispatch)->Listen;
+            pConnectionDispatch = (PWSK_CLIENT_CONNECTION_DISPATCH)((PWSK_CLIENT_STREAM_DISPATCH)Dispatch)->Connect;
+        }
+
+        pProviderDispatch = &gStreamDispatch;
+        ProviderDispatchSize = sizeof(gStreamDispatch);
+        break;
+#endif // if (NTDDI_VERSION >= NTDDI_WIN10_RS2)
+    default:
+        Status = STATUS_INVALID_PARAMETER;
+        break;
+    }
+
+    if (!NT_SUCCESS(Status))
+        goto Exit;
+
+    pSocket = ExAllocatePoolUninitialized(NonPagedPoolNx, sizeof(VIOWSK_SOCKET), VIOSOCK_WSK_MEMORY_TAG);
+    if (!pSocket) {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Exit;
+    }
+
+    memset(pSocket, 0, sizeof(VIOWSK_SOCKET));
+    pSocket->Client = Client;
+    pSocket->SocketContext = SocketContext;
+    pSocket->Type = Flags;
+    if (pListenDispatch)
+        RtlCopyMemory(&pSocket->ListenDispatch, pListenDispatch, sizeof(*pListenDispatch));
+
+    if (pConnectionDispatch)
+        RtlCopyMemory(&pSocket->ConnectionDispatch, pConnectionDispatch, sizeof(*pConnectionDispatch));
+
+    if (pProviderDispatch)
+        RtlCopyMemory(&pSocket->ProviderDispatch, pProviderDispatch, ProviderDispatchSize);
+
+    pSocket->WskSocket.Dispatch = &pSocket->ProviderDispatch;
+    Status = _VioSocketCreate(Client, ListenSocket, SOCK_STREAM, &pSocket->FileHandle, &pSocket->FileObject);
+    if (!NT_SUCCESS(Status))
+        goto FreeSocket;
+
+    KeInitializeEvent(&ConfigEvent, NotificationEvent, FALSE);
+    ConfigIrp = IoBuildDeviceIoControlRequest(IOCTL_GET_CONFIG, pContext->VIOSockDevice, NULL, 0, &SocketConfig, sizeof(SocketConfig), FALSE, &ConfigEvent, &ConfigIosb);
+    if (!ConfigIrp)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto CloseSocket;
+    }
+
+    ObReferenceObject(pSocket->FileObject);
+    ConfigIrp->Tail.Overlay.OriginalFileObject = pSocket->FileObject;
+    IoGetNextIrpStackLocation(ConfigIrp)->FileObject = pSocket->FileObject;
+    Status = IoCallDriver(pContext->VIOSockDevice, ConfigIrp);
+    if (Status == STATUS_PENDING) {
+        KeWaitForSingleObject(&ConfigEvent, Executive, KernelMode, FALSE, NULL);
+        Status = ConfigIosb.Status;
+    }
+
+    if (NT_SUCCESS(Status) && ConfigIosb.Information < sizeof(SocketConfig))
+        Status = STATUS_INVALID_PARAMETER;
+
+    if (!NT_SUCCESS(Status))
+        goto CloseSocket;
+
+    pSocket->GuestId = SocketConfig.guest_cid;
+    IoInitializeRemoveLock(&pSocket->CloseRemoveLock, VIOSOCK_WSK_MEMORY_TAG, 0, 0x7FFFFFFF);
+    *pNewSocket = pSocket;
+    pSocket = NULL;
+
+CloseSocket:
+    if (pSocket)
+    {
+        ZwClose(pSocket->FileHandle);
+        ObDereferenceObject(pSocket->FileObject);
+    }
+FreeSocket:
+    if (pSocket)
+        ExFreePoolWithTag(pSocket, VIOSOCK_WSK_MEMORY_TAG);
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x, *pNewSocket=0x%p", Status, *pNewSocket);
+    return Status;
+}
+
+
+NTSTATUS
+VioWskCloseSocketInternal(
+    _Inout_ PVIOWSK_SOCKET Socket,
+    _In_opt_ PVOID         ReleaseTag
+)
+{
+    HANDLE fileHandle = NULL;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; ReleaseTag=0x%p", Socket, ReleaseTag);
+
+    PAGED_CODE();
+    fileHandle = InterlockedExchangePointer(&Socket->FileHandle, NULL);
+    if (fileHandle)
+    {
+        Status = ZwClose(fileHandle);
+        if (ReleaseTag)
+            IoReleaseRemoveLockAndWait(&Socket->CloseRemoveLock, ReleaseTag);
+
+        ObDereferenceObject(Socket->FileObject);
+        ExFreePoolWithTag(Socket, VIOSOCK_WSK_MEMORY_TAG);
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}

--- a/viosock/wsk/socket-internal.c
+++ b/viosock/wsk/socket-internal.c
@@ -32,11 +32,16 @@
 #include "..\inc\debug-utils.h"
 #include "wsk-utils.h"
 #include "viowsk-internal.h"
+#ifdef EVENT_TRACING
+#include "socket-internal.tmh"
+#endif
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (PAGE, VioWskSocketInternal)
 #pragma alloc_text (PAGE, VioWskCloseSocketInternal)
 #endif
+
+
 
 
 _Must_inspect_result_

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -626,11 +626,27 @@ VioWskInspectComplete(
     _Inout_ PIRP            Irp
 )
 {
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(ListenSocket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("ListenSocket=0x%p; InspectID=0x%p; Action=%u; Irp=0x%p", ListenSocket, InspectID, Action, Irp);
+
     UNREFERENCED_PARAMETER(ListenSocket);
     UNREFERENCED_PARAMETER(InspectID);
     UNREFERENCED_PARAMETER(Action);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+    Status = STATUS_NOT_IMPLEMENTED;
+CompleteIrp:
+    VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 NTSTATUS
@@ -894,12 +910,27 @@ VioWskConnectEx(
     _Inout_ PIRP      Irp
 )
 {
-    UNREFERENCED_PARAMETER(Socket);
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; RemoteAddress=0x%p; Buffer=0x%p; Flags=0x%x; Irp=0x%p", Socket, RemoteAddress, Buffer, Flags, Irp);
+
     UNREFERENCED_PARAMETER(RemoteAddress);
     UNREFERENCED_PARAMETER(Buffer);
     UNREFERENCED_PARAMETER(Flags);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+    Status = STATUS_NOT_IMPLEMENTED;
+CompleteIrp:
+    VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 NTSTATUS
@@ -913,13 +944,28 @@ VioWskSendEx(
     _Inout_ PIRP     Irp
 )
 {
-    UNREFERENCED_PARAMETER(Socket);
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Buffer=0x%p; Flags=0x%x; ControlInfoLength=%u; ControlInfo=0x%p; Irp=0x%p", Socket, Buffer, Flags, ControlInfoLength, ControlInfo, Irp);
+
     UNREFERENCED_PARAMETER(Buffer);
     UNREFERENCED_PARAMETER(Flags);
     UNREFERENCED_PARAMETER(ControlInfoLength);
     UNREFERENCED_PARAMETER(ControlInfo);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+    Status = STATUS_NOT_IMPLEMENTED;
+CompleteIrp:
+    VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 NTSTATUS
@@ -934,14 +980,29 @@ VioWskReceiveEx(
     _Inout_ PIRP       Irp
 )
 {
-    UNREFERENCED_PARAMETER(Socket);
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Buffer=0x%p; Flags=0x%x; ControlInfoLength=0x%p; ControlInfo=0x%p; ControlFlags=0x%p; Irp=0x%p", Socket, Buffer, Flags, ControlInfoLength, ControlInfo, ControlFlags, Irp);
+
     UNREFERENCED_PARAMETER(Buffer);
     UNREFERENCED_PARAMETER(Flags);
     UNREFERENCED_PARAMETER(ControlInfoLength);
     UNREFERENCED_PARAMETER(ControlInfo);
     UNREFERENCED_PARAMETER(ControlFlags);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+    Status = STATUS_NOT_IMPLEMENTED;
+CompleteIrp:
+    VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 NTSTATUS
@@ -951,7 +1012,21 @@ VioWskListen(
     _Inout_ PIRP     Irp
 )
 {
-    UNREFERENCED_PARAMETER(Socket);
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p", Socket, Irp);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+    Status = STATUS_NOT_IMPLEMENTED;
+CompleteIrp:
+    VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -35,6 +35,11 @@
 #include "wsk-completion.h"
 #include "wsk-workitem.h"
 #include "..\inc\vio_wsk.h"
+#ifdef EVENT_TRACING
+#include "socket.tmh"
+#endif
+
+
 
 NTSTATUS
 WSKAPI
@@ -293,7 +298,7 @@ VioWskControlSocket(
     PVIOSOCKET_COMPLETION_CONTEXT CompContext = NULL;
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
     PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
-    DEBUG_ENTER_FUNCTION("Socket=0x%p; RequestType=%u; ControlCode=0x%x; Level=%u; InputSize=%zu; InputBuffer=0x%p; OutputSize=%zu; OutputBuffer=0x%p; OutputSizeReturned=0x%p; Irp=0x%p", Socket, RequestType, ControlCode, Level, InputSize, InputBuffer, OutputSize, OutputBuffer, OutputSizeReturned, Irp);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; RequestType=%u; ControlCode=0x%x; Level=%u; InputSize=%Iu; InputBuffer=0x%p; OutputSize=%Iu; OutputBuffer=0x%p; OutputSizeReturned=0x%p; Irp=0x%p", Socket, RequestType, ControlCode, Level, InputSize, InputBuffer, OutputSize, OutputBuffer, OutputSizeReturned, Irp);
 
     UNREFERENCED_PARAMETER(OutputSizeReturned);
 

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -430,10 +430,25 @@ VioWskGetRemoteAddress(
     _Inout_ PIRP     Irp
 )
 {
-    UNREFERENCED_PARAMETER(Socket);
-    UNREFERENCED_PARAMETER(RemoteAddress);
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; RemoteAddress=0x%p; Irp=0x%p", Socket, RemoteAddress, Irp);
 
-    return VioWskCompleteIrp(Irp, STATUS_NOT_IMPLEMENTED, 0);
+    Status = VioWskIrpAcquire(pSocket, Irp);
+    if (!NT_SUCCESS(Status))
+    {
+        pSocket = NULL;
+        goto CompleteIrp;
+    }
+
+	Status = VioWskSocketIOCTL(pSocket, IOCTL_SOCKET_GET_PEER_NAME, NULL, 0, RemoteAddress, sizeof(SOCKADDR_VM), Irp, NULL);
+    Irp = NULL;
+CompleteIrp:
+    if (Irp)
+        VioWskIrpComplete(pSocket, Irp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 NTSTATUS

--- a/viosock/wsk/viowsk-internal.h
+++ b/viosock/wsk/viowsk-internal.h
@@ -1,3 +1,31 @@
+/*
+ * Exports definition for virtio socket WSK interface
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 
 #ifndef __VIOWSK_INTERNAL_H__
 #define __VIOWSK_INTERNAL_H__
@@ -6,6 +34,46 @@
 
 extern PDRIVER_OBJECT _viowskDriverObject;
 extern PDEVICE_OBJECT _viowskDeviceObject;
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketInternal(
+    _In_ PWSK_CLIENT              Client,
+    _In_opt_ PVIOWSK_SOCKET       ListenSocket,
+    _In_ ULONG                    Flags,
+    _In_opt_ PVOID                SocketContext,
+    _In_opt_ CONST VOID* Dispatch,
+    _In_opt_ PEPROCESS            OwningProcess,
+    _In_opt_ PETHREAD             OwningThread,
+    _In_opt_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Out_ PVIOWSK_SOCKET* pNewSocket
+);
+
+NTSTATUS
+VioWskCloseSocketInternal(
+    _Inout_ PVIOWSK_SOCKET Socket,
+    _In_opt_ PVOID         ReleleaseTag
+);
+
+NTSTATUS
+WSKAPI
+VioWskCloseSocket(
+    _In_ PWSK_SOCKET Socket,
+    _Inout_ PIRP     Irp
+);
+
+NTSTATUS
+WSKAPI
+VioWskAccept(
+    _In_ PWSK_SOCKET                               ListenSocket,
+    _Reserved_ ULONG                               Flags,
+    _In_opt_ PVOID                                 AcceptSocketContext,
+    _In_opt_ CONST WSK_CLIENT_CONNECTION_DISPATCH* AcceptSocketDispatch,
+    _Out_opt_ PSOCKADDR                            LocalAddress,
+    _Out_opt_ PSOCKADDR                            RemoteAddress,
+    _Inout_ PIRP                                   Irp
+);
 
 
 

--- a/viosock/wsk/viowsk-internal.h
+++ b/viosock/wsk/viowsk-internal.h
@@ -1,0 +1,12 @@
+
+#ifndef __VIOWSK_INTERNAL_H__
+#define __VIOWSK_INTERNAL_H__
+
+
+
+extern PDRIVER_OBJECT _viowskDriverObject;
+extern PDEVICE_OBJECT _viowskDeviceObject;
+
+
+
+#endif

--- a/viosock/wsk/viowsk.c
+++ b/viosock/wsk/viowsk.c
@@ -28,6 +28,8 @@
  */
 
 #include "precomp.h"
+#include "..\inc\debug-utils.h"
+#include "viowsk-internal.h"
 #include "viowsk.h"
 #include "..\inc\vio_wsk.h"
 
@@ -35,6 +37,164 @@
 #pragma alloc_text (PAGE, VioWskRegister)
 #pragma alloc_text (PAGE, VioWskDeregister)
 #endif
+
+
+typedef struct _VIOSOCK_WAIT_CONTEXT {
+    UNICODE_STRING SymbolicLinkName;
+    KEVENT Event;
+    NTSTATUS Result;
+} VIOSOCK_WAIT_CONTEXT, * PVIOSOCK_WAIT_CONTEXT;
+
+
+PDRIVER_OBJECT _viowskDriverObject = NULL;
+PDEVICE_OBJECT _viowskDeviceObject = NULL;
+
+static const WSK_PROVIDER_DISPATCH _providerDispatch = {
+    MAKE_WSK_VERSION(VIOWSK_PROVIDER_VERSION, 0),
+    0,
+    VioWskSocket,
+    VioWskSocketConnect,
+    VioWskControlClient,
+    VioWskGetAddressInfo,
+    VioWskFreeAddressInfo,
+    VioWskGetNameInfo,
+};
+
+
+
+static
+NTSTATUS
+_NotifyCallback(
+    _In_ PVOID    NotificationStructure,
+    _Inout_ PVOID Context
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOSOCK_WAIT_CONTEXT Ctx = (PVIOSOCK_WAIT_CONTEXT)Context;
+    PDEVICE_INTERFACE_CHANGE_NOTIFICATION NotifyInfo = (PDEVICE_INTERFACE_CHANGE_NOTIFICATION)NotificationStructure;
+    DEBUG_ENTER_FUNCTION("NotificationStructure=0x%p; Context=0x%p", NotificationStructure, Context);
+
+    Status = STATUS_SUCCESS;
+    if (IsEqualGUID(&NotifyInfo->Event, &GUID_DEVICE_INTERFACE_ARRIVAL) &&
+        NotifyInfo->SymbolicLinkName != NULL)
+    {
+        Ctx->SymbolicLinkName = *NotifyInfo->SymbolicLinkName;
+        Ctx->SymbolicLinkName.MaximumLength = Ctx->SymbolicLinkName.Length;
+        Ctx->SymbolicLinkName.Buffer = ExAllocatePoolUninitialized(PagedPool, Ctx->SymbolicLinkName.MaximumLength, VIOSOCK_WSK_MEMORY_TAG);
+        if (Ctx->SymbolicLinkName.Buffer == NULL)
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+
+        if (NT_SUCCESS(Status))
+        {
+            RtlCopyMemory(Ctx->SymbolicLinkName.Buffer, NotifyInfo->SymbolicLinkName->Buffer, Ctx->SymbolicLinkName.Length);
+        }
+
+        Ctx->Result = Status;
+        KeSetEvent(&Ctx->Event, IO_NO_INCREMENT, FALSE);
+        Status = STATUS_SUCCESS;
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}
+
+_Must_inspect_result_
+static
+NTSTATUS
+_VioSockDriverConnect(
+    _Inout_ PVIOWSK_REG_CONTEXT WskContext,
+    _In_ DWORD                  Timeout,
+    _In_ PDRIVER_OBJECT         DriverObject)
+{
+    PVOID NotifyHandle = NULL;
+    LARGE_INTEGER Timeout100ns;
+    PLARGE_INTEGER pTimeout = NULL;
+    VIOSOCK_WAIT_CONTEXT WaitContext;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("WskContext=0x%p; Timeout=%u; DriverObject=0x%p", WskContext, Timeout, DriverObject);
+
+    switch (Timeout) {
+    case WSK_NO_WAIT:
+        Timeout100ns.QuadPart = 0;
+        pTimeout = &Timeout100ns;
+        break;
+    case WSK_INFINITE_WAIT:
+        break;
+    default:
+        Timeout100ns.QuadPart = Timeout;
+        Timeout100ns.QuadPart *= -10000;
+        pTimeout = &Timeout100ns;
+        break;
+    }
+
+    KeInitializeEvent(&WaitContext.Event, NotificationEvent, FALSE);
+    WaitContext.Result = STATUS_UNSUCCESSFUL;
+    Status = IoRegisterPlugPlayNotification(
+        EventCategoryDeviceInterfaceChange,
+        PNPNOTIFY_DEVICE_INTERFACE_INCLUDE_EXISTING_INTERFACES,
+        (PVOID)&GUID_DEVINTERFACE_VIOSOCK,
+        DriverObject,
+        _NotifyCallback,
+        &WaitContext,
+        &NotifyHandle);
+
+    if (!NT_SUCCESS(Status))
+    {
+        DEBUG_ERROR("IoRegisterPlugPlayNotification: 0x%x", Status);
+        goto Exit;
+    }
+
+    Status = KeWaitForSingleObject(&WaitContext.Event, Executive, KernelMode, FALSE, pTimeout);
+#if (NTDDI_VERSION >= NTDDI_WIN7)
+    IoUnregisterPlugPlayNotificationEx(NotifyHandle);
+#else // if (NTDDI_VERSION >= NTDDI_WIN7)
+    IoUnregisterPlugPlayNotification(NotifyHandle);
+#endif // if (NTDDI_VERSION < NTDDI_WIN7)
+    switch (Status) {
+    case STATUS_WAIT_0:
+        Status = WaitContext.Result;
+        if (!NT_SUCCESS(Status))
+        {
+            DEBUG_ERROR("The interface arrival notificaiton routine failed: 0x%x", Status);
+            break;
+        }
+
+        Status = IoGetDeviceObjectPointer(&WaitContext.SymbolicLinkName, FILE_READ_ATTRIBUTES, &WskContext->VIOSockMainFileObject, &WskContext->VIOSockDevice);
+        if (!NT_SUCCESS(Status))
+        {
+            DEBUG_ERROR("IoGetDeviceObjectPointer: 0x%x", Status);
+            ExFreePoolWithTag(WaitContext.SymbolicLinkName.Buffer, VIOSOCK_WSK_MEMORY_TAG);
+            break;
+        }
+
+        WskContext->VIOSockLinkName = WaitContext.SymbolicLinkName;
+        break;
+    case STATUS_TIMEOUT:
+        Status = STATUS_DEVICE_NOT_READY;
+        break;
+    }
+
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}
+
+static
+VOID
+_VIOSockDriverDisconnect(
+    _Inout_ PVIOWSK_REG_CONTEXT RegContext)
+{
+    DEBUG_ENTER_FUNCTION("RegContext=0x%p", RegContext);
+
+    ObDereferenceObject(RegContext->VIOSockMainFileObject);
+    RegContext->VIOSockMainFileObject = NULL;
+    ExFreePoolWithTag(RegContext->VIOSockLinkName.Buffer, VIOSOCK_WSK_MEMORY_TAG);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
 
 _Must_inspect_result_
 NTSTATUS
@@ -44,19 +204,24 @@ VioWskRegister(
 )
 {
     PVIOWSK_REG_CONTEXT pContext;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("WskClientNpi=0x%p; WskRegistration=0x%p", WskClientNpi, WskRegistration);
 
     PAGED_CODE();
-
-    if (!WskClientNpi || !WskRegistration)
-        return STATUS_INVALID_PARAMETER;
 
     pContext = ExAllocatePoolUninitialized(NonPagedPoolNx,
         sizeof(VIOWSK_REG_CONTEXT), VIOSOCK_WSK_MEMORY_TAG);
 
     if (!pContext)
-        return STATUS_INSUFFICIENT_RESOURCES;
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Exit;
+    }
 
     RtlZeroMemory(pContext, sizeof(VIOWSK_REG_CONTEXT));
+    Status = ExInitializeResourceLite(&pContext->NPILock);
+    if (!NT_SUCCESS(Status))
+        goto FreeContext;
 
     pContext->ClientContext = WskClientNpi->ClientContext;
     if (WskClientNpi->Dispatch)
@@ -64,7 +229,12 @@ VioWskRegister(
 
     WskRegistration->ReservedRegistrationContext = pContext;
 
-    return STATUS_SUCCESS;
+FreeContext:
+    if (!NT_SUCCESS(Status))
+        ExFreePoolWithTag(pContext, VIOSOCK_WSK_MEMORY_TAG);
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 VOID
@@ -72,14 +242,19 @@ VioWskDeregister(
     _In_ PWSK_REGISTRATION WskRegistration
 )
 {
-    if (!WskRegistration)
-        return;
+    PVIOWSK_REG_CONTEXT pContext = NULL;
+    DEBUG_ENTER_FUNCTION("WskRegistration=0x%p", WskRegistration);
 
-    if (WskRegistration->ReservedRegistrationContext)
+    pContext = WskRegistration->ReservedRegistrationContext;
+    if (pContext != NULL)
     {
-        ExFreePool(WskRegistration->ReservedRegistrationContext);
+        ExDeleteResourceLite(&pContext->NPILock);
+        ExFreePoolWithTag(pContext, VIOSOCK_WSK_MEMORY_TAG);
         WskRegistration->ReservedRegistrationContext = NULL;
     }
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
 }
 
 _Must_inspect_result_
@@ -90,29 +265,37 @@ VioWskCaptureProviderNPI(
     _Out_ PWSK_PROVIDER_NPI WskProviderNpi
 )
 {
-    WSK_PROVIDER_DISPATCH *Dispatch;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_REG_CONTEXT regContext = (PVIOWSK_REG_CONTEXT)WskRegistration->ReservedRegistrationContext;
+    DEBUG_ENTER_FUNCTION("WskRegistration=0x%p; WaitTimeout=%u; WskProviderNpi=0x%p", WskRegistration, WaitTimeout, WskProviderNpi);
 
-    UNREFERENCED_PARAMETER(WaitTimeout);
+    if (KeGetCurrentIrql() >= APC_LEVEL)
+    {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
 
-    if (!WskProviderNpi || !WskProviderNpi->Dispatch || !WskRegistration)
-        return STATUS_INVALID_PARAMETER;
+    Status = STATUS_SUCCESS;
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(&regContext->NPILock, TRUE);
+    if (InterlockedIncrement(&regContext->NPICount) == 1)
+    {
+        Status = _VioSockDriverConnect(regContext, WaitTimeout, _viowskDriverObject);
+        if (!NT_SUCCESS(Status))
+            InterlockedDecrement(&regContext->NPICount);
+	}
 
-    Dispatch = (WSK_PROVIDER_DISPATCH *)WskProviderNpi->Dispatch;
+    ExReleaseResourceLite(&regContext->NPILock);
+    KeLeaveCriticalRegion();
+    if (NT_SUCCESS(Status))
+    {
+        WskProviderNpi->Client = (PWSK_CLIENT)WskRegistration;
+        WskProviderNpi->Dispatch =  &_providerDispatch;
+    }
 
-    //TODO: open viosock and handle WaitTimeout
-    WskProviderNpi->Client = (PWSK_CLIENT)WskRegistration;
-
-    Dispatch->Version = MAKE_WSK_VERSION(VIOWSK_PROVIDER_VERSION, 0);
-    Dispatch->Reserved = 0;
-
-    Dispatch->WskSocket = VioWskSocket;
-    Dispatch->WskSocketConnect = VioWskSocketConnect;
-    Dispatch->WskControlClient = VioWskControlClient;
-    Dispatch->WskGetAddressInfo = VioWskGetAddressInfo;
-    Dispatch->WskFreeAddressInfo = VioWskFreeAddressInfo;
-    Dispatch->WskGetNameInfo = VioWskGetNameInfo;
-
-    return STATUS_SUCCESS;
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
 }
 
 VOID
@@ -120,8 +303,19 @@ VioWskReleaseProviderNPI(
     _In_ PWSK_REGISTRATION WskRegistration
 )
 {
-    UNREFERENCED_PARAMETER(WskRegistration);
-    //TODO: close viosock
+    PVIOWSK_REG_CONTEXT regContext = (PVIOWSK_REG_CONTEXT)WskRegistration->ReservedRegistrationContext;
+    DEBUG_ENTER_FUNCTION("WskRegistration=0x%p", WskRegistration);
+
+    KeEnterCriticalRegion();
+    ExAcquireResourceExclusiveLite(&regContext->NPILock, TRUE);
+    if (InterlockedDecrement(&regContext->NPICount) == 0)
+        _VIOSockDriverDisconnect(regContext);
+
+    ExReleaseResourceLite(&regContext->NPILock);
+    KeLeaveCriticalRegion();
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
 }
 
 _Must_inspect_result_
@@ -140,3 +334,46 @@ VioWskQueryProviderCharacteristics(
     return STATUS_SUCCESS;
 }
 
+_Must_inspect_result_
+NTSTATUS
+VioWskModuleInit(
+    _In_ PDRIVER_OBJECT     DriverObject,
+    _In_ PUNICODE_STRING    RegistryPath,
+    _In_opt_ PDEVICE_OBJECT DeviceObject
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("DriverObject=0x%p; RegistryPath=\"%wZ\"", DriverObject, RegistryPath);
+
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    Status = STATUS_SUCCESS;
+    ObReferenceObject(DriverObject);
+    _viowskDriverObject = DriverObject;
+    if (DeviceObject) {
+        ObReferenceObject(DeviceObject);
+        _viowskDeviceObject = DeviceObject;
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}
+
+VOID
+VioWskModuleFinit(
+    VOID
+)
+{
+    DEBUG_ENTER_FUNCTION_NO_ARGS();
+
+    if (_viowskDeviceObject) {
+        ObDereferenceObject(_viowskDeviceObject);
+        _viowskDeviceObject = NULL;
+    }
+
+    ObDereferenceObject(_viowskDriverObject);
+    _viowskDriverObject = NULL;
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}

--- a/viosock/wsk/viowsk.c
+++ b/viosock/wsk/viowsk.c
@@ -29,9 +29,9 @@
 
 #include "precomp.h"
 #include "..\inc\debug-utils.h"
-#include "viowsk-internal.h"
 #include "viowsk.h"
 #include "..\inc\vio_wsk.h"
+#include "viowsk-internal.h"
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (PAGE, VioWskRegister)

--- a/viosock/wsk/viowsk.c
+++ b/viosock/wsk/viowsk.c
@@ -32,11 +32,15 @@
 #include "viowsk.h"
 #include "..\inc\vio_wsk.h"
 #include "viowsk-internal.h"
+#ifdef EVENT_TRACING
+#include "viowsk.tmh"
+#endif
 
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text (PAGE, VioWskRegister)
 #pragma alloc_text (PAGE, VioWskDeregister)
 #endif
+
 
 
 typedef struct _VIOSOCK_WAIT_CONTEXT {

--- a/viosock/wsk/viowsk.h
+++ b/viosock/wsk/viowsk.h
@@ -152,10 +152,14 @@ VioWskCompleteIrp(
 typedef struct _VIOWSK_SOCKET
 {
     WSK_SOCKET WskSocket;
+    PWSK_CLIENT Client;
     volatile LONG RequestCount;
     IO_REMOVE_LOCK CloseRemoveLock;
     PVOID SocketContext;
     ULONG Type;
+    ULONG GuestId;
+    HANDLE FileHandle;
+    PFILE_OBJECT FileObject;
     WSK_CLIENT_LISTEN_DISPATCH ListenDispatch;
     WSK_CLIENT_CONNECTION_DISPATCH ConnectionDispatch;
     union

--- a/viosock/wsk/viowsk.h
+++ b/viosock/wsk/viowsk.h
@@ -152,6 +152,8 @@ VioWskCompleteIrp(
 typedef struct _VIOWSK_SOCKET
 {
     WSK_SOCKET WskSocket;
+    volatile LONG RequestCount;
+    IO_REMOVE_LOCK CloseRemoveLock;
     PVOID SocketContext;
     ULONG Type;
     WSK_CLIENT_LISTEN_DISPATCH ListenDispatch;

--- a/viosock/wsk/viowsk.h
+++ b/viosock/wsk/viowsk.h
@@ -40,6 +40,11 @@ typedef struct _VIOWSK_REG_CONTEXT
 {
     PVOID ClientContext;
     WSK_CLIENT_DISPATCH ClientDispatch;
+    volatile LONG NPICount;
+    ERESOURCE NPILock;
+    UNICODE_STRING VIOSockLinkName;
+    PDEVICE_OBJECT VIOSockDevice;
+    PFILE_OBJECT VIOSockMainFileObject;
 }VIOWSK_REG_CONTEXT,*PVIOWSK_REG_CONTEXT;
 
 #define VIOWSK_PROVIDER_VERSION 1

--- a/viosock/wsk/wpp-trace.h
+++ b/viosock/wsk/wpp-trace.h
@@ -1,0 +1,113 @@
+/*
+ * This file contains trace and debugging related definitions
+ *
+ * Copyright (c) 2019 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #pragma once
+
+#define EVENT_TRACING
+
+#if !defined(EVENT_TRACING)
+
+#if !defined(TRACE_LEVEL_NONE)
+#define TRACE_LEVEL_NONE        0
+#define TRACE_LEVEL_CRITICAL    1
+#define TRACE_LEVEL_FATAL       1
+#define TRACE_LEVEL_ERROR       2
+#define TRACE_LEVEL_WARNING     3
+#define TRACE_LEVEL_INFORMATION 4
+#define TRACE_LEVEL_VERBOSE     5
+#define TRACE_LEVEL_RESERVED6   6
+#define TRACE_LEVEL_RESERVED7   7
+#define TRACE_LEVEL_RESERVED8   8
+#define TRACE_LEVEL_RESERVED9   9
+#endif
+
+
+//
+// Define Debug Flags
+//
+#define DBG_VIOWSK                0x00000001
+
+#define WPP_INIT_TRACING(a,b)
+#define WPP_CLEANUP(DriverObject)
+
+#else
+
+#define WPP_CHECK_FOR_NULL_STRING
+
+//
+// Define the tracing flags.
+//
+// Tracing GUID - C2D7F82F-CE5F-4408-8A37-8B9FE2B3D52E
+//
+
+// {13b9cfb4-b962-4b43-b59d-92242fab52e3}
+#define WPP_CONTROL_GUIDS \
+    WPP_DEFINE_CONTROL_GUID(WskTraceGuid,(13b9cfb4,b962,4b43,b59d,92242fab52e3), \
+        WPP_DEFINE_BIT(DBG_VIOWSK)             /* bit  0 = 0x00000001 */ \
+        )
+
+#define WPP_FLAG_LEVEL_LOGGER(flag, level) \
+    WPP_LEVEL_LOGGER(flag)
+
+#define WPP_FLAG_LEVEL_ENABLED(flag, level) \
+    (WPP_LEVEL_ENABLED(flag) && WPP_CONTROL(WPP_BIT_ ## flag).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) \
+    WPP_LEVEL_LOGGER(flags)
+
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) \
+    (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+ //
+ // This comment block is scanned by the trace preprocessor to define our
+ // Trace function.
+ //
+ // begin_wpp config
+ //
+ // USEPREFIX(DEBUG_ENTER_FUNCTION, "%!STDPREFIX! %!FUNC!(");
+ // USESUFFIX(DEBUG_ENTER_FUNCTION, ")");
+ // USEPREFIX(DEBUG_ENTER_FUNCTION_NO_ARGS, "%!STDPREFIX! %!FUNC!()");
+ // USEPREFIX(DEBUG_EXIT_FUNCTION, "%!STDPREFIX! %!FUNC!(-)");
+ // USEPREFIX(DEBUG_EXIT_FUNCTION_VOID, "%!STDPREFIX! %!FUNC!");
+ // USESUFFIX(DEBUG_EXIT_FUNCTION_VOID, "(-)");
+ // 
+ // FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
+ // FUNC DEBUG_ENTER_FUNCTION{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_VIOWSK}(MSG, ...);
+ // FUNC DEBUG_ENTER_FUNCTION_NO_ARGS{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_VIOWSK}();
+ // FUNC DEBUG_EXIT_FUNCTION{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_VIOWSK}(MSG, ...);
+ // FUNC DEBUG_EXIT_FUNCTION_VOID{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_VIOWSK}();
+ // FUNC DEBUG_ERROR{LEVEL=TRACE_LEVEL_ERROR, FLAGS=DBG_VIOWSK}(MSG, ...);
+ // FUNC DEBUG_WARNING{LEVEL=TRACE_LEVEL_WARNING, FLAGS=DBG_VIOWSK}(MSG, ...);
+ // FUNC DEBUG_TRACE{LEVEL=TRACE_LEVEL_VERBOSE, FLAGS=DBG_VIOWSK}(MSG, ...);
+ // FUNC DEBUG_INFO{LEVEL=TRACE_LEVEL_INFORMATION, FLAGS=DBG_VIOWSK}(MSG, ...);
+ //
+ // end_wpp
+ //
+
+#endif

--- a/viosock/wsk/wsk-completion.c
+++ b/viosock/wsk/wsk-completion.c
@@ -32,7 +32,9 @@
 #include "wsk-utils.h"
 #include "viowsk-internal.h"
 #include "wsk-completion.h"
-
+#ifdef EVENT_TRACING
+#include "wsk-completion.tmh"
+#endif
 
 
 
@@ -230,7 +232,7 @@ WskGeneralIrpCompletion(
 
     WskCompContextDereference(Ctx);
     
-    DEBUG_EXIT_FUNCTION("0x%x", STATUS_MORE_PROCESSING_REQUIRED);
+    DEBUG_EXIT_FUNCTION("0x%ix", STATUS_MORE_PROCESSING_REQUIRED);
     return STATUS_MORE_PROCESSING_REQUIRED;
 }
 

--- a/viosock/wsk/wsk-completion.c
+++ b/viosock/wsk/wsk-completion.c
@@ -1,0 +1,232 @@
+/*
+ * Provider NPI functions
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "precomp.h"
+#include "..\inc\debug-utils.h"
+#include "wsk-utils.h"
+#include "viowsk-internal.h"
+#include "wsk-completion.h"
+
+
+
+
+static
+void
+WskCancelIrp(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP           Irp
+)
+{
+    PIRP CurrentIrp = NULL;
+    DEBUG_ENTER_FUNCTION("DeviceObject=0x%p; Irp=0x%p", DeviceObject, Irp);
+
+    UNREFERENCED_PARAMETER(DeviceObject);
+
+    IoReleaseCancelSpinLock(Irp->CancelIrql);
+    CurrentIrp = InterlockedExchangePointer(Irp->Tail.Overlay.DriverContext + 1, NULL);
+    if (CurrentIrp)
+        IoCancelIrp(CurrentIrp);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
+static
+NTSTATUS
+WskGeneralIrpCompletion(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP           Irp,
+    _In_ PVOID          Context
+)
+{
+    EWSKState opState;
+    PVIOSOCKET_COMPLETION_CONTEXT Ctx = (PVIOSOCKET_COMPLETION_CONTEXT)Context;
+    DEBUG_ENTER_FUNCTION("DeviceObject=0x%p; Irp=0x%p; Context=0x%p", DeviceObject, Irp, Context);
+
+    if (Ctx->MasterIrp)
+    {
+        InterlockedExchangePointer(Ctx->MasterIrp->Tail.Overlay.DriverContext + 1, NULL);
+        if (Ctx->MasterIrp->Cancel)
+            Irp->IoStatus.Status = STATUS_CANCELLED;
+    }
+
+    UNREFERENCED_PARAMETER(DeviceObject);
+    opState = Ctx->State;
+    if (NT_SUCCESS(Irp->IoStatus.Status)) {
+        switch (opState)
+        {
+        case wsksSingleIOCTL:
+            memcpy(Irp->UserBuffer, Irp->AssociatedIrp.SystemBuffer, Irp->IoStatus.Information);
+            opState = wsksFinished;
+            break;
+        default:
+            opState = wsksFinished;
+            break;
+        }
+    }
+
+    IO_STATUS_BLOCK irpStatus;
+
+    irpStatus = Irp->IoStatus;
+    VioWskIrpFree(Irp, Ctx->DeviceObject, TRUE);
+    if (!NT_SUCCESS(irpStatus.Status) ||
+        opState == wsksFinished) {
+        if (Ctx->IoStatusBlock)
+            *Ctx->IoStatusBlock = irpStatus;
+
+        if (Ctx->MasterIrp)
+        {
+            if (!Ctx->UseIOSBInformation)
+                Ctx->IOSBInformation = irpStatus.Information;
+
+            VioWskIrpComplete(Ctx->Socket, Ctx->MasterIrp, irpStatus.Status, Ctx->IOSBInformation);
+        }
+    }
+
+    WskCompContextDereference(Ctx);
+    
+    DEBUG_EXIT_FUNCTION("0x%x", STATUS_MORE_PROCESSING_REQUIRED);
+    return STATUS_MORE_PROCESSING_REQUIRED;
+}
+
+
+static
+void
+WskCompContextFree(
+    PVIOSOCKET_COMPLETION_CONTEXT CompContext
+)
+{
+    DEBUG_ENTER_FUNCTION("CompContext=0x%p", CompContext);
+
+    ExFreePoolWithTag(CompContext, VIOSOCK_WSK_MEMORY_TAG);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
+PVIOSOCKET_COMPLETION_CONTEXT
+WskCompContextAlloc(
+	_In_ EWSKState            State,
+	_In_ PVIOWSK_SOCKET       Socket,
+	_In_opt_ PIRP             MasterIrp,
+    _In_opt_ PIO_STATUS_BLOCK IoStatusBlock
+)
+{
+    PVIOWSK_REG_CONTEXT pContext = NULL;
+    PWSK_REGISTRATION Registration = NULL;
+    PVIOSOCKET_COMPLETION_CONTEXT Ret = NULL;
+    DEBUG_ENTER_FUNCTION("State=%u; Socket=0x%p; MasterIrp=0x%p; IoStatusBlock=0x%p", State, Socket, MasterIrp, IoStatusBlock);
+
+    Ret = ExAllocatePoolUninitialized(NonPagedPool, sizeof(*Ret), VIOSOCK_WSK_MEMORY_TAG);
+    if (!Ret)
+        goto Exit;
+
+    memset(Ret, 0, sizeof(*Ret));
+    InterlockedExchange(&Ret->ReferenceCount, 1);
+    Ret->State = State;
+    Ret->Socket = Socket;
+    Ret->MasterIrp = MasterIrp;
+    Ret->IoStatusBlock = IoStatusBlock;
+    Registration = (PWSK_REGISTRATION)Socket->Client;
+    pContext = (PVIOWSK_REG_CONTEXT)Registration->ReservedRegistrationContext;
+    Ret->DeviceObject = pContext->VIOSockDevice;
+
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%p", Ret);
+    return Ret;
+}
+
+void
+WskCompContextReference(
+    _Inout_ PVIOSOCKET_COMPLETION_CONTEXT CompContext
+)
+{
+    DEBUG_ENTER_FUNCTION("CompContext=0x%p", CompContext);
+
+    InterlockedIncrement(&CompContext->ReferenceCount);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+void
+WskCompContextDereference(
+    _Inout_ PVIOSOCKET_COMPLETION_CONTEXT CompContext
+)
+{
+    DEBUG_ENTER_FUNCTION("CompContext=0x%p", CompContext);
+
+    if (InterlockedDecrement(&CompContext->ReferenceCount) == 0)
+        WskCompContextFree(CompContext);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
+NTSTATUS
+WskCompContextSendIrp(
+    _Inout_ PVIOSOCKET_COMPLETION_CONTEXT CompContext,
+    _In_ PIRP                             Irp
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PVIOWSK_REG_CONTEXT pContext = NULL;
+    PWSK_REGISTRATION Registration = NULL;
+    DEBUG_ENTER_FUNCTION("CompContext=0x%p; Irp=0x%p", CompContext, Irp);
+
+    Status = STATUS_SUCCESS;
+    Registration = (PWSK_REGISTRATION)CompContext->Socket->Client;
+    pContext = (PVIOWSK_REG_CONTEXT)Registration->ReservedRegistrationContext;
+    if (_viowskDeviceObject)
+    {
+        Status = IoSetCompletionRoutineEx(_viowskDeviceObject, Irp, WskGeneralIrpCompletion, CompContext, TRUE, TRUE, TRUE);
+        if (!NT_SUCCESS(Status))
+            goto CompleteMasterIrp;
+    } else IoSetCompletionRoutine(Irp, WskGeneralIrpCompletion, CompContext, TRUE, TRUE, TRUE);
+   
+    WskCompContextReference(CompContext);
+    if (CompContext->MasterIrp)
+    {
+        InterlockedExchangePointer(CompContext->MasterIrp->Tail.Overlay.DriverContext + 1, Irp);
+        IoSetCancelRoutine(CompContext->MasterIrp, WskCancelIrp);
+    }
+        
+    IoCallDriver(pContext->VIOSockDevice, Irp);
+    Status = STATUS_PENDING;
+    Irp = NULL;
+CompleteMasterIrp:
+    if (Irp && CompContext->MasterIrp)
+        VioWskIrpComplete(CompContext->Socket, CompContext->MasterIrp, Status, 0);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}

--- a/viosock/wsk/wsk-completion.c
+++ b/viosock/wsk/wsk-completion.c
@@ -88,6 +88,26 @@ WskGeneralIrpCompletion(
             memcpy(Irp->UserBuffer, Irp->AssociatedIrp.SystemBuffer, Irp->IoStatus.Information);
             opState = wsksFinished;
             break;
+        case wsksBind:
+            if (Ctx->Socket->Type == WSK_FLAG_LISTEN_SOCKET)
+            {
+                ULONG SendLog = 128;
+
+                Irp->IoStatus.Status = VioWskSocketBuildIOCTL(Ctx->Socket, IOCTL_SOCKET_LISTEN, &SendLog, sizeof(SendLog), NULL, 0, &NextIrp);
+                if (!NT_SUCCESS(Irp->IoStatus.Status))
+                    break;
+
+                Ctx->State = wsksListen;
+                NextIrpStatus = WskCompContextSendIrp(Ctx, NextIrp);
+                if (!NT_SUCCESS(NextIrpStatus))
+                {
+                    Irp->IoStatus.Status = NextIrpStatus;
+                    Ctx->MasterIrp = NULL;
+                    VioWskIrpFree(NextIrp, NULL, FALSE);
+                }
+            }
+ 			else opState = wsksFinished;
+			break;
         case wsksAcceptLocal:
             memcpy(Ctx->Specific.Accept.LocalAddress, Irp->AssociatedIrp.SystemBuffer, sizeof(SOCKADDR_VM));
             if (Ctx->Specific.Accept.RemoteAddress)
@@ -122,6 +142,7 @@ WskGeneralIrpCompletion(
             Ctx->IOSBInformation = (ULONG_PTR)Ctx->Specific.Accept.Socket;
             Ctx->UseIOSBInformation = 1;
             break;
+        case wsksListen:
         case wsksDisconnected:
             opState = wsksFinished;
             break;

--- a/viosock/wsk/wsk-completion.c
+++ b/viosock/wsk/wsk-completion.c
@@ -88,6 +88,9 @@ WskGeneralIrpCompletion(
             memcpy(Irp->UserBuffer, Irp->AssociatedIrp.SystemBuffer, Irp->IoStatus.Information);
             opState = wsksFinished;
             break;
+        case wsksReceive:
+            opState = wsksFinished;
+            break;
         case wsksSend:
             if (Ctx->Specific.Transfer.NextMdl &&
                 (Irp->IoStatus.Information == Ctx->Specific.Transfer.CurrentMdlSize))

--- a/viosock/wsk/wsk-completion.c
+++ b/viosock/wsk/wsk-completion.c
@@ -101,6 +101,12 @@ WskGeneralIrpCompletion(
         if (Ctx->IoStatusBlock)
             *Ctx->IoStatusBlock = irpStatus;
 
+        if (Ctx->BytesReturned)
+            *Ctx->BytesReturned = irpStatus.Information;
+
+        if (Ctx->Event)
+            KeSetEvent(Ctx->Event, IO_NO_INCREMENT, FALSE);
+
         if (Ctx->MasterIrp)
         {
             if (!Ctx->UseIOSBInformation)

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -49,6 +49,8 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
     EWSKState State;
     PIRP MasterIrp;
     PIO_STATUS_BLOCK IoStatusBlock;
+    PSIZE_T BytesReturned;
+    PKEVENT Event;
     ULONG_PTR IOSBInformation;
     int UseIOSBInformation : 1;
 } VIOSOCKET_COMPLETION_CONTEXT, * PVIOSOCKET_COMPLETION_CONTEXT;

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -39,6 +39,8 @@
 typedef enum _EWSKState {
     wsksUndefined,
     wsksSingleIOCTL,
+    wsksSend,
+    wsksReceive,
     wsksFinished,
 } EWSKState, * PEWSKState;
 
@@ -53,6 +55,13 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
     PKEVENT Event;
     ULONG_PTR IOSBInformation;
     int UseIOSBInformation : 1;
+    union {
+        struct {
+            PMDL NextMdl;
+            ULONG CurrentMdlSize;
+            ULONG LastMdlSize;
+        } Transfer;
+    } Specific;
 } VIOSOCKET_COMPLETION_CONTEXT, * PVIOSOCKET_COMPLETION_CONTEXT;
 
 

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -45,6 +45,8 @@ typedef enum _EWSKState {
     wsksDisconnected,
     wsksAcceptLocal,
     wsksAcceptRemote,
+    wsksBind,
+    wsksListen,
     wsksFinished,
 } EWSKState, * PEWSKState;
 

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -33,7 +33,7 @@
 
 
 #include "..\inc\vio_wsk.h"
-
+#include "wsk-workitem.h"
 
 
 typedef enum _EWSKState {
@@ -43,6 +43,8 @@ typedef enum _EWSKState {
     wsksReceive,
     wsksDisconnect,
     wsksDisconnected,
+    wsksAcceptLocal,
+    wsksAcceptRemote,
     wsksFinished,
 } EWSKState, * PEWSKState;
 
@@ -58,6 +60,12 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
     ULONG_PTR IOSBInformation;
     int UseIOSBInformation : 1;
     union {
+        struct {
+            PWSK_SOCKET Socket;
+            PSOCKADDR LocalAddress;
+            PSOCKADDR RemoteAddress;
+            PWSK_WORKITEM CloseWorkItem;
+        } Accept;
         struct {
             PMDL NextMdl;
             ULONG CurrentMdlSize;

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -41,6 +41,8 @@ typedef enum _EWSKState {
     wsksSingleIOCTL,
     wsksSend,
     wsksReceive,
+    wsksDisconnect,
+    wsksDisconnected,
     wsksFinished,
 } EWSKState, * PEWSKState;
 

--- a/viosock/wsk/wsk-utils.c
+++ b/viosock/wsk/wsk-utils.c
@@ -34,6 +34,9 @@
 #include "viowsk-internal.h"
 #include "wsk-completion.h"
 #include "wsk-utils.h"
+#ifdef EVENT_TRACING
+#include "wsk-utils.tmh"
+#endif
 
 #ifdef ALLOC_PRAGMA
 #endif
@@ -89,6 +92,7 @@ VioWskIrpRelease(
 }
 
 
+
 NTSTATUS
 VioWskIrpComplete(
 	_Inout_opt_ PVIOWSK_SOCKET Socket,
@@ -97,7 +101,7 @@ VioWskIrpComplete(
 	_In_ ULONG_PTR             Information
 )
 {
-    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p; Status=0x%x; Information=%zu", Socket, Irp, Status, Information);
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p; Status=0x%x; Information=%Iu", Socket, Irp, Status, (ULONG64)Information);
 
     IoSetCancelRoutine(Irp, NULL);
     if (Socket)

--- a/viosock/wsk/wsk-utils.c
+++ b/viosock/wsk/wsk-utils.c
@@ -1,0 +1,167 @@
+/*
+ * Provider NPI functions
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "precomp.h"
+#include "viowsk.h"
+#include "..\inc\debug-utils.h"
+#include "..\inc\vio_wsk.h"
+#include "viowsk-internal.h"
+#include "wsk-utils.h"
+
+#ifdef ALLOC_PRAGMA
+#endif
+
+
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskIrpAcquire(
+    _In_opt_ PVIOWSK_SOCKET Socket,
+	_Inout_ PIRP            Irp
+)
+{
+    LONG reqCount = 0;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p", Socket, Irp);
+
+    Status = STATUS_SUCCESS;
+
+    if (Socket)
+    {
+        Status = IoAcquireRemoveLock(&Socket->CloseRemoveLock, Irp);
+        if (NT_SUCCESS(Status))
+            reqCount = InterlockedIncrement(&Socket->RequestCount);
+
+        if (!NT_SUCCESS(Status))
+            Status = STATUS_FILE_FORCED_CLOSED;
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%x, reqCount=%i", Status, reqCount);
+    return Status;
+}
+
+
+void
+VioWskIrpRelease(
+    _In_opt_ PVIOWSK_SOCKET Socket,
+	_In_ PIRP               Irp
+)
+{
+    LONG reqCount = 0;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p", Socket, Irp);
+
+    if (Socket)
+    {
+        IoReleaseRemoveLock(&Socket->CloseRemoveLock, Irp);
+        reqCount = InterlockedDecrement(&Socket->RequestCount);
+    }
+
+    DEBUG_EXIT_FUNCTION("void, reqCount=%i", reqCount);
+    return;
+}
+
+
+NTSTATUS
+VioWskIrpComplete(
+	_Inout_opt_ PVIOWSK_SOCKET Socket,
+	_In_ PIRP                  Irp,
+	_In_ NTSTATUS              Status,
+	_In_ ULONG_PTR             Information
+)
+{
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p; Status=0x%x; Information=%zu", Socket, Irp, Status, Information);
+
+    IoSetCancelRoutine(Irp, NULL);
+    if (Socket)
+        VioWskIrpRelease(Socket, Irp);
+
+    Irp->IoStatus.Information = Information;
+    Irp->IoStatus.Status = Status;
+    IoSetNextIrpStackLocation(Irp);
+    IoCompleteRequest(Irp, IO_NO_INCREMENT);
+
+    DEBUG_EXIT_FUNCTION("0x%x", Status);
+    return Status;
+}
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskAddressPartToString(
+    _In_ ULONG            Value,
+    _Out_ PUNICODE_STRING String
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("Value=%u; String=0x%p", Value, String);
+
+    String->Length = 0;
+    Status = RtlIntegerToUnicodeString(Value, 0, String);
+    if (!NT_SUCCESS(Status))
+        goto Exit;
+
+    if (String->Length == String->MaximumLength) {
+        Status = STATUS_BUFFER_OVERFLOW;
+        goto Exit;
+    }
+
+    String->Buffer[String->Length / sizeof(wchar_t)] = L'\0';
+
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x, *String=\"%wZ\"", Status, String);
+    return Status;
+}
+
+_Must_inspect_result_
+NTSTATUS
+VioWskStringToAddressPart(
+    _In_ PUNICODE_STRING String,
+    _Out_ PULONG         Value
+)
+{
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    DEBUG_ENTER_FUNCTION("String=\"%wZ\"; Value=0x%p", String, Value);
+
+    *Value = 0;
+    if (String->Length > 0) {
+        if (String->Buffer[0] < L'0' || String->Buffer[0] > '9') {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        Status = RtlUnicodeStringToInteger(String, 0, Value);
+        if (!NT_SUCCESS(Status))
+            goto Exit;
+    }
+
+Exit:
+    DEBUG_EXIT_FUNCTION("0x%x, *Value=%u", Status, *Value);
+    return Status;
+}

--- a/viosock/wsk/wsk-utils.c
+++ b/viosock/wsk/wsk-utils.c
@@ -32,6 +32,7 @@
 #include "..\inc\debug-utils.h"
 #include "..\inc\vio_wsk.h"
 #include "viowsk-internal.h"
+#include "wsk-completion.h"
 #include "wsk-utils.h"
 
 #ifdef ALLOC_PRAGMA
@@ -112,6 +113,41 @@ VioWskIrpComplete(
 }
 
 
+void
+VioWskIrpFree(
+    _Inout_ PIRP            Irp,
+    _In_opt_ PDEVICE_OBJECT DeviceObject,
+    _In_ BOOLEAN            Completion
+)
+{
+    PDEVICE_OBJECT targetDevice = NULL;
+    DEBUG_ENTER_FUNCTION("Irp=0x%p; DeviceObject=0x%p; Completion=%u", Irp, DeviceObject, Completion);
+
+    targetDevice = (Completion) ? DeviceObject : IoGetNextIrpStackLocation(Irp)->DeviceObject;
+    if (Irp->MdlAddress)
+    {
+        if ((targetDevice->Flags & DO_DIRECT_IO) == DO_DIRECT_IO)
+            MmUnlockPages(Irp->MdlAddress);
+
+        IoFreeMdl(Irp->MdlAddress);
+        Irp->MdlAddress = NULL;
+    }
+
+    if ((Irp->Flags & IRP_BUFFERED_IO) != 0 &&
+        (Irp->Flags & IRP_DEALLOCATE_BUFFER) != 0)
+    {
+        Irp->Flags &= ~(IRP_BUFFERED_IO | IRP_DEALLOCATE_BUFFER);
+        ExFreePoolWithTag(Irp->AssociatedIrp.SystemBuffer, VIOSOCK_WSK_MEMORY_TAG);
+        Irp->AssociatedIrp.SystemBuffer = NULL;
+    }
+
+    IoFreeIrp(Irp);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
 _Must_inspect_result_
 NTSTATUS
 VioWskAddressPartToString(
@@ -164,4 +200,193 @@ VioWskStringToAddressPart(
 Exit:
     DEBUG_EXIT_FUNCTION("0x%x, *Value=%u", Status, *Value);
     return Status;
+}
+
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketIOCTL(
+    _In_ PVIOWSK_SOCKET        Socket,
+    _In_ ULONG                 ControlCode,
+    _In_opt_ PVOID             InputBuffer,
+    _In_ ULONG                 InputBufferLength,
+    _Out_opt_ PVOID            OutputBuffer,
+    _In_ ULONG                 OutputBufferLength,
+    _Inout_opt_ PIRP           Irp,
+    _Out_opt_ PIO_STATUS_BLOCK IoStatusBlock
+)
+{
+	PIRP IOCTLIrp = NULL;
+	PVIOWSK_REG_CONTEXT pContext = NULL;
+	PWSK_REGISTRATION Registraction = NULL;
+	NTSTATUS Status = STATUS_UNSUCCESSFUL;
+	PVIOSOCKET_COMPLETION_CONTEXT CompContext = NULL;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; ControlCode=0x%x; InputBuffer=0x%p; InputBufferLength=%u; OutputBuffer=0x%p; OutputBufferLength=%u; Irp=0x%p; IoStatusBLock=0x%p", Socket, ControlCode, InputBuffer, InputBufferLength, OutputBuffer, OutputBufferLength, Irp, IoStatusBlock);
+
+    Registraction = (PWSK_REGISTRATION)Socket->Client;
+    pContext = (PVIOWSK_REG_CONTEXT)Registraction->ReservedRegistrationContext;
+    Status = VioWskSocketBuildIOCTL(Socket, ControlCode, InputBuffer, InputBufferLength, OutputBuffer, OutputBufferLength, &IOCTLIrp);
+    if (!NT_SUCCESS(Status))
+        goto Complete;
+
+    CompContext = WskCompContextAlloc(wsksSingleIOCTL, Socket, Irp, IoStatusBlock);
+    if (CompContext == NULL)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto FreeIOCTL;
+	}
+
+	Status = WskCompContextSendIrp(CompContext, IOCTLIrp);
+    WskCompContextDereference(CompContext);
+    if (NT_SUCCESS(Status))
+        IOCTLIrp = NULL;
+
+    Irp = NULL;
+
+FreeIOCTL:
+    if (IOCTLIrp)
+        VioWskIrpFree(IOCTLIrp, NULL, FALSE);
+Complete:
+    if (Irp)
+        VioWskIrpComplete(Socket, Irp, Status, 0);
+
+	DEBUG_EXIT_FUNCTION("0x%x", Status);
+	return Status;
+}
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketBuildIOCTL(
+    _In_ PVIOWSK_SOCKET  Socket,
+    _In_ ULONG           ControlCode,
+    _In_opt_ PVOID       InputBuffer,
+    _In_ ULONG           InputBufferLength,
+    _In_opt_ PVOID       OutputBuffer,
+    _In_ ULONG           OutputBufferLength,
+    _Out_ PIRP          *Irp
+)
+{
+    PIRP IOCTLIrp = NULL;
+    ULONG method = 0;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    PIO_STACK_LOCATION IrpStack = NULL;
+    PVIOWSK_REG_CONTEXT pContext = NULL;
+    PWSK_REGISTRATION Registraction = NULL;
+    DEBUG_ENTER_FUNCTION("Socket=0x%p; ControlCode=0x%x; InputBuffer=0x%p; InputBufferLength=%u; OutputBuffer=0x%p; OutputBufferLength=%u; Irp=0x%p", Socket, ControlCode, InputBuffer, InputBufferLength, OutputBuffer, OutputBufferLength, Irp);
+
+    Status = STATUS_SUCCESS;
+    Registraction = (PWSK_REGISTRATION)Socket->Client;
+    pContext = (PVIOWSK_REG_CONTEXT)Registraction->ReservedRegistrationContext;
+    IOCTLIrp = IoAllocateIrp(pContext->VIOSockDevice->StackSize, FALSE);
+    if (!IOCTLIrp)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Exit;
+    }
+
+    IOCTLIrp->Tail.Overlay.Thread = PsGetCurrentThread();
+    IrpStack = IoGetNextIrpStackLocation(IOCTLIrp);
+    IrpStack->MajorFunction = IRP_MJ_DEVICE_CONTROL;
+    IrpStack->DeviceObject = pContext->VIOSockDevice;
+    IrpStack->FileObject = Socket->FileObject;
+    IrpStack->Parameters.DeviceIoControl.InputBufferLength = InputBufferLength;
+    IrpStack->Parameters.DeviceIoControl.OutputBufferLength = OutputBufferLength;
+    IrpStack->Parameters.DeviceIoControl.IoControlCode = ControlCode;
+    method = ControlCode & 3;
+    switch (method)
+    {
+    case METHOD_BUFFERED:
+        if (InputBufferLength != 0 || OutputBufferLength != 0)
+        {
+            IOCTLIrp->AssociatedIrp.SystemBuffer = ExAllocatePoolUninitialized(
+                NonPagedPool, 
+                InputBufferLength > OutputBufferLength ? InputBufferLength : OutputBufferLength,
+                VIOSOCK_WSK_MEMORY_TAG);
+
+            if (IOCTLIrp->AssociatedIrp.SystemBuffer)
+            {
+                if (InputBuffer)
+                    memcpy(IOCTLIrp->AssociatedIrp.SystemBuffer, InputBuffer, InputBufferLength);
+
+                IOCTLIrp->Flags = IRP_BUFFERED_IO | IRP_DEALLOCATE_BUFFER;
+                IOCTLIrp->UserBuffer = OutputBuffer;
+                if (OutputBuffer)
+                    IOCTLIrp->Flags |= IRP_INPUT_OPERATION;
+            }
+            else Status = STATUS_INSUFFICIENT_RESOURCES;
+        }
+        else {
+            IOCTLIrp->Flags = 0;
+            IOCTLIrp->UserBuffer = NULL;
+        }
+        break;
+    case METHOD_IN_DIRECT:
+    case METHOD_OUT_DIRECT:
+        if (InputBuffer)
+        {
+            IOCTLIrp->AssociatedIrp.SystemBuffer = ExAllocatePoolUninitialized(
+                NonPagedPool,
+                InputBufferLength,
+                VIOSOCK_WSK_MEMORY_TAG);
+
+            if (IOCTLIrp->AssociatedIrp.SystemBuffer)
+            {
+                memcpy(IOCTLIrp->AssociatedIrp.SystemBuffer, InputBuffer, InputBufferLength);
+                IOCTLIrp->Flags = IRP_BUFFERED_IO | IRP_DEALLOCATE_BUFFER;
+            }
+            else Status = STATUS_INSUFFICIENT_RESOURCES;
+        }
+        else IOCTLIrp->Flags = 0;
+
+        if (NT_SUCCESS(Status) && OutputBuffer) {
+            IOCTLIrp->MdlAddress = IoAllocateMdl(
+                OutputBuffer,
+                OutputBufferLength,
+                FALSE,
+                FALSE,
+                NULL);
+
+            if (!IOCTLIrp->MdlAddress)
+            {
+                if (InputBuffer)
+                    ExFreePoolWithTag(IOCTLIrp->AssociatedIrp.SystemBuffer, VIOSOCK_WSK_MEMORY_TAG);
+
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+            }
+
+            if (NT_SUCCESS(Status)) {
+                __try
+                {
+                    MmProbeAndLockPages(IOCTLIrp->MdlAddress, KernelMode, (LOCK_OPERATION)((method == METHOD_IN_DIRECT) ? IoReadAccess : IoWriteAccess));
+                }
+                __except (EXCEPTION_EXECUTE_HANDLER) {
+                    if (IOCTLIrp->MdlAddress)
+                        IoFreeMdl(IOCTLIrp->MdlAddress);
+
+                    if (InputBuffer)
+                        ExFreePoolWithTag(IOCTLIrp->AssociatedIrp.SystemBuffer, VIOSOCK_WSK_MEMORY_TAG);
+
+                    Status = GetExceptionCode();
+                }
+            }
+        }
+        break;
+    case METHOD_NEITHER:
+        IOCTLIrp->UserBuffer = OutputBuffer;
+        IrpStack->Parameters.DeviceIoControl.Type3InputBuffer = InputBuffer;
+        break;
+	}
+
+    if (NT_SUCCESS(Status)) {
+        *Irp = IOCTLIrp;
+        IOCTLIrp = NULL;
+    }
+
+    if (IOCTLIrp)
+        VioWskIrpFree(IOCTLIrp, NULL, FALSE);
+Exit:
+	DEBUG_EXIT_FUNCTION("0x%x, *Irp=0x%p", Status, *Irp);
+	return Status;
 }

--- a/viosock/wsk/wsk-utils.h
+++ b/viosock/wsk/wsk-utils.h
@@ -107,4 +107,34 @@ VioWskSocketBuildIOCTL(
 );
 
 
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketReadWrite(
+    _In_ PVIOWSK_SOCKET Socket,
+    const WSK_BUF      *Buffers,
+    _In_ UCHAR          MajorFunction,
+    _Inout_ PIRP        Irp
+);
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskSocketBuildReadWriteSingleMdl(
+    _In_ PVIOWSK_SOCKET Socket,
+    _In_ PMDL           Mdl,
+    _In_ ULONG          Offset,
+    _In_ ULONG          Length,
+    _In_ UCHAR          MajorFunction,
+    _Out_ PIRP*         Irp
+);
+
+
+NTSTATUS
+WskBufferValidate(
+    _In_ const WSK_BUF* Buffer,
+    _Out_ PULONG FirstMdlLength,
+    _Out_ PULONG LastMdlLength
+);
+
+
 #endif

--- a/viosock/wsk/wsk-utils.h
+++ b/viosock/wsk/wsk-utils.h
@@ -1,0 +1,78 @@
+/*
+ * Provider NPI functions
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _WSK_UTILS_H
+#define _WSK_UTILS_H
+
+#ifdef _MSC_VER
+#pragma once
+#endif //_MSC_VER
+
+
+#include "..\inc\vio_wsk.h"
+#include "viowsk.h"
+
+
+_Must_inspect_result_
+NTSTATUS
+VioWskIrpAcquire(
+    _In_opt_ PVIOWSK_SOCKET Socket,
+    _Inout_                 PIRP Irp
+);
+
+void
+VioWskIrpRelease(
+    _In_opt_ PVIOWSK_SOCKET Socket,
+    _In_                    PIRP Irp
+);
+
+NTSTATUS
+VioWskIrpComplete(
+    _Inout_opt_ PVIOWSK_SOCKET Socket,
+    _In_ PIRP                  Irp,
+    _In_ NTSTATUS              Status,
+    _In_ ULONG_PTR             Information
+);
+
+_Must_inspect_result_
+NTSTATUS
+VioWskAddressPartToString(
+    _In_ ULONG            Value,
+    _Out_ PUNICODE_STRING String
+);
+
+_Must_inspect_result_
+NTSTATUS
+VioWskStringToAddressPart(
+    _In_ PUNICODE_STRING String,
+    _Out_ PULONG         Value
+);
+
+
+#endif

--- a/viosock/wsk/wsk-workitem.c
+++ b/viosock/wsk/wsk-workitem.c
@@ -1,0 +1,187 @@
+/*
+ * Exports definition for virtio socket WSK interface
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "precomp.h"
+#include "..\inc\debug-utils.h"
+#include "viowsk.h"
+#include "..\inc\vio_wsk.h"
+#include "viowsk-internal.h"
+#include "wsk-workitem.h"
+
+
+#pragma warning(disable : 4996)
+
+
+static
+void
+_ProcessWorkItem(
+    _In_ PWSK_WORKITEM WorkItem
+)
+{
+    DEBUG_ENTER_FUNCTION("WorkItem=0x%p", WorkItem);
+
+    switch (WorkItem->Type)
+    {
+    case wskwitSocket:
+        VioWskSocket(WorkItem->Specific.Socket.Client,
+            WorkItem->Specific.Socket.AddressFamily,
+            WorkItem->Specific.Socket.SocketType,
+            WorkItem->Specific.Socket.Protocol,
+            WorkItem->Specific.Socket.Flags,
+            WorkItem->Specific.Socket.SocketContext,
+            WorkItem->Specific.Socket.Dispatch,
+            WorkItem->Specific.Socket.OwningProcess,
+            WorkItem->Specific.Socket.OwningThread,
+            WorkItem->Specific.Socket.SecurityDescriptor,
+            WorkItem->Irp);
+			break;
+    case wskwitSocketAndConnect:
+        VioWskSocketConnect(
+            WorkItem->Specific.SocketConnect.Client,
+            WorkItem->Specific.SocketConnect.SocketType,
+            WorkItem->Specific.SocketConnect.Protocol,
+            WorkItem->Specific.SocketConnect.LocalAddress,
+            WorkItem->Specific.SocketConnect.RemoteAddress,
+            WorkItem->Specific.SocketConnect.Flags,
+            WorkItem->Specific.SocketConnect.SocketContext,
+            WorkItem->Specific.SocketConnect.Dispatch,
+            WorkItem->Specific.SocketConnect.OwningProcess,
+            WorkItem->Specific.SocketConnect.OwningThread,
+            WorkItem->Specific.SocketConnect.SecurityDescriptor,
+            WorkItem->Irp);
+        break;
+    case wskwitCloseSocket:
+        VioWskCloseSocket(
+            WorkItem->Specific.CloseSocket.Socket,
+            WorkItem->Irp);
+        break;
+    case wskwitAccept:
+        VioWskAccept(
+            WorkItem->Specific.Accept.ListenSocket,
+            WorkItem->Specific.Accept.Flags,
+            WorkItem->Specific.Accept.AcceptSocketContext,
+            WorkItem->Specific.Accept.AcceptSocketDispatch,
+            WorkItem->Specific.Accept.LocalAddress,
+            WorkItem->Specific.Accept.RemoteAddress,
+            WorkItem->Irp);
+        break;
+    default:
+        ASSERT(FALSE);
+        break;
+    }
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+static
+void
+_IoWskRoutine(
+    _In_ PVOID        IoObject,
+    _In_opt_ PVOID    Context,
+    _In_ PIO_WORKITEM IoWorkItem
+)
+{
+    PWSK_WORKITEM WorkItem = (PWSK_WORKITEM)Context;
+    DEBUG_ENTER_FUNCTION("IoObject=0x%p; Context=0x%p; IoWorkItem=0x%p", IoObject, Context, IoWorkItem);
+
+    __analysis_assert(WorkItem);
+    UNREFERENCED_PARAMETER(IoObject);
+    _ProcessWorkItem(WorkItem);
+    IoUninitializeWorkItem(IoWorkItem);
+    ExFreePoolWithTag(WorkItem, VIOSOCK_WSK_MEMORY_TAG);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+static
+void
+_ExWskRoutine(
+    _In_opt_ PVOID Context
+)
+{
+    PWSK_WORKITEM WorkItem = (PWSK_WORKITEM)Context;
+    DEBUG_ENTER_FUNCTION("Context=0x%p", Context);
+
+    __analysis_assert(WorkItem);
+    _ProcessWorkItem(WorkItem);
+    ExFreePoolWithTag(WorkItem, VIOSOCK_WSK_MEMORY_TAG);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}
+
+
+
+PWSK_WORKITEM
+WskWorkItemAlloc(
+    _In_ EWSKWorkItemType Type,
+    _In_ PIRP             Irp
+)
+{
+    PWSK_WORKITEM Ret = NULL;
+    SIZE_T TotalSize = sizeof(WSK_WORKITEM);
+    BOOLEAN IoWorkItem = (_viowskDeviceObject != NULL);
+    DEBUG_ENTER_FUNCTION("Type%u; Irp=0x%p", Type, Irp);
+
+    if (IoWorkItem)
+        TotalSize += (IoSizeofWorkItem() - sizeof(Ret->ExWorkItem));
+
+    Ret = ExAllocatePoolWithTag(NonPagedPool,TotalSize , VIOSOCK_WSK_MEMORY_TAG);
+    if (Ret)
+    {
+        memset(Ret, 0, TotalSize);
+        Ret->Type = Type;
+        Ret->IoMethod = IoWorkItem;
+        Ret->Irp = Irp;
+        if (Ret->IoMethod)
+            IoInitializeWorkItem(_viowskDeviceObject, (PIO_WORKITEM)Ret->IoWorkItem);
+        else ExInitializeWorkItem(&Ret->ExWorkItem, _ExWskRoutine, Ret);
+    }
+
+    DEBUG_EXIT_FUNCTION("0x%p", Ret);
+    return Ret;
+}
+
+
+void
+WskWorkItemQueue(
+	_In_ PWSK_WORKITEM WorkItem
+)
+{
+    DEBUG_ENTER_FUNCTION("WorkItem=0x%p", WorkItem);
+
+    if (WorkItem->IoMethod)
+        IoQueueWorkItemEx((PIO_WORKITEM)WorkItem->IoWorkItem, _IoWskRoutine, DelayedWorkQueue, WorkItem);
+    else ExQueueWorkItem(&WorkItem->ExWorkItem, DelayedWorkQueue);
+
+    DEBUG_EXIT_FUNCTION_VOID();
+    return;
+}

--- a/viosock/wsk/wsk-workitem.c
+++ b/viosock/wsk/wsk-workitem.c
@@ -34,6 +34,9 @@
 #include "..\inc\vio_wsk.h"
 #include "viowsk-internal.h"
 #include "wsk-workitem.h"
+#ifdef EVENT_TRACING
+#include "wsk-workitem.tmh"
+#endif
 
 
 #pragma warning(disable : 4996)

--- a/viosock/wsk/wsk-workitem.h
+++ b/viosock/wsk/wsk-workitem.h
@@ -105,6 +105,10 @@ WskWorkItemQueue(
     _In_ PWSK_WORKITEM WorkItem
 );
 
+void
+WskWorkItemFree(
+    _In_ PWSK_WORKITEM WorkItem
+);
 
 
 #endif

--- a/viosock/wsk/wsk-workitem.h
+++ b/viosock/wsk/wsk-workitem.h
@@ -1,0 +1,110 @@
+/*
+ * Exports definition for virtio socket WSK interface
+ *
+ * Copyright (c) 2021 Virtuozzo International GmbH
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met :
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and / or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of their contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __WSK_WORKITEM_H__
+#define __WSK_WORKITEM_H__
+
+
+#include <ntifs.h>
+#include "viowsk.h"
+
+
+
+typedef enum _EWSKWorkItemType {
+    wskwitUndefined,
+    wskwitSocket,
+    wskwitSocketAndConnect,
+    wskwitCloseSocket,
+    wskwitAccept,
+    wskwitMax,
+} EWSKWorkItemType, *PEWSKWorkItemType;
+
+typedef struct _WSK_WORKITEM {
+    EWSKWorkItemType Type;
+    BOOLEAN IoMethod;
+    PIRP Irp;
+    union {
+        struct {
+            PWSK_CLIENT Client;
+            ADDRESS_FAMILY AddressFamily;
+            USHORT SocketType;
+            ULONG Protocol;
+            ULONG Flags;
+            PVOID SocketContext;
+            const VOID *Dispatch;
+            PEPROCESS OwningProcess;
+            PETHREAD OwningThread;
+            PSECURITY_DESCRIPTOR SecurityDescriptor;
+        } Socket;
+        struct {
+            PWSK_CLIENT Client;
+            USHORT SocketType;
+            ULONG Protocol;
+            PSOCKADDR LocalAddress;
+            PSOCKADDR RemoteAddress;
+            ULONG Flags;
+            PVOID SocketContext;
+            const WSK_CLIENT_CONNECTION_DISPATCH *Dispatch;
+            PEPROCESS OwningProcess;
+            PETHREAD OwningThread;
+            PSECURITY_DESCRIPTOR SecurityDescriptor;
+        } SocketConnect;
+        struct {
+            PWSK_SOCKET Socket;
+        } CloseSocket;
+        struct {
+            PWSK_SOCKET ListenSocket;
+            ULONG Flags;
+            PVOID AcceptSocketContext;
+            CONST WSK_CLIENT_CONNECTION_DISPATCH *AcceptSocketDispatch;
+            PSOCKADDR LocalAddress;
+            PSOCKADDR RemoteAddress;
+        } Accept;
+    } Specific;
+    union {
+        WORK_QUEUE_ITEM ExWorkItem;
+        unsigned char IoWorkItem[1]; 
+    };
+} WSK_WORKITEM, *PWSK_WORKITEM;
+
+
+PWSK_WORKITEM
+WskWorkItemAlloc(
+    _In_ EWSKWorkItemType Type,
+    _In_ PIRP             Irp
+);
+
+void
+WskWorkItemQueue(
+    _In_ PWSK_WORKITEM WorkItem
+);
+
+
+
+#endif

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ClInclude Include="..\inc\debug-utils.h" />
     <ClInclude Include="precomp.h" />
+    <ClInclude Include="wpp-trace.h" />
     <ClInclude Include="viowsk-internal.h" />
     <ClInclude Include="viowsk.h" />
     <ClInclude Include="wsk-completion.h" />
@@ -125,12 +126,36 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWsk;WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP;WINAPI_PARTITION_DESKTOP=1;WINAPI_PARTITION_SYSTEM=1;WINAPI_PARTITION_APP=1;WINAPI_PARTITION_PC_APP=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">true</WppEnabled>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">wpp-trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">wpp-trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">wpp-trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">trace.h</WppScanConfigurationData>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">true</WppEnabled>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">wpp-trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">wpp-trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">wpp-trace.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="$(Configuration.EndsWith('Debug'))">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACE_PROJECT_NAME=VioWsk;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">true</WppEnabled>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|ARM64'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|ARM64'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">trace.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="precomp.h" />
     <ClInclude Include="viowsk-internal.h" />
     <ClInclude Include="viowsk.h" />
+    <ClInclude Include="wsk-completion.h" />
     <ClInclude Include="wsk-utils.h" />
     <ClInclude Include="wsk-workitem.h" />
   </ItemGroup>
@@ -39,6 +40,7 @@
     <ClCompile Include="socket-internal.c" />
     <ClCompile Include="socket.c" />
     <ClCompile Include="viowsk.c" />
+    <ClCompile Include="wsk-completion.c" />
     <ClCompile Include="wsk-utils.c" />
     <ClCompile Include="wsk-workitem.c" />
   </ItemGroup>

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Win10 Debug|ARM64">
-      <Configuration>Win10 Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Win10 Debug|Win32">
-      <Configuration>Win10 Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Win10 Debug|x64">
-      <Configuration>Win10 Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Win10 Release|Win32">
       <Configuration>Win10 Release</Configuration>
       <Platform>Win32</Platform>

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -27,6 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\inc\debug-utils.h" />
     <ClInclude Include="precomp.h" />
     <ClInclude Include="viowsk.h" />
   </ItemGroup>

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ClInclude Include="..\inc\debug-utils.h" />
     <ClInclude Include="precomp.h" />
+    <ClInclude Include="viowsk-internal.h" />
     <ClInclude Include="viowsk.h" />
   </ItemGroup>
   <ItemGroup>

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -32,12 +32,15 @@
     <ClInclude Include="viowsk-internal.h" />
     <ClInclude Include="viowsk.h" />
     <ClInclude Include="wsk-utils.h" />
+    <ClInclude Include="wsk-workitem.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c" />
+    <ClCompile Include="socket-internal.c" />
     <ClCompile Include="socket.c" />
     <ClCompile Include="viowsk.c" />
     <ClCompile Include="wsk-utils.c" />
+    <ClCompile Include="wsk-workitem.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{96FDD976-0035-4E24-A61B-E93BED675101}</ProjectGuid>

--- a/viosock/wsk/wsk.vcxproj
+++ b/viosock/wsk/wsk.vcxproj
@@ -31,11 +31,13 @@
     <ClInclude Include="precomp.h" />
     <ClInclude Include="viowsk-internal.h" />
     <ClInclude Include="viowsk.h" />
+    <ClInclude Include="wsk-utils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c" />
     <ClCompile Include="socket.c" />
     <ClCompile Include="viowsk.c" />
+    <ClCompile Include="wsk-utils.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{96FDD976-0035-4E24-A61B-E93BED675101}</ProjectGuid>

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="..\inc\debug-utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="viowsk-internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClInclude Include="viowsk.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\inc\debug-utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="wsk-completion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wpp-trace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="viowsk-internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wsk-utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">
@@ -36,6 +39,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="viowsk.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wsk-utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="wsk-utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wsk-workitem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">
@@ -42,6 +45,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="wsk-utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="socket-internal.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wsk-workitem.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/viosock/wsk/wsk.vcxproj.filters
+++ b/viosock/wsk/wsk.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="wsk-workitem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wsk-completion.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="provider.c">
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="wsk-workitem.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wsk-completion.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This pull request introduces WSK interface for the Socket driver. That allows to take advantage of the driver (and communicate with other virtual machines and the hypervisor through `AF_VSOCK`) also directly in the kernel.

Starting Windows Vista, Microsoft implements WSK interface for `AF_INET` and `AF_INET6` address families. The interface provides similar functions to WinSock2 known from the usermode (well, the word *similar* needs to be relaxed a bit). Support for `AF_VM` allows the user, in theory, to easily reuse kernel code communicating over a network.
## Limitations
Aim of this PR is to provide sort of a basic implementation of the WSK interface for `AF_VSOCK`, without any changes to the Socket driver code. This means that some WSK calls and features are NOT implemented yet.
The following WSK calls are not implemented
- `WskListen`, (`WskBind` on a listening socket does the trick),
- `WskConnectEx` (the same as `WskConnect` + `WskSend`),
- `WskSendEx`,
- `WskReceiveEx`,
- `WskSocketConnect` (same as `WskSocket` + `WskBind` + `WskConnect`),
- `WskControlClient`.

Also, socket event callbacks are not working yet. Their implementation possibly requires some changes to the Socket driver code, thus, I decided to possibly do that in a later PR. These callbacks can be used to notify the user about an incomming connection or of newly arrived data.

This is still a **WORK IN PROGRESS**, some formatting needs to be altered and some descriptions added. It will be finished this Monday or Tuesday. 