### PR TITLE
viostor: Fix guest hang issue caused by hot plugging vioblk and vcpus

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -242,6 +242,7 @@ typedef struct _ADAPTER_EXTENSION {
     BOOLEAN               check_condition;
     SENSE_INFO            sense_info;
     BOOLEAN               removed;
+    BOOLEAN               stopped;
     ULONG                 max_tx_length;
     PGROUP_AFFINITY       pmsg_affinity;
     ULONG                 num_affinity;


### PR DESCRIPTION
If user hot plugs a vioblk device and then hot plugs vcpus, the guest hangs after vcpus have been hot plugged.

vioblk hot plug:
drive_add auto file=test.img,format=raw,if=none,id=test1,cache=none device_add virtio-blk-pci,drive=test1,id=test-disk,bus=pciroot2

vcpu hot plug:
device_add host-x86_64-cpu,socket-id=16,core-id=0,thread-id=0,id=cpu16 device_add host-x86_64-cpu,socket-id=17,core-id=0,thread-id=0,id=cpu17 device_add host-x86_64-cpu,socket-id=18,core-id=0,thread-id=0,id=cpu18 device_add host-x86_64-cpu,socket-id=19,core-id=0,thread-id=0,id=cpu19

This hang issue is a regression caused by following commit, commit 65589a2d4dbf7844a3f363e78b1837fe4a1136c5
[viostor] report SRB_STATUS_NO_DEVICE status on removed virtio-blk HBA Reporting status on the removed virtio-blk HBA is fine, but this commit stops supporting the PnPAction of 'StorStopDevice' for the adapter.

When vcpu is hot plugged, a SRB of 'StorStopDevice' PnPAction is sent to the vioblk driver. Without processing this SRB, the guest will hang. This patch adds the support of SRB of 'StorStopDevice' PnPAction.