### PR TITLE
vioscsi: logging improvements for SRB tracing

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -63,7 +63,7 @@ ENTER_FN_SRB();
     if (!Srb)
         return;
 
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> %s (%d::%d::%d), SRB 0x%p\n", DbgGetScsiOpStr((PSCSI_REQUEST_BLOCK)Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+    LOG_SRB_INFO();
 
     if (adaptExt->num_queues > 1) {
         STARTIO_PERFORMANCE_PARAMETERS param;

--- a/vioscsi/trace.h
+++ b/vioscsi/trace.h
@@ -39,7 +39,10 @@
 #include <stdarg.h>
 #include "kdebugprint.h"
 
-char *DbgGetScsiOpStr(PSCSI_REQUEST_BLOCK Srb);
+#define UCHAR_MAX 0xFF
+#define DbgGetScsiOp(Srb) (SRB_CDB(Srb) ? SRB_CDB(Srb)->CDB6GENERIC.OperationCode : UCHAR_MAX)
+
+char *DbgGetScsiOpStr(UCHAR opCode);
 
 #if !defined(DBG)
 #define EVENT_TRACING 1
@@ -72,7 +75,7 @@ extern int nVioscsiDebugLevel;
 #define VioScsiDbgBreak()\
     if (KD_DEBUGGER_ENABLED && !KD_DEBUGGER_NOT_PRESENT) DbgBreakPoint();
 #else
-#define RhelDbgPrint(Level, MSG, ...) 
+#define RhelDbgPrint(Level, MSG, ...)
 #define VioScsiDbgBreak()
 #endif
 
@@ -83,6 +86,7 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING R
 #define EXIT_ERR() RhelDbgPrint(TRACE_LEVEL_ERROR, " <--> %s (%d).\n", __FUNCTION__, __LINE__)
 #define ENTER_FN_SRB() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)
 #define EXIT_FN_SRB()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define LOG_SRB_INFO() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
 
 #else
 #pragma warning(disable: 28170)
@@ -125,6 +129,9 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING R
 // FUNC ENTER_FN_SRB{LEVEL=TRACE_LEVEL_VERBOSE}(...);
 // USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <--- %!FUNC! 0x%p.", Srb);
 // FUNC EXIT_FN_SRB{LEVEL=TRACE_LEVEL_VERBOSE}(...);
+
+// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! %!FUNC! <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO{LEVEL=TRACE_LEVEL_INFORMATION}(...);
 
 // end_wpp
 

--- a/vioscsi/utils.c
+++ b/vioscsi/utils.c
@@ -107,111 +107,152 @@ nViostorDebugLevel = 0xFF;
 tDebugPrintFunc VirtioDebugPrintProc = DbgPrint;
 #endif
 
-char *DbgGetScsiOpStr(IN PSCSI_REQUEST_BLOCK Srb)
+
+#undef MAKE_CASE
+#define MAKE_CASE(scsiOpCode)    \
+    case scsiOpCode:             \
+        scsiOpStr = #scsiOpCode; \
+        break;
+
+char *DbgGetScsiOpStr(IN UCHAR opCode)
 {
-    PCDB pCdb = SRB_CDB(Srb);
     char *scsiOpStr = "?";
-
-    if (pCdb) {
-        switch (pCdb->CDB6GENERIC.OperationCode) {
-            #undef MAKE_CASE
-            #define MAKE_CASE(scsiOpCode) case scsiOpCode: scsiOpStr = #scsiOpCode; break;
-
-            MAKE_CASE(SCSIOP_TEST_UNIT_READY)
-            MAKE_CASE(SCSIOP_REWIND)    // aka SCSIOP_REZERO_UNIT
-            MAKE_CASE(SCSIOP_REQUEST_BLOCK_ADDR)
-            MAKE_CASE(SCSIOP_REQUEST_SENSE)
-            MAKE_CASE(SCSIOP_FORMAT_UNIT)
-            MAKE_CASE(SCSIOP_READ_BLOCK_LIMITS)
-            MAKE_CASE(SCSIOP_INIT_ELEMENT_STATUS)   // aka SCSIOP_REASSIGN_BLOCKS
-            MAKE_CASE(SCSIOP_RECEIVE)       // aka SCSIOP_READ6
-            MAKE_CASE(SCSIOP_SEND)  // aka SCSIOP_WRITE6, SCSIOP_PRINT
-            MAKE_CASE(SCSIOP_SLEW_PRINT)    // aka SCSIOP_SEEK6, SCSIOP_TRACK_SELECT
-            MAKE_CASE(SCSIOP_SEEK_BLOCK)
-            MAKE_CASE(SCSIOP_PARTITION)
-            MAKE_CASE(SCSIOP_READ_REVERSE)
-            MAKE_CASE(SCSIOP_FLUSH_BUFFER)      // aka SCSIOP_WRITE_FILEMARKS
-            MAKE_CASE(SCSIOP_SPACE)
-            MAKE_CASE(SCSIOP_INQUIRY)
-            MAKE_CASE(SCSIOP_VERIFY6)
-            MAKE_CASE(SCSIOP_RECOVER_BUF_DATA)
-            MAKE_CASE(SCSIOP_MODE_SELECT)
-            MAKE_CASE(SCSIOP_RESERVE_UNIT)
-            MAKE_CASE(SCSIOP_RELEASE_UNIT)
-            MAKE_CASE(SCSIOP_COPY)
-            MAKE_CASE(SCSIOP_ERASE)
-            MAKE_CASE(SCSIOP_MODE_SENSE)
-            MAKE_CASE(SCSIOP_START_STOP_UNIT)   // aka SCSIOP_STOP_PRINT, SCSIOP_LOAD_UNLOAD
-            MAKE_CASE(SCSIOP_RECEIVE_DIAGNOSTIC)
-            MAKE_CASE(SCSIOP_SEND_DIAGNOSTIC)
-            MAKE_CASE(SCSIOP_MEDIUM_REMOVAL)
-            MAKE_CASE(SCSIOP_READ_FORMATTED_CAPACITY)
-            MAKE_CASE(SCSIOP_READ_CAPACITY)
-            MAKE_CASE(SCSIOP_READ)
-            MAKE_CASE(SCSIOP_WRITE)
-            MAKE_CASE(SCSIOP_SEEK)  // aka SCSIOP_LOCATE, SCSIOP_POSITION_TO_ELEMENT
-            MAKE_CASE(SCSIOP_WRITE_VERIFY)
-            MAKE_CASE(SCSIOP_VERIFY)
-            MAKE_CASE(SCSIOP_SEARCH_DATA_HIGH)
-            MAKE_CASE(SCSIOP_SEARCH_DATA_EQUAL)
-            MAKE_CASE(SCSIOP_SEARCH_DATA_LOW)
-            MAKE_CASE(SCSIOP_SET_LIMITS)
-            MAKE_CASE(SCSIOP_READ_POSITION)
-            MAKE_CASE(SCSIOP_SYNCHRONIZE_CACHE)
-            MAKE_CASE(SCSIOP_COMPARE)
-            MAKE_CASE(SCSIOP_COPY_COMPARE)
-            MAKE_CASE(SCSIOP_WRITE_DATA_BUFF)
-            MAKE_CASE(SCSIOP_READ_DATA_BUFF)
-            MAKE_CASE(SCSIOP_CHANGE_DEFINITION)
-            MAKE_CASE(SCSIOP_READ_SUB_CHANNEL)
-            MAKE_CASE(SCSIOP_READ_TOC)
-            MAKE_CASE(SCSIOP_READ_HEADER)
-            MAKE_CASE(SCSIOP_PLAY_AUDIO)
-            MAKE_CASE(SCSIOP_GET_CONFIGURATION)
-            MAKE_CASE(SCSIOP_PLAY_AUDIO_MSF)
-            MAKE_CASE(SCSIOP_PLAY_TRACK_INDEX)
-            MAKE_CASE(SCSIOP_PLAY_TRACK_RELATIVE)
-            MAKE_CASE(SCSIOP_GET_EVENT_STATUS)
-            MAKE_CASE(SCSIOP_PAUSE_RESUME)
-            MAKE_CASE(SCSIOP_LOG_SELECT)
-            MAKE_CASE(SCSIOP_LOG_SENSE)
-            MAKE_CASE(SCSIOP_STOP_PLAY_SCAN)
-            MAKE_CASE(SCSIOP_READ_DISK_INFORMATION)
-            MAKE_CASE(SCSIOP_READ_TRACK_INFORMATION)
-            MAKE_CASE(SCSIOP_RESERVE_TRACK_RZONE)
-            MAKE_CASE(SCSIOP_SEND_OPC_INFORMATION)
-            MAKE_CASE(SCSIOP_MODE_SELECT10)
-            MAKE_CASE(SCSIOP_MODE_SENSE10)
-            MAKE_CASE(SCSIOP_CLOSE_TRACK_SESSION)
-            MAKE_CASE(SCSIOP_READ_BUFFER_CAPACITY)
-            MAKE_CASE(SCSIOP_SEND_CUE_SHEET)
-            MAKE_CASE(SCSIOP_PERSISTENT_RESERVE_IN)
-            MAKE_CASE(SCSIOP_PERSISTENT_RESERVE_OUT)
-            MAKE_CASE(SCSIOP_REPORT_LUNS)
-            MAKE_CASE(SCSIOP_BLANK)
-            MAKE_CASE(SCSIOP_SEND_KEY)
-            MAKE_CASE(SCSIOP_REPORT_KEY)
-            MAKE_CASE(SCSIOP_MOVE_MEDIUM)
-            MAKE_CASE(SCSIOP_LOAD_UNLOAD_SLOT)  // aka SCSIOP_EXCHANGE_MEDIUM
-            MAKE_CASE(SCSIOP_SET_READ_AHEAD)
-            MAKE_CASE(SCSIOP_READ_DVD_STRUCTURE)
-            MAKE_CASE(SCSIOP_REQUEST_VOL_ELEMENT)
-            MAKE_CASE(SCSIOP_SEND_VOLUME_TAG)
-            MAKE_CASE(SCSIOP_READ_ELEMENT_STATUS)
-            MAKE_CASE(SCSIOP_READ_CD_MSF)
-            MAKE_CASE(SCSIOP_SCAN_CD)
-            MAKE_CASE(SCSIOP_SET_CD_SPEED)
-            MAKE_CASE(SCSIOP_PLAY_CD)
-            MAKE_CASE(SCSIOP_MECHANISM_STATUS)
-            MAKE_CASE(SCSIOP_READ_CD)
-            MAKE_CASE(SCSIOP_SEND_DVD_STRUCTURE)
-            MAKE_CASE(SCSIOP_INIT_ELEMENT_RANGE)
-            MAKE_CASE(SCSIOP_READ16)
-            MAKE_CASE(SCSIOP_WRITE16)
-            MAKE_CASE(SCSIOP_VERIFY16)
-            MAKE_CASE(SCSIOP_SYNCHRONIZE_CACHE16)
-            MAKE_CASE(SCSIOP_READ_CAPACITY16)
-        }
+    switch (opCode)
+    {
+        MAKE_CASE(SCSIOP_TEST_UNIT_READY)               // Code 0x00
+        MAKE_CASE(SCSIOP_REWIND)                        // Code 0x01
+        MAKE_CASE(SCSIOP_REQUEST_BLOCK_ADDR)            // Code 0x02
+        MAKE_CASE(SCSIOP_REQUEST_SENSE)                 // Code 0x03
+        MAKE_CASE(SCSIOP_FORMAT_UNIT)                   // Code 0x04
+        MAKE_CASE(SCSIOP_READ_BLOCK_LIMITS)             // Code 0x05
+        MAKE_CASE(SCSIOP_INIT_ELEMENT_STATUS)           // Code 0x07, aka SCSIOP_REASSIGN_BLOCKS
+        MAKE_CASE(SCSIOP_READ6)                         // Code 0x08, aka SCSIOP_RECEIVE
+        MAKE_CASE(SCSIOP_WRITE6)                        // Code 0x0A, aka SCSIOP_PRINT, SCSIOP_SEND
+        MAKE_CASE(SCSIOP_SEEK6)                         // Code 0x0B, aka SCSIOP_SET_CAPACITY, SCSIOP_SLEW_PRINT, SCSIOP_TRACK_SELECT
+        MAKE_CASE(SCSIOP_SEEK_BLOCK)                    // Code 0x0C
+        MAKE_CASE(SCSIOP_PARTITION)                     // Code 0x0D
+        MAKE_CASE(SCSIOP_READ_REVERSE)                  // Code 0x0F
+        MAKE_CASE(SCSIOP_FLUSH_BUFFER)                  // Code 0x10, aka SCSIOP_WRITE_FILEMARKS
+        MAKE_CASE(SCSIOP_SPACE)                         // Code 0x11
+        MAKE_CASE(SCSIOP_INQUIRY)                       // Code 0x12
+        MAKE_CASE(SCSIOP_VERIFY6)                       // Code 0x13
+        MAKE_CASE(SCSIOP_RECOVER_BUF_DATA)              // Code 0x14
+        MAKE_CASE(SCSIOP_MODE_SELECT)                   // Code 0x15
+        MAKE_CASE(SCSIOP_RESERVE_UNIT)                  // Code 0x16
+        MAKE_CASE(SCSIOP_RELEASE_UNIT)                  // Code 0x17
+        MAKE_CASE(SCSIOP_COPY)                          // Code 0x18
+        MAKE_CASE(SCSIOP_ERASE)                         // Code 0x19
+        MAKE_CASE(SCSIOP_MODE_SENSE)                    // Code 0x1A
+        MAKE_CASE(SCSIOP_START_STOP_UNIT)               // Code 0x1B, aka SCSIOP_LOAD_UNLOAD, SCSIOP_STOP_PRINT
+        MAKE_CASE(SCSIOP_RECEIVE_DIAGNOSTIC)            // Code 0x1C
+        MAKE_CASE(SCSIOP_SEND_DIAGNOSTIC)               // Code 0x1D
+        MAKE_CASE(SCSIOP_MEDIUM_REMOVAL)                // Code 0x1E
+        MAKE_CASE(SCSIOP_READ_FORMATTED_CAPACITY)       // Code 0x23
+        MAKE_CASE(SCSIOP_READ_CAPACITY)                 // Code 0x25
+        MAKE_CASE(SCSIOP_READ)                          // Code 0x28
+        MAKE_CASE(SCSIOP_WRITE)                         // Code 0x2A
+        MAKE_CASE(SCSIOP_SEEK)                          // Code 0x2B, aka SCSIOP_LOCATE, SCSIOP_POSITION_TO_ELEMENT
+        MAKE_CASE(SCSIOP_WRITE_VERIFY)                  // Code 0x2E
+        MAKE_CASE(SCSIOP_VERIFY)                        // Code 0x2F
+        MAKE_CASE(SCSIOP_SEARCH_DATA_HIGH)              // Code 0x30
+        MAKE_CASE(SCSIOP_SEARCH_DATA_EQUAL)             // Code 0x31
+        MAKE_CASE(SCSIOP_SEARCH_DATA_LOW)               // Code 0x32
+        MAKE_CASE(SCSIOP_SET_LIMITS)                    // Code 0x33
+        MAKE_CASE(SCSIOP_READ_POSITION)                 // Code 0x34
+        MAKE_CASE(SCSIOP_SYNCHRONIZE_CACHE)             // Code 0x35
+        MAKE_CASE(SCSIOP_COMPARE)                       // Code 0x39
+        MAKE_CASE(SCSIOP_COPY_COMPARE)                  // Code 0x3A
+        MAKE_CASE(SCSIOP_WRITE_DATA_BUFF)               // Code 0x3B
+        MAKE_CASE(SCSIOP_READ_DATA_BUFF)                // Code 0x3C
+        MAKE_CASE(SCSIOP_WRITE_LONG)                    // Code 0x3F
+        MAKE_CASE(SCSIOP_CHANGE_DEFINITION)             // Code 0x40
+        MAKE_CASE(SCSIOP_WRITE_SAME)                    // Code 0x41
+        MAKE_CASE(SCSIOP_UNMAP)                         // Code 0x42, aka SCSIOP_READ_SUB_CHANNEL
+        MAKE_CASE(SCSIOP_READ_TOC)                      // Code 0x43
+        MAKE_CASE(SCSIOP_READ_HEADER)                   // Code 0x44, aka SCSIOP_REPORT_DENSITY_SUPPORT
+        MAKE_CASE(SCSIOP_PLAY_AUDIO)                    // Code 0x45
+        MAKE_CASE(SCSIOP_GET_CONFIGURATION)             // Code 0x46
+        MAKE_CASE(SCSIOP_PLAY_AUDIO_MSF)                // Code 0x47
+        MAKE_CASE(SCSIOP_SANITIZE)                      // Code 0x48, aka SCSIOP_PLAY_TRACK_INDEX
+        MAKE_CASE(SCSIOP_PLAY_TRACK_RELATIVE)           // Code 0x49
+        MAKE_CASE(SCSIOP_GET_EVENT_STATUS)              // Code 0x4A
+        MAKE_CASE(SCSIOP_PAUSE_RESUME)                  // Code 0x4B
+        MAKE_CASE(SCSIOP_LOG_SELECT)                    // Code 0x4C
+        MAKE_CASE(SCSIOP_LOG_SENSE)                     // Code 0x4D
+        MAKE_CASE(SCSIOP_STOP_PLAY_SCAN)                // Code 0x4E
+        MAKE_CASE(SCSIOP_XDWRITE)                       // Code 0x50
+        MAKE_CASE(SCSIOP_READ_DISC_INFORMATION)         // Code 0x51, aka SCSIOP_XPWRITE
+        MAKE_CASE(SCSIOP_READ_TRACK_INFORMATION)        // Code 0x52
+        MAKE_CASE(SCSIOP_XDWRITE_READ)                  // Code 0x53, aka SCSIOP_RESERVE_TRACK_RZONE
+        MAKE_CASE(SCSIOP_SEND_OPC_INFORMATION)          // Code 0x54
+        MAKE_CASE(SCSIOP_MODE_SELECT10)                 // Code 0x55
+        MAKE_CASE(SCSIOP_RESERVE_ELEMENT)               // Code 0x56, aka SCSIOP_RESERVE_UNIT10
+        MAKE_CASE(SCSIOP_RELEASE_ELEMENT)               // Code 0x57, aka SCSIOP_RELEASE_UNIT10
+        MAKE_CASE(SCSIOP_REPAIR_TRACK)                  // Code 0x58
+        MAKE_CASE(SCSIOP_MODE_SENSE10)                  // Code 0x5A
+        MAKE_CASE(SCSIOP_CLOSE_TRACK_SESSION)           // Code 0x5B
+        MAKE_CASE(SCSIOP_READ_BUFFER_CAPACITY)          // Code 0x5C
+        MAKE_CASE(SCSIOP_SEND_CUE_SHEET)                // Code 0x5D
+        MAKE_CASE(SCSIOP_PERSISTENT_RESERVE_IN)         // Code 0x5E
+        MAKE_CASE(SCSIOP_PERSISTENT_RESERVE_OUT)        // Code 0x5F
+        MAKE_CASE(SCSIOP_OPERATION32)                   // Code 0x7F
+        MAKE_CASE(SCSIOP_XDWRITE_EXTENDED16)            // Code 0x80, aka SCSIOP_WRITE_FILEMARKS16
+        MAKE_CASE(SCSIOP_REBUILD16)                     // Code 0x81, aka SCSIOP_READ_REVERSE16
+        MAKE_CASE(SCSIOP_REGENERATE16)                  // Code 0x82
+        MAKE_CASE(SCSIOP_WRITE_USING_TOKEN)             // Code 0x83, aka SCSIOP_EXTENDED_COPY, SCSIOP_POPULATE_TOKEN
+        MAKE_CASE(SCSIOP_RECEIVE_ROD_TOKEN_INFORMATION) // Code 0x84, aka SCSIOP_RECEIVE_COPY_RESULTS
+        MAKE_CASE(SCSIOP_ATA_PASSTHROUGH16)             // Code 0x85
+        MAKE_CASE(SCSIOP_ACCESS_CONTROL_IN)             // Code 0x86
+        MAKE_CASE(SCSIOP_ACCESS_CONTROL_OUT)            // Code 0x87
+        MAKE_CASE(SCSIOP_READ16)                        // Code 0x88
+        MAKE_CASE(SCSIOP_COMPARE_AND_WRITE)             // Code 0x89
+        MAKE_CASE(SCSIOP_WRITE16)                       // Code 0x8A
+        MAKE_CASE(SCSIOP_READ_ATTRIBUTES)               // Code 0x8C
+        MAKE_CASE(SCSIOP_WRITE_ATTRIBUTES)              // Code 0x8D
+        MAKE_CASE(SCSIOP_WRITE_VERIFY16)                // Code 0x8E
+        MAKE_CASE(SCSIOP_VERIFY16)                      // Code 0x8F
+        MAKE_CASE(SCSIOP_PREFETCH16)                    // Code 0x90
+        MAKE_CASE(SCSIOP_SYNCHRONIZE_CACHE16)           // Code 0x91, aka SCSIOP_SPACE16
+        MAKE_CASE(SCSIOP_LOCK_UNLOCK_CACHE16)           // Code 0x92, aka SCSIOP_LOCATE16
+        MAKE_CASE(SCSIOP_WRITE_SAME16)                  // Code 0x93, aka SCSIOP_ERASE16
+        MAKE_CASE(SCSIOP_ZBC_OUT)                       // Code 0x94
+        MAKE_CASE(SCSIOP_ZBC_IN)                        // Code 0x95
+        MAKE_CASE(SCSIOP_READ_DATA_BUFF16)              // Code 0x9B
+        MAKE_CASE(SCSIOP_GET_LBA_STATUS)                // Code 0x9E, aka SCSIOP_GET_PHYSICAL_ELEMENT_STATUS, SCSIOP_READ_CAPACITY16, SCSIOP_REMOVE_ELEMENT_AND_TRUNCATE, SCSIOP_SERVICE_ACTION_IN16
+        MAKE_CASE(SCSIOP_SERVICE_ACTION_OUT16)          // Code 0x9F
+        MAKE_CASE(SCSIOP_REPORT_LUNS)                   // Code 0xA0
+        MAKE_CASE(SCSIOP_BLANK)                         // Code 0xA1, aka SCSIOP_ATA_PASSTHROUGH12
+        MAKE_CASE(SCSIOP_SEND_EVENT)                    // Code 0xA2
+        MAKE_CASE(SCSIOP_MAINTENANCE_IN)                // Code 0xA3, aka SCSIOP_SEND_KEY
+        MAKE_CASE(SCSIOP_MAINTENANCE_OUT)               // Code 0xA4, aka SCSIOP_REPORT_KEY
+        MAKE_CASE(SCSIOP_MOVE_MEDIUM)                   // Code 0xA5
+        MAKE_CASE(SCSIOP_LOAD_UNLOAD_SLOT)              // Code 0xA6
+        MAKE_CASE(SCSIOP_SET_READ_AHEAD)                // Code 0xA7
+        MAKE_CASE(SCSIOP_READ12)                        // Code 0xA8
+        MAKE_CASE(SCSIOP_SERVICE_ACTION_OUT12)          // Code 0xA9
+        MAKE_CASE(SCSIOP_WRITE12)                       // Code 0xAA
+        MAKE_CASE(SCSIOP_SEND_MESSAGE)                  // Code 0xAB
+        MAKE_CASE(SCSIOP_GET_PERFORMANCE)               // Code 0xAC
+        MAKE_CASE(SCSIOP_READ_DVD_STRUCTURE)            // Code 0xAD
+        MAKE_CASE(SCSIOP_WRITE_VERIFY12)                // Code 0xAE
+        MAKE_CASE(SCSIOP_VERIFY12)                      // Code 0xAF
+        MAKE_CASE(SCSIOP_SEARCH_DATA_HIGH12)            // Code 0xB0
+        MAKE_CASE(SCSIOP_SEARCH_DATA_EQUAL12)           // Code 0xB1
+        MAKE_CASE(SCSIOP_SEARCH_DATA_LOW12)             // Code 0xB2
+        MAKE_CASE(SCSIOP_SET_LIMITS12)                  // Code 0xB3
+        MAKE_CASE(SCSIOP_READ_ELEMENT_STATUS_ATTACHED)  // Code 0xB4
+        MAKE_CASE(SCSIOP_REQUEST_VOL_ELEMENT)           // Code 0xB5, aka SCSIOP_SECURITY_PROTOCOL_OUT
+        MAKE_CASE(SCSIOP_SEND_VOLUME_TAG)               // Code 0xB6
+        MAKE_CASE(SCSIOP_READ_DEFECT_DATA)              // Code 0xB7
+        MAKE_CASE(SCSIOP_READ_ELEMENT_STATUS)           // Code 0xB8
+        MAKE_CASE(SCSIOP_READ_CD_MSF)                   // Code 0xB9
+        MAKE_CASE(SCSIOP_REDUNDANCY_GROUP_IN)           // Code 0xBA
+        MAKE_CASE(SCSIOP_REDUNDANCY_GROUP_OUT)          // Code 0xBB
+        MAKE_CASE(SCSIOP_SPARE_IN)                      // Code 0xBC
+        MAKE_CASE(SCSIOP_SPARE_OUT)                     // Code 0xBD, aka SCSIOP_MECHANISM_STATUS
+        MAKE_CASE(SCSIOP_VOLUME_SET_IN)                 // Code 0xBE
+        MAKE_CASE(SCSIOP_VOLUME_SET_OUT)                // Code 0xBF
+        MAKE_CASE(SCSIOP_INIT_ELEMENT_RANGE)            // Code 0xE7
     }
     return scsiOpStr;
 }

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -896,7 +896,7 @@ HandleResponse(
 
 ENTER_FN();
 
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> %s (%d::%d::%d), SRB 0x%p\n", DbgGetScsiOpStr((PSCSI_REQUEST_BLOCK)Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+    LOG_SRB_INFO();
 
     switch (resp->response) {
     case VIRTIO_SCSI_S_OK:
@@ -1258,7 +1258,7 @@ ENTER_FN_SRB();
         return FALSE;
     }
 
-    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <--> %s (%d::%d::%d), SRB 0x%p\n", DbgGetScsiOpStr(Srb), SRB_PATH_ID(Srb), TargetId, Lun, Srb);
+    LOG_SRB_INFO();
 
     RtlZeroMemory(srbExt, sizeof(*srbExt));
     srbExt->Srb = Srb;
@@ -1491,7 +1491,7 @@ ENTER_FN_SRB();
         case SRB_FUNCTION_RESET_BUS:
         case SRB_FUNCTION_RESET_DEVICE:
         case SRB_FUNCTION_RESET_LOGICAL_UNIT:
-            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> SRB_FUNCTION_RESET_LOGICAL_UNIT (%d::%d::%d), SRB 0x%p\n", SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> SRB_FUNCTION_RESET_LOGICAL_UNIT Target (%d::%d::%d), SRB 0x%p\n", SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
             CompletePendingRequests(DeviceExtension);
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
             return TRUE;

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -896,6 +896,8 @@ HandleResponse(
 
 ENTER_FN();
 
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> %s (%d::%d::%d), SRB 0x%p\n", DbgGetScsiOpStr((PSCSI_REQUEST_BLOCK)Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+
     switch (resp->response) {
     case VIRTIO_SCSI_S_OK:
         SRB_SET_SCSI_STATUS(Srb, resp->status);
@@ -1256,7 +1258,7 @@ ENTER_FN_SRB();
         return FALSE;
     }
 
-    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <--> %s (%d::%d::%d)\n", DbgGetScsiOpStr(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb));
+    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <--> %s (%d::%d::%d), SRB 0x%p\n", DbgGetScsiOpStr(Srb), SRB_PATH_ID(Srb), TargetId, Lun, Srb);
 
     RtlZeroMemory(srbExt, sizeof(*srbExt));
     srbExt->Srb = Srb;
@@ -1463,7 +1465,7 @@ CompletePendingRequests(
         StorPortResume(DeviceExtension);
     }
     else {
-        RhelDbgPrint(TRACE_LEVEL_FATAL, "RESET IN THE PROGRESS !!!!\n");
+        RhelDbgPrint(TRACE_LEVEL_FATAL, " Reset is already in progress, doing nothing.\n");
     }
     adaptExt->reset_in_progress = FALSE;
 }
@@ -1489,7 +1491,7 @@ ENTER_FN_SRB();
         case SRB_FUNCTION_RESET_BUS:
         case SRB_FUNCTION_RESET_DEVICE:
         case SRB_FUNCTION_RESET_LOGICAL_UNIT:
-            RhelDbgPrint(TRACE_LEVEL_VERBOSE, "SRB_FUNCTION_RESET_LOGICAL_UNIT %d::%d::%d\n", SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb));
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> SRB_FUNCTION_RESET_LOGICAL_UNIT (%d::%d::%d), SRB 0x%p\n", SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
             CompletePendingRequests(DeviceExtension);
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
             return TRUE;


### PR DESCRIPTION
This PR is consist of two cosmetic logging improvements:

1. The first one is to slightly change the wording to reflect the current code and make it more comprehensive. Extended the list of SCSI Ops.
2. The second one is to improve SRB tracing with INFORMATION logging level to reduce the noise from ENTER/LEAVE functions (that is logged with VERBSOE level). With this change we start logging SRB info for `VioScsiBuildIo`, `SendSRB` and `HandleResponse` calls. Also extended the list of SCSI Ops from EWDK2022. 

It is the way the log looks like:
```
[0]0004.01D0::08/06/2023-11:18:36.954 [vioscsi.sys] VioScsiBuildIo <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), Target (0::0::2), SRB 0xFFFFCE0C44852980
[0]0004.01D0::08/06/2023-11:18:36.954 [vioscsi.sys] SendSRB <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), TargetId (0::0::2), SRB 0xFFFFCE0C44852980
[0]0000.0000::08/06/2023-11:18:36.955 [vioscsi.sys] HandleResponse <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), Target (0::0::2), SRB 0xFFFFCE0C44852980
[1]0004.01D0::08/06/2023-11:18:36.970 [vioscsi.sys] VioScsiBuildIo <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), Target (0::0::0), SRB 0xFFFFCE0C44853B00
[1]0004.01D0::08/06/2023-11:18:36.970 [vioscsi.sys] SendSRB <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), TargetId (0::0::0), SRB 0xFFFFCE0C44853B00
[1]0000.0000::08/06/2023-11:18:36.970 [vioscsi.sys] HandleResponse <--> Operation SCSIOP_PERSISTENT_RESERVE_IN (0x5E), Target (0::0::0), SRB 0xFFFFCE0C44853B00
```

So with the above change, it is easier to parse the text file when you need to measure IO request time that is spent in the backend. 

Note: trace.h seems to have had CRLF, so when I changed it to LF git thinks it is the change of the whole file, however, the changes in this file are only:
```
#define UCHAR_MAX 0xFF
#define DbgGetScsiOp(Srb) (SRB_CDB(Srb) ? SRB_CDB(Srb)->CDB6GENERIC.OperationCode : UCHAR_MAX)

char *DbgGetScsiOpStr(UCHAR opCode);
...
#define LOG_SRB_INFO() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
...
// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! %!FUNC! <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
// FUNC LOG_SRB_INFO{LEVEL=TRACE_LEVEL_INFORMATION}(...);
```

