### PR TITLE
viosock: Fix compilation warning in EWDK11 22H2

### DIFF
--- a/viosock/wsk/provider.c
+++ b/viosock/wsk/provider.c
@@ -102,9 +102,11 @@ VioWskSocketInternal(
 
     *CompleteIrp = TRUE;
 
-    pSocket = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(VIOWSK_SOCKET), VIOSOCK_WSK_MEMORY_TAG);
+    pSocket = ExAllocatePoolUninitialized(NonPagedPoolNx, sizeof(VIOWSK_SOCKET), VIOSOCK_WSK_MEMORY_TAG);
     if (pSocket)
     {
+        RtlZeroMemory(pSocket, sizeof(VIOWSK_SOCKET));
+
         pSocket->SocketContext = SocketContext;
         pSocket->Type = Flags;
 

--- a/viosock/wsk/viowsk.c
+++ b/viosock/wsk/viowsk.c
@@ -50,7 +50,7 @@ VioWskRegister(
     if (!WskClientNpi || !WskRegistration)
         return STATUS_INVALID_PARAMETER;
 
-    pContext = ExAllocatePoolWithTag(NonPagedPoolNx,
+    pContext = ExAllocatePoolUninitialized(NonPagedPoolNx,
         sizeof(VIOWSK_REG_CONTEXT), VIOSOCK_WSK_MEMORY_TAG);
 
     if (!pContext)


### PR DESCRIPTION
ExAllocatePoolWithTag has been deprecated in Windows 10 version 2004. Starting with EWDK 11 22H2, using ExAllocatePoolWithTag causes a warning, which is treated as an error.

EWDK suggests replacing ExAllocatePoolWithTag on ExAllocatePool2, but ExAllocatePool2 only works on Windows 10 2004 and above. This commit replaced this function with ExAllocatePoolUninitialized to support Windows 10 2004 and below.
All of these features first appeared in WDK 2004.

Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=2138115

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>