### PR TITLE
VirtIO-FS: handle EACCES as FUSE request output

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -488,6 +488,7 @@ static NTSTATUS VirtFsFuseRequest(HANDLE Device, LPVOID InBuffer,
         switch (out_hdr->error)
         {
             case -EPERM:
+            case -EACCES:
                 Status = STATUS_ACCESS_DENIED;
                 break;
             case -ENOENT:


### PR DESCRIPTION
For example, FUSE_OPEN may return -EACCES. Previously, it was returning "Catastrophic failure". Now it will return "Access Denied" as follows:
![image](https://user-images.githubusercontent.com/8286747/202263235-db34c893-8499-4cfc-a5af-229770c77f0a.png)