### PR TITLE
NETKVM: fix packet loss in special case

### DIFF
--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -38,6 +38,8 @@ public:
 
     PARANDIS_RECEIVE_QUEUE &UnclassifiedPacketsQueue() { return m_UnclassifiedPacketsQueue;  }
 
+    UINT GetAvailRecvBufferCount() { return  m_NetNofReceiveBuffers; }
+
 private:
     /* list of Rx buffers available for data (under VIRTIO management) */
     LIST_ENTRY              m_NetReceiveBuffers;


### PR DESCRIPTION
If a poor designed TCP server application doesn't receive data from windows socket function driver afd.sys as quickly as possible, then afd.sys will hold recv buffers temporaryly, and don't call NdisReturnNetBufferLists until afd return-buffer timer expired(at most 1 second).At this time, if there are many packets send in by tcp clients, there may not be enough receive buffer descriptors in the vring to receive packets, and finally packet loss.

Notes:
1. If someone found this patch could help you to avoid packet loss, the most probably root cause is the application is not well-designed;
2. An another way which can avoid packet loss under the situation described above is set DoNotHoldNICBuffers to 1(REG_DWORD) under registry path HKEY_LOCAL_MACHINE\SYSTEM\CCS\Services\AFD\Parameters. But microsoft had never mentioned this registry (even hadn't document the behavior of HoldNICBuffers), so the registry param maybe not working in the future version of windows.
3. According to my analysis, the pusrpose of HoldNICBuffers behavior in afd.sys is mainly to decrease memory copy times when deliver incomming tcp packets to the buffer of recv/wsarecv systemcall. But sometimes it may lead packet loss.

Signed-off-by: junjiehua <junjiehua@tencent.com>
Reviewed-by: yongduan <yongduan@tencent.com>