### PR TITLE
VirtIO-WDF: Dma: fix CodeAnalysis warnings

### DIFF
--- a/VirtIO/WDF/Dma.c
+++ b/VirtIO/WDF/Dma.c
@@ -265,6 +265,7 @@ PVIRTIO_DMA_MEMORY_SLICED VirtIOWdfDeviceAllocDmaMemorySliced(
     if (!p) {
         return NULL;
     }
+    __analysis_assume(allocSize > sizeof(*p));
     RtlZeroMemory(p, sizeof(*p));
     p->va = AllocateCommonBuffer(pWdfDriver, blockSize, 0);
     p->pa = GetPhysicalAddress(pWdfDriver, p->va);

--- a/VirtIO/WDF/Dma.c
+++ b/VirtIO/WDF/Dma.c
@@ -354,12 +354,14 @@ BOOLEAN VirtIOWdfDeviceDmaTxAsync(VirtIODevice *vdev,
         if (ctx->buffer) {
             RtlCopyMemory(ctx->buffer, params->buffer, params->size);
             ctx->mdl = IoAllocateMdl(ctx->buffer, params->size, FALSE, FALSE, NULL);
-        }
-        if (ctx->mdl) {
-            MmBuildMdlForNonPagedPool(ctx->mdl);
-            status = WdfDmaTransactionInitialize(
-                tr, OnDmaTransactionProgramDma, WdfDmaDirectionWriteToDevice,
-                ctx->mdl, ctx->buffer, params->size);
+            if (ctx->mdl) {
+                MmBuildMdlForNonPagedPool(ctx->mdl);
+                status = WdfDmaTransactionInitialize(
+                    tr, OnDmaTransactionProgramDma, WdfDmaDirectionWriteToDevice,
+                    ctx->mdl, ctx->buffer, params->size);
+            } else {
+                status = STATUS_INSUFFICIENT_RESOURCES;
+            }
         } else {
             status = STATUS_INSUFFICIENT_RESOURCES;
         }


### PR DESCRIPTION
* Fix warning `C6387`: `ctx->buffer` could be `0`: this does not adhere to the specification for the function `WdfDmaTransactionInitialize`.
* Fix warning `C6386`: Buffer overrun while writing to `p`: the writable size is `allocSize` bytes, but `72` bytes might be written
