### PR TITLE
viogpu: Fix compilation warning in EWDK11 22H2

### DIFF
--- a/viogpu/common/baseobj.cpp
+++ b/viogpu/common/baseobj.cpp
@@ -7,7 +7,7 @@ _When_((PoolType & NonPagedPoolMustSucceed) != 0,
 {
     Size = (Size != 0) ? Size : 1;
 
-    void* pObject = ExAllocatePoolWithTag(PoolType, Size, VIOGPUTAG);
+    void* pObject = ExAllocatePoolUninitialized(PoolType, Size, VIOGPUTAG);
 
     if (pObject != NULL)
     {
@@ -28,7 +28,7 @@ _When_((PoolType & NonPagedPoolMustSucceed) != 0,
 
     Size = (Size != 0) ? Size : 1;
 
-    void* pObject = ExAllocatePoolWithTag(PoolType, Size, VIOGPUTAG);
+    void* pObject = ExAllocatePoolUninitialized(PoolType, Size, VIOGPUTAG);
 
     if (pObject != NULL)
     {

--- a/viogpu/common/viogpu_pci.cpp
+++ b/viogpu/common/viogpu_pci.cpp
@@ -127,7 +127,7 @@ ULONGLONG mem_get_physical_address(void *context, void *virt)
 void *mem_alloc_nonpaged_block(void *context, size_t size)
 {
     UNREFERENCED_PARAMETER(context);
-    PVOID ptr = ExAllocatePoolWithTag(
+    PVOID ptr = ExAllocatePoolUninitialized(
         NonPagedPoolNx,
         size,
         VIOGPUTAG);


### PR DESCRIPTION
ExAllocatePoolWithTag has been deprecated in Windows 10 version 2004. Starting with EWDK 11 22H2, using ExAllocatePoolWithTag causes a warning, which is treated as an error.

EWDK suggests replacing ExAllocatePoolWithTag on ExAllocatePool2, but ExAllocatePool2 only works on Windows 10 2004 and above. This commit replaced this function with ExAllocatePoolUninitialized to support Windows 10 2004 and below.
All of these features first appeared in WDK 2004.

Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=2138115

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>