### PR TITLE
set ProvisioningType in LOGICAL_BLOCK_PROVISIONING VPD according discard_granularity size

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1580,13 +1580,12 @@ RhelScsiGetInquiryData(
         ProvisioningPage->DeviceTypeQualifier = DEVICE_CONNECTED;
         ProvisioningPage->PageCode = VPD_LOGICAL_BLOCK_PROVISIONING;
         REVERSE_BYTES_SHORT(&ProvisioningPage->PageLength, &pageLen);
-
         ProvisioningPage->DP = 0;
         ProvisioningPage->LBPRZ = 0;
         ProvisioningPage->LBPWS10 = 0;
         ProvisioningPage->LBPWS = 0;
         ProvisioningPage->LBPU = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD) ? 1 : 0;
-        ProvisioningPage->ProvisioningType = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD) ? PROVISIONING_TYPE_THIN : PROVISIONING_TYPE_RESOURCE;
+        ProvisioningPage->ProvisioningType = adaptExt->info.discard_sector_alignment ? PROVISIONING_TYPE_THIN : PROVISIONING_TYPE_RESOURCE;
     }
 
     else if (dataLen > sizeof(INQUIRYDATA)) {

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -647,8 +647,9 @@ RhelGetDiskGeometry(
     if(CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD)) {
         virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, discard_sector_alignment),
                           &v, sizeof(v));
-
-        v = max(v, MIN_DISCARD_SECTOR_ALIGNMENT);
+        if (v > 0) {
+            v = max(v, MIN_DISCARD_SECTOR_ALIGNMENT);
+        }
         adaptExt->info.discard_sector_alignment = v << SECTOR_SHIFT;
 
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " discard_sector_alignment = %d\n", adaptExt->info.discard_sector_alignment);


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=2133261
Win11 22H2 can perform only quick format on a thinly provisioning volume.
Windows can recognize such volume by checking ProvisioningType == PROVISIONING_TYPE_THIN
reported in VPD_LOGICAL_BLOCK_PROVISIONING VPD. in case of virtio-scsi the ProvisioningType
can be changed from PROVISIONING_TYPE_THIN to PROVISIONING_TYPE_RESOURCE by setting discard_granularity to 0.
Previously virtio-blk driver was setting  ProvisioningType based on discard type but not on discard_granularity value, which 
was different from virtio-scsi.