### PR TITLE
vioserial : host connection status set to false when driver exit

### DIFF
--- a/vioserial/sys/Port.c
+++ b/vioserial/sys/Port.c
@@ -1454,6 +1454,7 @@ VIOSerialPortEvtDeviceD0Exit(
         __FUNCTION__, Port->PortId, TargetState - WdfPowerDeviceD0);
 
     Port->Removed = TRUE;
+    Port->HostConnected = FALSE;
 
     VIOSerialDisableInterruptQueue(GetInQueue(Port));
 


### PR DESCRIPTION
In some scenario such as suspend the guest, the host will notify connect close, but the status can not be sync to guest driver,
which will cause a bug while the guest write the seiral before the host connect happend. so it's better just let the connection status to be false rather then true. because the next boot(resume) will enable the connection again