### PR TITLE
viosock: Use STATUS_IO_TIMEOUT instead of STATUS_TIMEOUT

### DIFF
--- a/viosock/lib/native.c
+++ b/viosock/lib/native.c
@@ -77,6 +77,7 @@ NtReadFile(
 #define STATUS_CONNECTION_RESET          ((NTSTATUS)0xC000020DL)
 #define STATUS_LOCAL_DISCONNECT          ((NTSTATUS)0xC000013BL)
 #define STATUS_HOST_UNREACHABLE          ((NTSTATUS)0xC000023DL)
+#define STATUS_IO_TIMEOUT                ((NTSTATUS)0xc00000b5L)
 
 INT
 NtStatusToWsaError(
@@ -90,6 +91,7 @@ NtStatusToWsaError(
         wsaError = WSAEINVAL;
         break;
     case STATUS_TIMEOUT:
+    case STATUS_IO_TIMEOUT:
         wsaError = WSAETIMEDOUT;
         break;
     case STATUS_CANT_WAIT:

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -944,7 +944,7 @@ VIOSockSelectWorkitem(
                 if (pPkt->Timeout <= TimePassed + VIOSOCK_TIMER_TOLERANCE)
                 {
                     bRemove = TRUE;
-                    pPkt->Status = STATUS_TIMEOUT;
+                    pPkt->Status = STATUS_IO_TIMEOUT;
                 }
                 else
                 {

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1378,7 +1378,7 @@ VIOSockReadDequeueCb(
         bStop = TRUE;
         if (llTimeout && llTimeout <= VIOSOCK_TIMER_TOLERANCE)
         {
-            status = STATUS_TIMEOUT;
+            status = STATUS_IO_TIMEOUT;
         }
         else
         {
@@ -1486,7 +1486,7 @@ VIOSockReadDequeueCb(
     {
         if (llTimeout && llTimeout <= VIOSOCK_TIMER_TOLERANCE)
         {
-            status = STATUS_TIMEOUT;
+            status = STATUS_IO_TIMEOUT;
         }
         else
         {
@@ -1797,7 +1797,7 @@ VIOSockReadTimerFunc(
     while (!IsListEmpty(&CompletionList))
     {
         pRequest = CONTAINING_RECORD(RemoveHeadList(&CompletionList), VIOSOCK_RX_CONTEXT, ListEntry);
-        WdfRequestCompleteWithInformation(pRequest->ThisRequest, STATUS_TIMEOUT, pRequest->BufferLen - pRequest->FreeBytes);
+        WdfRequestCompleteWithInformation(pRequest->ThisRequest, STATUS_IO_TIMEOUT, pRequest->BufferLen - pRequest->FreeBytes);
     }
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_READ, "<-- %s, status: 0x%08x, counter: %u\n", __FUNCTION__, status, lCounter);

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -598,8 +598,8 @@ VIOSockPendedTimerFunc(
     if (NT_SUCCESS(VIOSockPendedRequestGetLocked(pSocket, &PendedRequest)) &&
         PendedRequest != WDF_NO_HANDLE)
     {
-        WdfRequestComplete(PendedRequest, STATUS_TIMEOUT);
-        //        VIOSockTxCancel(GetDeviceContextFromSocket(pSocket), pSocket, STATUS_TIMEOUT);
+        WdfRequestComplete(PendedRequest, STATUS_IO_TIMEOUT);
+        //        VIOSockTxCancel(GetDeviceContextFromSocket(pSocket), pSocket, STATUS_IO_TIMEOUT);
     }
 }
 
@@ -670,7 +670,7 @@ VIOSockPendedRequestSetEx(
             if (!NT_SUCCESS(WdfRequestUnmarkCancelable(Request)))
                 status = STATUS_CANCELLED;
             else
-                status = STATUS_TIMEOUT;
+                status = STATUS_IO_TIMEOUT;
 
             pSocket->PendedRequest = WDF_NO_HANDLE;
             WdfObjectDereference(Request);

--- a/viosock/sys/Tx.c
+++ b/viosock/sys/Tx.c
@@ -1115,7 +1115,7 @@ VIOSockTxTimerFunc(
             PVIOSOCK_TX_ENTRY pTxEntry = CONTAINING_RECORD(RemoveHeadList(&CompletionList),
                 VIOSOCK_TX_ENTRY, ListEntry);
 
-            WdfRequestComplete(pTxEntry->Request, STATUS_TIMEOUT);
+            WdfRequestComplete(pTxEntry->Request, STATUS_IO_TIMEOUT);
         }
     }
 


### PR DESCRIPTION
The problem (or "problem") with `STATUS_TIMEOUT` is that it is classified as a success status code (the `NT_SUCCESS` macro returns `TRUE`). This problem does not appear in user mode since `viosocklib` converts `STATUS_TIMEOUT` to corresponding Win32 error code,

However, kernel mode components/drivers mostly use `NT_SUCCESS` macro to distinguish success from failure, thus, `STATUS_TIMEOUT` can be misleading for them. Also, some uses of the `VIOSockPendedRequestSetEx` in the viosock driver itself improperly handle `STATUS_TIMEOUT`.

This pull request modifies viosock driver to return `STATUS_IO_TIMEOUT` instead. This is an error code. `viosocklib` is also updated to translate this code to the timeout Win32 error.