### PR TITLE
viosock: fix one live lock issue

### DIFF
--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1309,7 +1309,7 @@ VIOSockReadDequeueCb(
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_READ, "--> %s\n", __FUNCTION__);
 
-    if (pSocket->RxProcessingThreadId == PsGetCurrentThreadId())
+    if (pSocket->RxProcessingThreadId == (LONG64)PsGetCurrentThreadId())
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_READ, "Another instance of VIOSockReadDequeueCb already running, stop Cb dequeue\n");
         return FALSE; //one running instance allowed
@@ -1380,9 +1380,9 @@ VIOSockReadDequeueCb(
         }
         else
         {
-            pSocket->RxProcessingThreadId = PsGetCurrentThreadId();
+            pSocket->RxProcessingThreadId = (LONG64)PsGetCurrentThreadId();
             status = WdfRequestRequeue(ReadRequest);
-            pSocket->RxProcessingThreadId = NULL;
+            pSocket->RxProcessingThreadId = INVALID_THREAD_ID;
             if (NT_SUCCESS(status))
             {
                 //continue timer
@@ -1489,9 +1489,9 @@ VIOSockReadDequeueCb(
         else
         {
             //requeue request
-            pSocket->RxProcessingThreadId = PsGetCurrentThreadId();
+            pSocket->RxProcessingThreadId = (LONG64)PsGetCurrentThreadId();
             status = WdfRequestRequeue(ReadRequest);
-            pSocket->RxProcessingThreadId = NULL;
+            pSocket->RxProcessingThreadId = INVALID_THREAD_ID;
             if (NT_SUCCESS(status))
             {
                 //continue timer

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -1042,7 +1042,7 @@ VIOSockCreate(
     }
 
     pSocket = GetSocketContext(FileObject);
-    pSocket->RxProcessingThreadId = NULL;
+    pSocket->RxProcessingThreadId = INVALID_THREAD_ID;
     pSocket->ThisSocket = FileObject;
     pSocket->SocketId = InterlockedIncrement(&pContext->SocketId);
 

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -105,6 +105,7 @@ typedef struct VirtIOBufferDescriptor VIOSOCK_SG_DESC, *PVIOSOCK_SG_DESC;
 
 #define LAST_RESERVED_PORT  1023
 #define MAX_PORT_RETRIES    24
+#define INVALID_THREAD_ID   LONG64_ERROR
 //////////////////////////////////////////////////////////////////////////
 #define VIOSOCK_TIMER_TOLERANCE MSEC_TO_NANO(50)
 typedef struct _VIOSOCK_TIMER
@@ -238,7 +239,7 @@ typedef struct _SOCKET_CONTEXT {
     _Guarded_by_(StateLock) NTSTATUS        EventsStatus[FD_MAX_EVENTS];
 
     WDFSPINLOCK     RxLock;         //accept list lock for listen socket
-    HANDLE RxProcessingThreadId; // Prevents recursion in 
+    LONG64 RxProcessingThreadId; // Prevents recursion in
     _Guarded_by_(RxLock) LIST_ENTRY      RxCbList;
     _Guarded_by_(RxLock) volatile ULONG           RxBytes;        //used bytes in rx buffer
     _Guarded_by_(RxLock) ULONG           RxBuffers;      //used rx buffers (for debug)


### PR DESCRIPTION
using traceview to see tracing events, it turns out the windows thread id handle returned by PsGetCurrentThreadId() is really an integer, this means a NULL handle can be equal to a zero value thread ID(handle is 0), thus cause one infinit wait live lock issue which I actually encounters. Anyway, use a non-positive integer value than this handle seems to be safer.