### PR TITLE
vioscsi: add logic to make reset mechanism configurable

### DIFF
--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -58,7 +58,8 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define IO_PORT_LENGTH          0x40
 #define MAX_CPU                 256
 
-#define MAX_PH_BREAKS           "PhysicalBreaks"
+#define REGISTRY_MAX_PH_BREAKS           "PhysicalBreaks"
+#define REGISTRY_ACTION_ON_RESET         "VioscsiActionOnReset"
 
 
 /* Feature Bits */
@@ -271,6 +272,12 @@ typedef struct virtio_bar {
     BOOLEAN           bPortSpace;
 } VIRTIO_BAR, *PVIRTIO_BAR;
 
+typedef enum ACTION_ON_RESET {
+    VioscsiResetCompleteRequests,
+    VioscsiResetDoNothing,
+    VioscsiResetBugCheck = 0xDEADDEAD,
+} ACTION_ON_RESET;
+
 typedef struct _ADAPTER_EXTENSION {
     VirtIODevice          vdev;
 
@@ -326,10 +333,11 @@ typedef struct _ADAPTER_EXTENSION {
     UCHAR                 prod_id[16 + 1];
     UCHAR                 rev_id[4 + 1];
     BOOLEAN               reset_in_progress;
+    ACTION_ON_RESET       action_on_reset;
 #if (NTDDI_VERSION >= NTDDI_WINTHRESHOLD)
     ULONGLONG             fw_ver;
 #endif
-}ADAPTER_EXTENSION, * PADAPTER_EXTENSION;
+} ADAPTER_EXTENSION, * PADAPTER_EXTENSION;
 
 #ifndef PCIX_TABLE_POINTER
 typedef struct {


### PR DESCRIPTION
We have seen many cases where we see vioscsi 129 reset events leading to a complete guest hang. While overall reset logic added in https://github.com/virtio-win/kvm-guest-drivers-windows/pull/684 likely mitigates the problem, we still see sporadic requests from customer where they see guest OSes hangs.

This change will make it possible configure system to bugcheck and get a memory dump and the state of the VQs.

By default, the behaviour will remain intact - complete pending SRBs, but can be changed to either to do nothing or bugcheck the guest by setting the registry value.
```
    Path:    HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\vioscsi\Parameters
    Name:    VioscsiActionOnReset
    Type:    REG_DWORD
    Values:
             0x0 - Complete all pending SRBs (default)
             0x1 - Do nothing (all unserved SRBs will be stored in memory)
             0xdeaddead - Bugcheck on the reset event
```
HLK2022 tests completed successfully as expected. 