### PR TITLE
RHBZ#2149547: print error message if failed to load WinFsp

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -2777,8 +2777,14 @@ int wmain(int argc, wchar_t **argv)
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
 
-    if (!NT_SUCCESS(FspLoad(0)))
+    Result = FspLoad(0);
+
+    if (!NT_SUCCESS(Result))
     {
+        fwprintf(stderr,
+            L"The service %s failed to load WinFsp DLL (Status=%lx).",
+            FS_SERVICE_NAME, Result);
+
         return ERROR_DELAY_LOAD_FAILED;
     }
 


### PR DESCRIPTION
Previously, the virtiofs.exe was exiting silently.