### PR TITLE
viosock: fix CurrentCb BytesToRead setting

### DIFF
--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1445,7 +1445,8 @@ VIOSockReadDequeueCb(
 
             if (!(pRequest->Flags & MSG_PEEK))
             {
-
+                ULONG uBytesToRead = pCurrentCb->BytesToRead;
+                pCurrentCb->BytesToRead = 0;
                 pCurrentItem = pCurrentItem->Blink;
                 RemoveEntryList(&pCurrentCb->ListEntry);
 
@@ -1456,7 +1457,7 @@ VIOSockReadDequeueCb(
                     if (NT_SUCCESS(status))
                     {
                         InsertTailList(&LoopbackList, &pCurrentCb->ListEntry); //complete loopback requests later
-                        VIOSockRxPktDec(pSocket, pCurrentCb->BytesToRead);
+                        VIOSockRxPktDec(pSocket, uBytesToRead);
                     }
                     else
                     {
@@ -1469,10 +1470,9 @@ VIOSockReadDequeueCb(
                 else
                 {
                     VIOSockRxCbPushLocked(pContext, pCurrentCb);
-                    VIOSockRxPktDec(pSocket, pCurrentCb->BytesToRead);
+                    VIOSockRxPktDec(pSocket, uBytesToRead);
                     bProcessRxPktList = TRUE;
                 }
-                pCurrentCb->BytesToRead = 0;
             }
         }
         else //request buffer is not big enough


### PR DESCRIPTION
We should set pCurrentCb->BytesToRead to 0 before calling VIOSockRxCbPushLocked(). Consider following scenario:
1. thread 1 calls VIOSockRxCbPushLocked(), add CurrentCb to RxCbBuffers
2. thread 2 calls VIOSockRxPktInsert(), get the CurrentCb from RxCbBuffers, and uses virtqueue_add_buf() to add the CurrentCb to RxVq
3. thread 2 calls VIOSockRxVqProcess(), get the CurrentCb from virtqueue_get_buf(), and ready to be read from user recv() call
4. thread 1 sets pCurrentCb->BytesToRead to 0, so it modifies the CurrentCb used by thread 2
