### PR TITLE
Vioser: Do not wait infinitely when power down or removal is imminent

### DIFF
--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -592,14 +592,14 @@ VIOSerialEvtDeviceD0EntryPostInterruptsEnabled(
     if(!pContext->DeviceOK)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "Sending VIRTIO_CONSOLE_DEVICE_READY 0\n");
-        VIOSerialSendCtrlMsg(WdfDevice, VIRTIO_CONSOLE_BAD_ID, VIRTIO_CONSOLE_DEVICE_READY, 0);
+        VIOSerialSendCtrlMsg(WdfDevice, VIRTIO_CONSOLE_BAD_ID, VIRTIO_CONSOLE_DEVICE_READY, 0, TRUE);
     }
     else
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "Setting VIRTIO_CONFIG_S_DRIVER_OK flag\n");
         VirtIOWdfSetDriverOK(&pContext->VDevice);
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "Sending VIRTIO_CONSOLE_DEVICE_READY 1\n");
-        VIOSerialSendCtrlMsg(WdfDevice, VIRTIO_CONSOLE_BAD_ID, VIRTIO_CONSOLE_DEVICE_READY, 1);
+        VIOSerialSendCtrlMsg(WdfDevice, VIRTIO_CONSOLE_BAD_ID, VIRTIO_CONSOLE_DEVICE_READY, 1, TRUE);
     }
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "<-- %s\n", __FUNCTION__);

--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -165,7 +165,7 @@ VIOSerialInitPortConsoleWork(
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "--> %s\n", __FUNCTION__);
 
-    VIOSerialSendCtrlMsg(pport->BusDevice, pport->PortId, VIRTIO_CONSOLE_PORT_OPEN, 1);
+    VIOSerialSendCtrlMsg(pport->BusDevice, pport->PortId, VIRTIO_CONSOLE_PORT_OPEN, 1, TRUE);
 
     WdfObjectDelete(WorkItem);
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<-- %s\n", __FUNCTION__);
@@ -593,7 +593,7 @@ VIOSerialDeviceListCreatePdo(
     if (!NT_SUCCESS(status))
     {
         // We can send this before PDO is PRESENT since the device won't send any response.
-        VIOSerialSendCtrlMsg(pport->BusDevice, pport->PortId, VIRTIO_CONSOLE_PORT_READY, 0);
+        VIOSerialSendCtrlMsg(pport->BusDevice, pport->PortId, VIRTIO_CONSOLE_PORT_READY, 0, TRUE);
     }
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "<-- %s status 0x%x\n", __FUNCTION__, status);
@@ -918,7 +918,7 @@ VIOSerialPortCreate(
         VIOSerialReclaimConsumedBuffers(pdoData->port);
 
         VIOSerialSendCtrlMsg(pdoData->port->BusDevice, pdoData->port->PortId,
-            VIRTIO_CONSOLE_PORT_OPEN, 1);
+            VIRTIO_CONSOLE_PORT_OPEN, 1, TRUE);
     }
 
     WdfRequestComplete(Request, status);
@@ -942,7 +942,7 @@ VIOSerialPortClose(
     {
         if (pdoData->port->GuestConnected) {
             VIOSerialSendCtrlMsg(pdoData->port->BusDevice,
-                pdoData->port->PortId, VIRTIO_CONSOLE_PORT_OPEN, 0);
+                pdoData->port->PortId, VIRTIO_CONSOLE_PORT_OPEN, 0, TRUE);
         }
 
         WdfSpinLockAcquire(pdoData->port->InBufLock);
@@ -1424,12 +1424,12 @@ NTSTATUS VIOSerialPortEvtDeviceD0Entry(
     }
 
     VIOSerialSendCtrlMsg(port->BusDevice, port->PortId,
-        VIRTIO_CONSOLE_PORT_READY, 1);
+        VIRTIO_CONSOLE_PORT_READY, 1, TRUE);
 
     if (port->GuestConnected)
     {
         VIOSerialSendCtrlMsg(port->BusDevice, port->PortId,
-            VIRTIO_CONSOLE_PORT_OPEN, 1);
+            VIRTIO_CONSOLE_PORT_OPEN, 1, TRUE);
     }
 
     port->Removed = FALSE;
@@ -1460,7 +1460,7 @@ VIOSerialPortEvtDeviceD0Exit(
     if (Port->GuestConnected)
     {
         VIOSerialSendCtrlMsg(Port->BusDevice,
-            Port->PortId, VIRTIO_CONSOLE_PORT_OPEN, 0);
+            Port->PortId, VIRTIO_CONSOLE_PORT_OPEN, 0, (TargetState != WdfPowerDeviceD3Final));
     }
 
     WdfSpinLockAcquire(Port->InBufLock);

--- a/vioserial/sys/vioser.h
+++ b/vioserial/sys/vioser.h
@@ -247,7 +247,8 @@ VIOSerialSendCtrlMsg(
     IN WDFDEVICE hDevice,
     IN ULONG id,
     IN USHORT event,
-    IN USHORT value
+    IN USHORT value,
+    IN BOOLEAN LongWaitAllowed
 );
 
 VOID


### PR DESCRIPTION
This PR prevents the VirtIO Serial Driver from potentially infinitely waiting for the hypervisor when switching to the `WdfPowerDeviceD3Final` power state (that happens when the system is being shut down, or the device is being removed). In such case, the `XxxEvtDeviceD0Exit` callback routine must complete within certain time interval. That is achieved by enhancing `VIOSerialSendCtrlMsg` with an extra parameter determining whether long waits are possible.

