### PR TITLE
viosock: Fix rare race condition in VIOSockReadDequeueCb

### DIFF
--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -1042,6 +1042,7 @@ VIOSockCreate(
     }
 
     pSocket = GetSocketContext(FileObject);
+    pSocket->RxProcessingThreadId = NULL;
     pSocket->ThisSocket = FileObject;
     pSocket->SocketId = InterlockedIncrement(&pContext->SocketId);
 

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -238,6 +238,7 @@ typedef struct _SOCKET_CONTEXT {
     _Guarded_by_(StateLock) NTSTATUS        EventsStatus[FD_MAX_EVENTS];
 
     WDFSPINLOCK     RxLock;         //accept list lock for listen socket
+    HANDLE RxProcessingThreadId; // Prevents recursion in 
     _Guarded_by_(RxLock) LIST_ENTRY      RxCbList;
     _Guarded_by_(RxLock) volatile ULONG           RxBytes;        //used bytes in rx buffer
     _Guarded_by_(RxLock) ULONG           RxBuffers;      //used rx buffers (for debug)


### PR DESCRIPTION
This routine is used to match send() and recv() operations made on a given socket. This occurs in these situations:
- after a send() is recorded for the socket,
- when a new recv() request is added to an empty queue of such requests,

The routine may requeue a recv() request (e.g. because it finds not enough send() ones to fully satisfy it), which may trigger it being called recursively again and again. Thus, a mechanism to detect the recursion is implemented through the lInProgress variable. However, this may backfire in some rare cases, for example:
- the routine is called after recording a send() request, it is about to exit since the recv() queue is empty, simultaneously
- a recv() request just got into the queue, however, VIOSockReadDequeueCb does not do the matching since another instance of itself is still running.

This leads to send() and recv() operations wait infinitely for each other.

This branch implements new recursion detection mechanism that does not suffer from this problem. The routine now check whether it is not called recursively by one thread which prevents the recursion but nothing else.