### PR TITLE
vioscsi: add DeviceReset on CompletePendingRequests path

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1428,7 +1428,7 @@ CompletePendingRequests(
     )
 {
     PADAPTER_EXTENSION adaptExt;
-    ULONG QueuNum;
+    ULONG QueueNum;
     ULONG MsgId;
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
@@ -1437,13 +1437,14 @@ CompletePendingRequests(
     {
         adaptExt->reset_in_progress = TRUE;
         StorPortPause(DeviceExtension, 10);
+        DeviceReset(DeviceExtension);
 
         for (ULONG index = 0; index < adaptExt->num_queues; index++) {
             PREQUEST_LIST element = &adaptExt->processing_srbs[index];
             STOR_LOCK_HANDLE    LockHandle = { 0 };
-            RhelDbgPrint(TRACE_LEVEL_FATAL, "queue %d cnt %d\n", index, element->srb_cnt);
-            QueuNum = index + VIRTIO_SCSI_REQUEST_QUEUE_0;
-            MsgId = QUEUE_TO_MESSAGE(QueuNum);
+            RhelDbgPrint(TRACE_LEVEL_FATAL, " queue %d cnt %d\n", index, element->srb_cnt);
+            QueueNum = index + VIRTIO_SCSI_REQUEST_QUEUE_0;
+            MsgId = QUEUE_TO_MESSAGE(QueueNum);
             VioScsiVQLock(DeviceExtension, MsgId, &LockHandle, FALSE);
             while (!IsListEmpty(&element->srb_list)) {
                 PLIST_ENTRY entry = RemoveHeadList(&element->srb_list);


### PR DESCRIPTION
We discovered recently that CompletePendingRequests has a flaw when it completes pending paging write IO requests. 

Here are the repro steps that 100% trigger the problem in our lab:
1. Start intensive IO write operations inside the guest.
2. Configure backend storage to *delay* all IO requests for more than 60 seconds. 
3. Wait until the guest gets frozen. 
4. Configure storage not to delay new IOs. 
5. Wait until storport invokes reset handler and vioscsi completes pending SRBs. 
6. Once the backend storage completes IO requests that were delayed, you will get the guest crashing with 0x1A bugcheck. 

```
kd> !analyze -show
MEMORY_MANAGEMENT (1a)
    # Any other values for parameter 1 must be individually examined.
Arguments:
Arg1: 000000000000003f, An inpage operation failed with a CRC error. Parameter 2 contains
	the pagefile offset. Parameter 3 contains the page CRC value.
	Parameter 4 contains the expected CRC value.
Arg2: 0000000000015878
Arg3: 000000002f037e89
Arg4: 00000000c2806dbe

kd> kL
 # Child-SP          RetAddr               Call Site
00 fffff884`144056a8 fffff800`5ddb9fb1     nt!KeBugCheckEx
01 fffff884`144056b0 fffff800`5dc6d563     nt!MiValidatePagefilePageHash+0x241
02 fffff884`14405790 fffff800`5da46b65     nt!MiWaitForInPageComplete+0x2263e3
03 fffff884`14405890 fffff800`5da58f8d     nt!MiIssueHardFault+0x1d5
04 fffff884`14405940 fffff800`5dc3bdb5     nt!MmAccessFault+0x35d
05 fffff884`14405ae0 00007ffe`d4ccc396     nt!KiPageFault+0x335
06 000000e3`2edff270 00000000`00000000     0x00007ffe`d4ccc396
```

With the proposed change, we will send DeviceReset() to notify the host side about the reset. This change is proved to work in the lab on Windows Server 2022. Here is a snippet from storport log: 
```
Storport RaidLogList
    Circular buffer location:  0xffff8406424b38a0
    Total logs written: 12

    Displaying entries 0 through 11
    ---------------------------------------------------------------------
    [0]_[14:30:11.959] UnitTimeOut........... Unit: 0xffff8406425fd1a0
    [1]_[14:30:11.959] PauseDevice........... Caller: storport!RaUnitStartResetIo+0x105 (fffff805`6fe9f485), P/P/T/L: 2/0/0/0, Pause count: 1
    [2]_[14:30:11.959] SpPause(Adapter)...... Caller: vioscsi!CompletePendingRequests+0x3a (fffff805`6fe338fa), Timeout: 10, Adapter: 0xffff8406424b21a0
    [3]_[14:30:11.959] PauseAdapter.......... Caller: storport!StorPortPause+0xa5 (fffff805`6fe8fbe5), Pause count: 1, Adapter: 0xffff8406424b21a0, Port: 2
    [4]_[14:30:11.959] SpPause(Adapter)...... Caller: vioscsi!DeviceReset+0x119 (fffff805`6fe31119), Timeout: 60, Adapter: 0xffff8406424b21a0
    [5]_[14:30:11.959] PauseAdapter.......... Caller: storport!StorPortPause+0xa5 (fffff805`6fe8fbe5), Pause count: 2, Adapter: 0xffff8406424b21a0, Port: 2
    [6]_[14:30:11.959] FailedAllocDefAction.. Caller: vioscsi!DeviceReset+0x119 (fffff805`6fe31119)
    [7]_[14:30:11.959] ResumeAdapter......... Caller: storport!StorPortPause+0x11c (fffff805`6fe8fc5c), Pause count: 1, Adapter: 0xffff8406424b21a0, Port: 2
    [8]_[14:30:11.959] SpResume(Adapter)..... Caller: vioscsi!CompletePendingRequests+0x151 (fffff805`6fe33a11), Adapter: 0xffff8406424b21a0
    [9]_[14:30:11.959] ResumeAdapter......... Caller: storport!RaidAdapterDeferredRoutine+0x294b5 (fffff805`6fe7bed5), Pause count: 0, Adapter: 0xffff8406424b21a0, Port: 2
    [10]_[14:30:11.959] ResumeDevice.......... Caller: storport!RaidUnitCompleteResetRequest+0x91 (fffff805`6fea0a11), P/P/T/L: 2/0/0/0, Pause count: 0, Resumed: True
    [11]_[14:30:15.031] SpResume(Adapter)..... Caller: vioscsi!VioScsiMSInterruptWorker+0x16f (fffff805`6fe372f7), Adapter: 0xffff8406424b21a0
```