### PR TITLE
virtiolib-WDF: prevent "Safe ejection" of WDF-maintained devices

### DIFF
--- a/VirtIO/WDF/VirtIOWdf.c
+++ b/VirtIO/WDF/VirtIOWdf.c
@@ -47,6 +47,12 @@ NTSTATUS VirtIOWdfInitialize(PVIRTIO_WDF_DRIVER pWdfDriver,
     WDF_DMA_ENABLER_CONFIG dmaEnablerConfig;
     WDF_OBJECT_ATTRIBUTES  attributes;
 
+    // prevent the appearance in "Safely eject" list
+    WDF_DEVICE_PNP_CAPABILITIES caps;
+    WDF_DEVICE_PNP_CAPABILITIES_INIT(&caps);
+    caps.SurpriseRemovalOK = WdfTrue;
+    WdfDeviceSetPnpCapabilities(Device, &caps);
+
     RtlZeroMemory(pWdfDriver, sizeof(*pWdfDriver));
     pWdfDriver->MemoryTag = MemoryTag;
     pWdfDriver->bLegacyMode = FALSE;


### PR DESCRIPTION
This PR is intentionally converted to "draft" one.

https://issues.redhat.com/browse/RHEL-19438
Fixes the behavior for vioinput,vioserial,viosock,viorng,balloon
They will not appear under "Safely remove" even if they are
removable according to PCIe driver indication