### PR TITLE
Consume the entire enumerator before letting it go out of scope

### DIFF
--- a/Balloon/app/memstat.cpp
+++ b/Balloon/app/memstat.cpp
@@ -233,5 +233,15 @@ BOOL CMemStat::Update()
         m_Stats[idx++].val = 0;
     }
 
+    // Consume the enumerator
+    while (enumerator != NULL && !FAILED(enumerator->Next(
+        WBEM_INFINITE,
+        1L,
+        &memory,
+        &retcnt))) {
+            if (retcnt == 0)
+                break;
+    }
+
     return TRUE;
 }


### PR DESCRIPTION
This diff seems to fix issue #614. I have replaced blnsvr.exe with a version that contains this patch, and the events are gone. I tested that blnsvr.exe built without this patch does exhibit the behavior. The service is running without any visible issues, but I have not been able to do a meaningful test of its functionality.

I compared the usage of IWbemServices:ExecQuery in memstat.cpp with other C++ code that uses the same API. The only material difference I noticed was that the other code used the form
```
    while(1) {
        hres = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
        if(0 == uReturn) {
            break;
        }
    }
```
which guarantees that the enumerator is consumed in its entirety. Apparently, the API doesn't clean up its own context unless all items are consumed and throws a hissy fit later on, and quite likely only on a few of the calls.

Please review the patch carefully. I think I got the indentation right according to the "When in Rome" rule, but I'm not positive. The patch is paranoid; the check for enumerator==NULL can probably be eliminated, and it could be made shorter.

I did not run the test suite.