### PR TITLE
NetKVM: Do not report vendor-specific OIDs (WHQL)

### DIFF
--- a/NetKVM/wlh/ParaNdis6_Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6_Oid.cpp
@@ -273,8 +273,8 @@ static NDIS_OID SupportedOids[] =
         OID_GEN_XMIT_OK,
         OID_GEN_RCV_OK,
         OID_GEN_VLAN_ID,
-#if NDIS_SUPPORT_NDIS61
-// disable WMI custom command on 2008 due to non-filtered NDIS test failure
+#ifdef NETKVM_REPORT_SPECIFIC_OIDS
+// disable WMI custom command on all OSes due to non-filtered NDIS test failure
         OID_GEN_SUPPORTED_GUIDS,
         OID_VENDOR_1,
         OID_VENDOR_2,
@@ -490,7 +490,7 @@ static NDIS_STATUS ParaNdis_OidQuery(PARANDIS_ADAPTER *pContext, tOidDesc *pOid)
             ulSize = sizeof(pContext->Statistics);
             break;
         case OID_GEN_SUPPORTED_GUIDS:
-#if NDIS_SUPPORT_NDIS61
+#ifdef NETKVM_REPORT_SPECIFIC_OIDS
             pInfo = (PVOID)&supportedGUIDs;
             ulSize = sizeof(supportedGUIDs);
 #endif


### PR DESCRIPTION
This step is necessary to pass the "NDISTest 6.0 - [1 Machine] - 1c_WMICoverage" which gets into trouble when a driver reports vendor-specific OIDs the test cannot find names for. If you wish NetKVM to report those OIDs again, define the NETKVM_REPORT_SPECIFIC_OIDS symbol.

NetKVM still handles these specific OIDs although it does not report them.

This issue happened in the past and was fixed the same way at that time [1]. We owe current appearance to a small time window between expiration of filtered test cases and adoption of their new versions. This commit should fix the problem for good.

[1]: https://bugzilla.redhat.com/show_bug.cgi?format=multiple&id=1439085
