### PR TITLE
vioscsi: Fix a memory leak in VioScsiReadRegistryParameter

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -313,6 +313,7 @@ BOOLEAN VioScsiReadRegistryParameter(
 
     if ((Ret == FALSE) || (Len == 0)) {
         RhelDbgPrint(TRACE_LEVEL_FATAL, "StorPortRegistryRead returned 0x%x, Len = %d\n", Ret, Len);
+        StorPortFreeRegistryBuffer(DeviceExtension, pBuf);
         return FALSE;
     }
 


### PR DESCRIPTION
Let's free the buffer even if the call to `StorPortRegistryRead` fails.