### PR TITLE
vioscsi: set SCSISTAT_QUEUE_FULL if a buffer cannot be added to a VQ

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -53,6 +53,7 @@ SendSRB(
     ULONG               QueueNumber = VIRTIO_SCSI_REQUEST_QUEUE_0;
     STOR_LOCK_HANDLE    LockHandle = { 0 };
     ULONG               status = STOR_STATUS_SUCCESS;
+    UCHAR               ScsiStatus = SCSISTAT_GOOD;
     ULONG MessageID;
     int res = 0;
     PREQUEST_LIST       element;
@@ -111,7 +112,9 @@ ENTER_FN_SRB();
         }
     } else {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
+        ScsiStatus = SCSISTAT_QUEUE_FULL;
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BUSY);
+        SRB_SET_SCSI_STATUS(Srb, ScsiStatus);
         StorPortBusy(DeviceExtension, 10);
         CompleteRequest(DeviceExtension, Srb);
         RhelDbgPrint(TRACE_LEVEL_FATAL, " CompleteRequest queue (%d) SRB = %p Lun = %d TimeOut = %d.\n", QueueNumber, srbExt->Srb, SRB_LUN(Srb), Srb->TimeOutValue);


### PR DESCRIPTION
# Problem description
It was noticed that if a VQ gets exhausted, completing a request with SRB_STATUS_BUSY only will result in stalling of a whole unit and it may lead to the performance degradation during IO intensive workloads. The issue is mostly seen when there is a high number of outstanding IOs, e.g. ~512 or more. This behaviour was introduced with the commit https://github.com/virtio-win/kvm-guest-drivers-windows/commit/f1338bb7edd712bb9c3cf9c9b122e60a3f518408. 

Instead of stalling the unit, it is better to report device-busy by setting SCSISTAT_QUEUE_FULL in ScsiStatus  of a SRB. In that case StorPort pauses the logical unit queue and waits until a certain amount I/O requests are completed by the miniport before sending any further requests. 

# Repro steps
The test case is simple:

1. Create a VM with 2 vCPUs.
2. Start writing simultaneously to two files on two SCSI disks using diskspd.exe (make sure that testfile.dat is created): 
`C:\temp\diskspd.exe -b8k -t2 -r -o512 -d30 -Sh <disk>:\testfile.dat`

# Observed results:
## **Before the change**
```
Test job 1:
Command Line: C:\temp\diskspd.exe -b8k -t2 -r -o512 -d30 -Sh D:\testfile.dat

Input parameters:

        timespan:   1
        -------------
        duration: 30s
        warm up time: 5s
        cool down time: 0s
        random seed: 0
        path: 'D:\testfile.dat'
                think time: 0ms
                burst size: 0
                software cache disabled
                hardware write cache disabled, writethrough on
                performing read test
                block size: 8KiB
                using random I/O (alignment: 8KiB)
                number of outstanding I/O operations per thread: 512
                threads per file: 2
                using I/O Completion Ports
                IO priority: normal

System information:

        computer name: WIN-4L9DKR4C3FK
        start time: 2023/06/06 11:25:50 UTC

Results for timespan 1:
*******************************************************************************

actual test time:       30.02s
thread count:           2
proc count:             2

CPU |  Usage |  User  |  Kernel |  Idle
-------------------------------------------
   0|  21.03%|   1.09%|   19.94%|  78.97%
   1|  18.38%|   0.57%|   17.80%|  81.62%
-------------------------------------------
avg.|  19.70%|   0.83%|   18.87%|  80.30%

Total IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |      1882775552 |       229831 |      59.82 |    7657.06 | D:\testfile.dat (768MiB)
     1 |      1887920128 |       230459 |      59.98 |    7677.98 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:        3770695680 |       460290 |     119.80 |   15335.04

Read IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |      1882775552 |       229831 |      59.82 |    7657.06 | D:\testfile.dat (768MiB)
     1 |      1887920128 |       230459 |      59.98 |    7677.98 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:        3770695680 |       460290 |     119.80 |   15335.04

Write IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |               0 |            0 |       0.00 |       0.00 | D:\testfile.dat (768MiB)
     1 |               0 |            0 |       0.00 |       0.00 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:                 0 |            0 |       0.00 |       0.00
```
Test job 2:
```
Command Line: C:\temp\diskspd.exe -b8k -t2 -r -o512 -d30 -Sh e:\testfile.dat

Input parameters:

        timespan:   1
        -------------
        duration: 30s
        warm up time: 5s
        cool down time: 0s
        random seed: 0
        path: 'e:\testfile.dat'
                think time: 0ms
                burst size: 0
                software cache disabled
                hardware write cache disabled, writethrough on
                performing read test
                block size: 8KiB
                using random I/O (alignment: 8KiB)
                number of outstanding I/O operations per thread: 512
                threads per file: 2
                using I/O Completion Ports
                IO priority: normal

System information:

        computer name: WIN-4L9DKR4C3FK
        start time: 2023/06/06 11:25:50 UTC

Results for timespan 1:
*******************************************************************************

actual test time:       30.02s
thread count:           2
proc count:             2

CPU |  Usage |  User  |  Kernel |  Idle
-------------------------------------------
   0|  20.51%|   1.09%|   19.42%|  79.49%
   1|  17.80%|   0.52%|   17.28%|  82.20%
-------------------------------------------
avg.|  19.16%|   0.81%|   18.35%|  80.84%

Total IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |      2333630464 |       284867 |      74.15 |    9490.63 | e:\testfile.dat (768MiB)
     1 |      2336587776 |       285228 |      74.24 |    9502.66 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:        4670218240 |       570095 |     148.39 |   18993.30

Read IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |      2333630464 |       284867 |      74.15 |    9490.63 | e:\testfile.dat (768MiB)
     1 |      2336587776 |       285228 |      74.24 |    9502.66 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:        4670218240 |       570095 |     148.39 |   18993.30

Write IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |               0 |            0 |       0.00 |       0.00 | e:\testfile.dat (768MiB)
     1 |               0 |            0 |       0.00 |       0.00 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:                 0 |            0 |       0.00 |       0.00
```

