### PR TITLE
viosock: Publish supported socket options also for the kernel

### DIFF
--- a/viosock/inc/vio_sockets.h
+++ b/viosock/inc/vio_sockets.h
@@ -37,6 +37,29 @@
 
 #include <ws2def.h>
 
+#ifndef _WINSOCK2API_
+
+#define IOCPARM_MASK    0x7f            /* parameters must be < 128 bytes */
+#define IOC_VOID        0x20000000      /* no parameters */
+#define IOC_OUT         0x40000000      /* copy out parameters */
+#define IOC_IN          0x80000000      /* copy in parameters */
+
+#define _IOR(x,y,t)     (IOC_OUT|(((long)sizeof(t)&IOCPARM_MASK)<<16)|((x)<<8)|(y))
+#define _IOW(x,y,t)     (IOC_IN|(((long)sizeof(t)&IOCPARM_MASK)<<16)|((x)<<8)|(y))
+
+#define FIONREAD    _IOR('f', 127, ULONG) /* get # bytes to read */
+#define FIONBIO     _IOW('f', 126, ULONG) /* set/clear non-blocking i/o */
+
+#define IOC_WS2                       0x08000000
+
+#define _WSAIO(x,y)                   (IOC_VOID|(x)|(y))
+#define _WSAIOR(x,y)                  (IOC_OUT|(x)|(y))
+
+#define SIO_ADDRESS_LIST_QUERY        _WSAIOR(IOC_WS2,22)
+#define SIO_ADDRESS_LIST_CHANGE       _WSAIO(IOC_WS2,23)
+
+#endif
+
 #define  VIOSOCK_NAME L"\\??\\Viosock"
 
 #ifdef _WINBASE_

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -2393,24 +2393,6 @@ VIOSockSetSockOpt(
     return status;
 }
 
-#define IOCPARM_MASK    0x7f            /* parameters must be < 128 bytes */
-#define IOC_VOID        0x20000000      /* no parameters */
-#define IOC_OUT         0x40000000      /* copy out parameters */
-#define IOC_IN          0x80000000      /* copy in parameters */
-
-#define _IOR(x,y,t)     (IOC_OUT|(((long)sizeof(t)&IOCPARM_MASK)<<16)|((x)<<8)|(y))
-#define _IOW(x,y,t)     (IOC_IN|(((long)sizeof(t)&IOCPARM_MASK)<<16)|((x)<<8)|(y))
-
-#define FIONREAD    _IOR('f', 127, ULONG) /* get # bytes to read */
-#define FIONBIO     _IOW('f', 126, ULONG) /* set/clear non-blocking i/o */
-
-#define IOC_WS2                       0x08000000
-
-#define _WSAIO(x,y)                   (IOC_VOID|(x)|(y))
-#define _WSAIOR(x,y)                  (IOC_OUT|(x)|(y))
-
-#define SIO_ADDRESS_LIST_QUERY        _WSAIOR(IOC_WS2,22)
-#define SIO_ADDRESS_LIST_CHANGE       _WSAIO(IOC_WS2,23)
 
 static
 NTSTATUS


### PR DESCRIPTION
The Socket driver enables its users to set several socket options, however, their values are not defined in kernel mode (winsock2.h defines them for usermode code). This commit moves these definitions from internal source file of the Socket driver into its public header file.

I would be happy if this PR can be merged before #835 since I am using one of the published socket options in a test driver there.