### PR TITLE
RHBZ#2172002: set CaseSensitiveSearch depending on -i argument

### DIFF
--- a/viofs/svc/utils.h
+++ b/viofs/svc/utils.h
@@ -180,6 +180,20 @@ static DWORD FindDeviceInterface(const GUID *ClassGuid, PHANDLE Device,
     }
 }
 
+static bool FileNameIgnoreCaseCompare(const char *a, const char *b)
+{
+    WCHAR wide_a[MAX_PATH];
+    WCHAR wide_b[MAX_PATH];
+
+    if (!MultiByteToWideChar(CP_UTF8, 0, a, -1, wide_a, MAX_PATH) ||
+        !MultiByteToWideChar(CP_UTF8, 0, b, -1, wide_b, MAX_PATH))
+    {
+        return false;
+    }
+
+    return (CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, wide_a, -1, wide_b, -1) == CSTR_EQUAL);
+}
+
 static bool FileNameIgnoreCaseCompare(PCWSTR a, const char *b, uint32_t b_len)
 {
     WCHAR wide_b[MAX_PATH];

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -1933,6 +1933,12 @@ static NTSTATUS Rename(FSP_FILE_SYSTEM *FileSystem, PVOID FileContext0,
         return Status;
     }
 
+    if (VirtFs->CaseInsensitive && oldparent == newparent &&
+        FileNameIgnoreCaseCompare(oldname, newname))
+    {
+        return STATUS_SUCCESS;
+    }
+
     // It is not allowed to rename to an existing directory even when
     // ReplaceIfExists is set.
     flags = ((FileContext->IsDirectory == FALSE) &&

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -2484,7 +2484,7 @@ NTSTATUS VIRTFS::Start()
     VolumeParams.VolumeCreationTime = ((PLARGE_INTEGER)&FileTime)->QuadPart;
 //    VolumeParams.VolumeSerialNumber = 0;
     VolumeParams.FileInfoTimeout = 1000;
-    VolumeParams.CaseSensitiveSearch = 1;
+    VolumeParams.CaseSensitiveSearch = !CaseInsensitive;
     VolumeParams.CasePreservedNames = 1;
     VolumeParams.UnicodeOnDisk = 1;
     VolumeParams.PersistentAcls = 1;


### PR DESCRIPTION
Case-insensitive file system should lower `FILE_CASE_SENSITIVE_SEARCH` flag in `FILE_FS_ATTRIBUTE_INFORMATION`. Along with `FILE_CASE_PRESERVED_NAMES` it means for Windows that the FS knows the correct case, but lookups can be case-insensitive.

Also, fix `MoveFile("FILE", "file", 0)` failure caused by this change.