### PR TITLE
viosock: make sure to get a correct computation

### DIFF
--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1433,8 +1433,6 @@ VIOSockReadDequeueCb(
                 pCurrentItem = pCurrentItem->Blink;
                 RemoveEntryList(&pCurrentCb->ListEntry);
 
-                pCurrentCb->BytesToRead = 0;
-
                 if (VIOSockIsLoopbackCb(pCurrentCb))
                 {
                     status = WdfRequestUnmarkCancelable(pCurrentCb->Request);
@@ -1457,6 +1455,7 @@ VIOSockReadDequeueCb(
                     VIOSockRxCbPushLocked(pContext, pCurrentCb);
                     VIOSockRxPktDec(pSocket, pCurrentCb->BytesToRead);
                 }
+                pCurrentCb->BytesToRead = 0;
             }
         }
         else //request buffer is not big enough


### PR DESCRIPTION
Assign the corresponding RxCb's attribute to zero only after it is not used, otherwise some computational errors may cause unexpected behivor.