### PR TITLE
viosock: select IO control should return with 'Information' in success

### DIFF
--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -988,7 +988,7 @@ VIOSockSelectWorkitem(
             PVIOSOCK_SELECT_PKT pPkt = CONTAINING_RECORD(RemoveHeadList(&CompletionList), VIOSOCK_SELECT_PKT, ListEntry);
 
             VIOSockSelectCleanupPkt(pPkt);
-            WdfRequestComplete(WdfObjectContextGetObject(pPkt), pPkt->Status);
+            WdfRequestCompleteWithInformation(WdfObjectContextGetObject(pPkt), pPkt->Status, pPkt->Status == STATUS_SUCCESS ? sizeof(VIRTIO_VSOCK_SELECT) : 0);
         }
 
     } while (InterlockedCompareExchange(&pContext->SelectInProgress, 0, 1) != 1);


### PR DESCRIPTION
When select called to poll events of vsock socket, there is a large chance of failure with WSAEINVAL code, especially with timeout param. The trace events gives "Invalid output len" output, which help us to find this bug, that IOCTL_SELECT should always return with correct 'BytesReturned' in success.