### PR TITLE
RHBZ#2183941: ignore FUSE_FALLOCATE failure in Create

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -571,7 +571,7 @@ static NTSTATUS VirtFsCreateFile(VIRTFS *VirtFs,
 
         if (AllocationSize > 0)
         {
-            Status = SetFileSize(VirtFs->FileSystem, FileContext,
+            SetFileSize(VirtFs->FileSystem, FileContext,
                 AllocationSize, TRUE, FileInfo);
         }
         else


### PR DESCRIPTION
The `fallocate` call is Linux-specific and some host filesystems don't support some of its arguments. NFS doesn't support `FALLOC_FL_KEEP_SIZE` which is helpful when `AllocationSize` > 0 in `Create`. Since we can't determine host FS from the guest side, ignore `fallocate` failure. We will get an error anyway during a further `Write`, if there isn't enough space.