### PR TITLE
viosock: remove an extra minus in select timeout computation

### DIFF
--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -923,7 +923,7 @@ VIOSockSelect(
     if (timeout)
     {
         //timeout in 100-ns intervals
-        Select.Timeout = -(SEC_TO_NANO((LONGLONG)timeout->tv_sec) + USEC_TO_NANO(timeout->tv_usec));
+        Select.Timeout = (SEC_TO_NANO((LONGLONG)timeout->tv_sec) + USEC_TO_NANO(timeout->tv_usec));
     }
 
     hFile = VIOSockCreateFile(NULL, lpErrno);


### PR DESCRIPTION
VIOSockTimerStart() already contains a minux symbol, using an extra minux in VIOSockSelect() is needless.