### PR TITLE
viosock: fix NtReadFile/NtWriteFile; fix sending large packet sg list

### DIFF
--- a/viosock/lib/native.c
+++ b/viosock/lib/native.c
@@ -255,15 +255,22 @@ VIOSockWriteFile(
     if (lpNumberOfBytesWritten)
         *lpNumberOfBytesWritten = 0;
 
-    status = NtWriteFile((HANDLE)s, NULL, NULL, NULL,
+    HANDLE evt = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!evt) 
+    {
+        return FALSE;
+    }
+
+    status = NtWriteFile((HANDLE)s, evt, NULL, NULL,
         &iosb, lpBuffer, nNumberOfBytesToWrite,
         &liBytesOffset, NULL);
 
     if (status == STATUS_PENDING)
     {
-        WaitForSingleObject((HANDLE)s, INFINITE);
+        WaitForSingleObject(evt, INFINITE);
         status = iosb.Status;
     }
+    CloseHandle(evt);
 
     if (NT_SUCCESS(status))
     {
@@ -297,15 +304,22 @@ VIOSockReadFile(
     if (lpNumberOfBytesRead)
         *lpNumberOfBytesRead = 0;
 
-    status = NtReadFile((HANDLE)s, NULL, NULL, NULL,
+    HANDLE evt = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!evt) 
+    {
+        return FALSE;
+    }
+
+    status = NtReadFile((HANDLE)s, evt, NULL, NULL,
         &iosb, lpBuffer, nNumberOfBytesToRead,
         &liBytesOffset, NULL);
 
     if (status == STATUS_PENDING)
     {
-        WaitForSingleObject((HANDLE)s, INFINITE);
+        WaitForSingleObject(evt, INFINITE);
         status = iosb.Status;
     }
+    CloseHandle(evt);
 
     if (NT_SUCCESS(status))
     {


### PR DESCRIPTION
This PR fixes 2 issues:

1. Wait on a Event instead of the socket itself after calling NtWriteFile()/NtReadFile(), otherwise WaitForSingleObject() may return before the write/read completes, thus returning wrong status to caller. This issue can be reproduced by having a sender thread and a receiver thread running on a socket at the same time, and sometimes send() may return 0 bytes sent, even though the other side can receive the packet.

2. If the first element in SgList is not 4KB, there will be 17 element in SgList for 64KB data, which will cause a stack buffer overrun BSOD. This issue can be reproduced by sending more then 64KB data in one send().