### PR TITLE
viosock: fix one fatal recv data error bug

### DIFF
--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1463,8 +1463,6 @@ VIOSockReadDequeueCb(
         {
             memcpy(pRequest->FreePtr, pCurrentCb->ReadPtr, pRequest->FreeBytes);
 
-            pRequest->FreeBytes = 0;
-
             if (!(pRequest->Flags & MSG_PEEK))
             {
                 //update current CB data ptr
@@ -1472,6 +1470,7 @@ VIOSockReadDequeueCb(
                 pCurrentCb->BytesToRead -= pRequest->FreeBytes;
                 VIOSockRxPktDec(pSocket, pRequest->FreeBytes);
             }
+            pRequest->FreeBytes = 0;
 
             break;
         }


### PR DESCRIPTION
This patch fixs one bug, that multiple recv calls always return the same data. From upper layer, it seems like Stream data pointer never moves. One simple multiple-recvs test case can reproduce this easily.