## **With the change**
Test job 1:
```
Command Line: C:\temp\diskspd.exe -b8k -t2 -r -o512 -d30 -Sh D:\testfile.dat

Input parameters:

        timespan:   1
        -------------
        duration: 30s
        warm up time: 5s
        cool down time: 0s
        random seed: 0
        path: 'D:\testfile.dat'
                think time: 0ms
                burst size: 0
                software cache disabled
                hardware write cache disabled, writethrough on
                performing read test
                block size: 8KiB
                using random I/O (alignment: 8KiB)
                number of outstanding I/O operations per thread: 512
                threads per file: 2
                using I/O Completion Ports
                IO priority: normal

System information:

        computer name: WIN-4L9DKR4C3FK
        start time: 2023/06/06 11:28:14 UTC

Results for timespan 1:
*******************************************************************************

actual test time:       30.00s
thread count:           2
proc count:             2

CPU |  Usage |  User  |  Kernel |  Idle
-------------------------------------------
   0|  88.39%|   4.17%|   84.22%|  11.61%
   1|  88.39%|   4.01%|   84.38%|  11.61%
-------------------------------------------
avg.|  88.39%|   4.09%|   84.30%|  11.61%

Total IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |     10282844160 |      1255230 |     326.88 |   41841.08 | D:\testfile.dat (768MiB)
     1 |     10215948288 |      1247064 |     324.76 |   41568.88 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:       20498792448 |      2502294 |     651.64 |   83409.96

Read IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |     10282844160 |      1255230 |     326.88 |   41841.08 | D:\testfile.dat (768MiB)
     1 |     10215948288 |      1247064 |     324.76 |   41568.88 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:       20498792448 |      2502294 |     651.64 |   83409.96

Write IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |               0 |            0 |       0.00 |       0.00 | D:\testfile.dat (768MiB)
     1 |               0 |            0 |       0.00 |       0.00 | D:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:                 0 |            0 |       0.00 |       0.00
```
Test job 2:
```
Command Line: C:\temp\diskspd.exe -b8k -t2 -r -o512 -d30 -Sh e:\testfile.dat

Input parameters:

        timespan:   1
        -------------
        duration: 30s
        warm up time: 5s
        cool down time: 0s
        random seed: 0
        path: 'e:\testfile.dat'
                think time: 0ms
                burst size: 0
                software cache disabled
                hardware write cache disabled, writethrough on
                performing read test
                block size: 8KiB
                using random I/O (alignment: 8KiB)
                number of outstanding I/O operations per thread: 512
                threads per file: 2
                using I/O Completion Ports
                IO priority: normal

System information:

        computer name: WIN-4L9DKR4C3FK
        start time: 2023/06/06 11:28:13 UTC

Results for timespan 1:
*******************************************************************************

actual test time:       30.00s
thread count:           2
proc count:             2

CPU |  Usage |  User  |  Kernel |  Idle
-------------------------------------------
   0|  89.53%|   4.17%|   85.36%|  10.47%
   1|  89.64%|   3.96%|   85.68%|  10.36%
-------------------------------------------
avg.|  89.58%|   4.06%|   85.52%|  10.42%

Total IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |     10410844160 |      1270855 |     330.95 |   42361.97 | e:\testfile.dat (768MiB)
     1 |     10460422144 |      1276907 |     332.53 |   42563.71 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:       20871266304 |      2547762 |     663.48 |   84925.68

Read IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |     10410844160 |      1270855 |     330.95 |   42361.97 | e:\testfile.dat (768MiB)
     1 |     10460422144 |      1276907 |     332.53 |   42563.71 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:       20871266304 |      2547762 |     663.48 |   84925.68

Write IO
thread |       bytes     |     I/Os     |    MiB/s   |  I/O per s |  file
------------------------------------------------------------------------------
     0 |               0 |            0 |       0.00 |       0.00 | e:\testfile.dat (768MiB)
     1 |               0 |            0 |       0.00 |       0.00 | e:\testfile.dat (768MiB)
------------------------------------------------------------------------------
total:                 0 |            0 |       0.00 |       0.00
```

# Additional information
Storport registry entries: https://learn.microsoft.com/en-us/windows-hardware/drivers/storage/registry-entries-for-storport-miniport-drivers

# HLK/HCK
I have run HLK2022 and HCK for Windows Server 2012R2 and encountered none of the unexpected failures. 