### PR TITLE
RHBZ#2174170: VirtIO-FS: introduce host owner UID:GID parameter

### DIFF
--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -342,3 +342,15 @@ public:
         WaitForThreadpoolWorkCallbacks(UnregWork, FALSE);
     }
 };
+
+static bool ParseIds(const std::wstring& ids, uint32_t& uid, uint32_t& gid)
+{
+    return (swscanf_s(ids.c_str(), L"%u:%u", &uid, &gid) == 2);
+}
+
+static bool CheckIds(const std::wstring& ids)
+{
+    uint32_t uid, gid;
+
+    return ParseIds(ids, uid, gid);
+}


### PR DESCRIPTION
By default, host owner UID:GID is set to UID:GID of shared directory owner. New command-line argument `-o` and registry parameter `Owner` override this behavior. A valid parameter value looks like `1234:5678`.