### PR TITLE
fix bug for query vq alloc of leagacy device

### DIFF
--- a/VirtIO/VirtIOPCILegacy.c
+++ b/VirtIO/VirtIOPCILegacy.c
@@ -160,7 +160,7 @@ static NTSTATUS vio_legacy_query_vq_alloc(VirtIODevice *vdev,
 
     /* Check if queue is either not available or already active. */
     num = ioread16(vdev, vdev->addr + VIRTIO_PCI_QUEUE_NUM);
-    if (!num || ioread32(vdev, vdev->addr + VIRTIO_PCI_QUEUE_PFN)) {
+    if (!num && ioread32(vdev, vdev->addr + VIRTIO_PCI_QUEUE_PFN)) {
         return STATUS_NOT_FOUND;
     }
 


### PR DESCRIPTION
for leagacy virtio device, vio_leagacy_query_vq_alloc will check queue num and queue pfn, so need to change the or to and when query.