### PR TITLE
[viostor] make sure that discard sector alignment is 8 sectors (4K) mnimum

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -84,6 +84,7 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_BLK_QUEUE_LAST   MAX_CPU
 
 #define VIRTIO_BLK_MSIX_CONFIG_VECTOR   0
+#define MIN_DISCARD_SECTOR_ALIGNMENT    8
 
 #define BLOCK_SERIAL_STRLEN     20
 

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -647,10 +647,10 @@ RhelGetDiskGeometry(
     if(CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD)) {
         virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, discard_sector_alignment),
                           &v, sizeof(v));
-        if (v == UINT_MAX) {
-            v = 8;
-        }
-        adaptExt->info.discard_sector_alignment = v ? v << SECTOR_SHIFT : 0;
+
+        v = max(v, MIN_DISCARD_SECTOR_ALIGNMENT);
+        adaptExt->info.discard_sector_alignment = v << SECTOR_SHIFT;
+
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " discard_sector_alignment = %d\n", adaptExt->info.discard_sector_alignment);
 
         virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, max_discard_sectors),


### PR DESCRIPTION
[Bug 2020998] Windows 10 "Optimize drive"/Trim/Discard causes all data to be rewritten

Signed-off-by: Vadim Rozenfeld <vrozenfe@redhat.com>