### PR TITLE
virtio: Fix compilation warning in EWDK11 22H2

### DIFF
--- a/VirtIO/WDF/Callbacks.c
+++ b/VirtIO/WDF/Callbacks.c
@@ -105,7 +105,7 @@ static void *mem_alloc_nonpaged_block(void *context, size_t size)
 {
     PVIRTIO_WDF_DRIVER pWdfDriver = (PVIRTIO_WDF_DRIVER)context;
 
-    PVOID addr = ExAllocatePoolWithTag(
+    PVOID addr = ExAllocatePoolUninitialized(
         NonPagedPool,
         size,
         pWdfDriver->MemoryTag);

--- a/VirtIO/WDF/Dma.c
+++ b/VirtIO/WDF/Dma.c
@@ -261,7 +261,7 @@ PVIRTIO_DMA_MEMORY_SLICED VirtIOWdfDeviceAllocDmaMemorySliced(
 {
     PVIRTIO_WDF_DRIVER pWdfDriver = vdev->DeviceContext;
     size_t allocSize = sizeof(VIRTIO_DMA_MEMORY_SLICED) + (blockSize / sliceSize) / 8 + sizeof(ULONG);
-    PVIRTIO_DMA_MEMORY_SLICED p = ExAllocatePoolWithTag(NonPagedPool, allocSize, pWdfDriver->MemoryTag);
+    PVIRTIO_DMA_MEMORY_SLICED p = ExAllocatePoolUninitialized(NonPagedPool, allocSize, pWdfDriver->MemoryTag);
     if (!p) {
         return NULL;
     }
@@ -350,7 +350,7 @@ BOOLEAN VirtIOWdfDeviceDmaTxAsync(VirtIODevice *vdev,
         status = WdfDmaTransactionInitializeUsingRequest(
             tr, params->req, OnDmaTransactionProgramDma, WdfDmaDirectionWriteToDevice);
     } else {
-        ctx->buffer = ExAllocatePoolWithTag(NonPagedPool, ctx->parameters.size, ctx->parameters.allocationTag);
+        ctx->buffer = ExAllocatePoolUninitialized(NonPagedPool, ctx->parameters.size, ctx->parameters.allocationTag);
         if (ctx->buffer) {
             RtlCopyMemory(ctx->buffer, params->buffer, params->size);
             ctx->mdl = IoAllocateMdl(ctx->buffer, params->size, FALSE, FALSE, NULL);

--- a/VirtIO/WDF/PCI.c
+++ b/VirtIO/WDF/PCI.c
@@ -59,7 +59,7 @@ NTSTATUS PCIAllocBars(WDFCMRESLIST ResourcesTranslated,
             switch (pResDescriptor->Type) {
                 case CmResourceTypePort:
                 case CmResourceTypeMemory:
-                    pBar = (PVIRTIO_WDF_BAR)ExAllocatePoolWithTag(
+                    pBar = (PVIRTIO_WDF_BAR)ExAllocatePoolUninitialized(
                         NonPagedPool,
                         sizeof(VIRTIO_WDF_BAR),
                         pWdfDriver->MemoryTag);


### PR DESCRIPTION
ExAllocatePoolWithTag has been deprecated in Windows 10 version 2004. Starting with EWDK 11 22H2, using ExAllocatePoolWithTag causes a warning, which is treated as an error.

EWDK suggests replacing ExAllocatePoolWithTag on ExAllocatePool2, but ExAllocatePool2 only works on Windows 10 2004 and above. This commit replaced this function with ExAllocatePoolUninitialized to support Windows 10 2004 and below.
All of these features first appeared in WDK 2004.

Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=2138115

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>