### PR TITLE
vioinput: Fix catalog file generation

### DIFF
--- a/buildAll.bat
+++ b/buildAll.bat
@@ -30,10 +30,11 @@ call tools\build.bat viosock\sys\viosock.vcxproj "Win10_SDV" %*
 if errorlevel 1 goto :fail
 call tools\build.bat viofs\pci\viofs.vcxproj "Win10_SDV" %*
 if errorlevel 1 goto :fail
-call tools\build.bat vioinput\sys\vioinput.vcxproj "Win10_SDV" %*
-if errorlevel 1 goto :fail
 call tools\build.bat vioinput\hidpassthrough\hidpassthrough.vcxproj "Win10_SDV" %*
 if errorlevel 1 goto :fail
+call tools\build.bat vioinput\sys\vioinput.vcxproj "Win10_SDV" %*
+if errorlevel 1 goto :fail
+
 
 :nosdv2022
 

--- a/vioinput/hidpassthrough/hidpassthrough.vcxproj
+++ b/vioinput/hidpassthrough/hidpassthrough.vcxproj
@@ -66,22 +66,27 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
     <OutDir>objfre_win10_x86\i386\</OutDir>
     <IntDir>objfre_win10_x86\i386\</IntDir>
+    <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">
     <OutDir>objfre_win8_x86\i386\</OutDir>
     <IntDir>objfre_win8_x86\i386\</IntDir>
+    <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
     <OutDir>objfre_win10_amd64\amd64\</OutDir>
     <IntDir>objfre_win10_amd64\amd64\</IntDir>
+    <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">
     <OutDir>objfre_win10_arm64\arm64\</OutDir>
     <IntDir>objfre_win10_arm64\arm64\</IntDir>
+    <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <OutDir>objfre_win8_amd64\amd64\</OutDir>
     <IntDir>objfre_win8_amd64\amd64\</IntDir>
+    <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup>
     <CustomBuildAfterTargets>dvl</CustomBuildAfterTargets>


### PR DESCRIPTION
- resolves: 
    BZ#2012756 - [virtio-win][vioinput]Signtool verify viohidkmdf.sys file failed with virtio-win-prewhql-211 on win10+ guests
    BZ#2141603 - HCK-CI failed to install virtio-input driver

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>