### PR TITLE
viosock: Do not inline functions working with spinlocks to paged code

### DIFF
--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -142,6 +142,57 @@ EVT_WDF_TIMER          VIOSockPendedTimerFunc;
 #endif
 
 //////////////////////////////////////////////////////////////////////////
+
+_Requires_lock_not_held_(pSocket->RxLock)
+__declspec(noinline)
+NTSTATUS
+VIOSockPendedRequestGetLocked(
+    IN PSOCKET_CONTEXT  pSocket,
+    OUT WDFREQUEST* Request
+)
+{
+    NTSTATUS status;
+
+    WdfSpinLockAcquire(pSocket->RxLock);
+    status = VIOSockPendedRequestGet(pSocket, Request);
+    WdfSpinLockRelease(pSocket->RxLock);
+
+    return status;
+}
+
+_Requires_lock_not_held_(pSocket->RxLock)
+NTSTATUS
+VIOSockPendedRequestSetLocked(
+    IN PSOCKET_CONTEXT  pSocket,
+    IN WDFREQUEST Request,
+    IN LONGLONG Timeout
+)
+{
+    NTSTATUS status;
+
+    WdfSpinLockAcquire(pSocket->RxLock);
+    status = VIOSockPendedRequestSet(pSocket, Request, Timeout);
+    WdfSpinLockRelease(pSocket->RxLock);
+
+    return status;
+}
+
+_Requires_lock_not_held_(pSocket->RxLock)
+NTSTATUS
+VIOSockPendedRequestSetResumeLocked(
+    IN PSOCKET_CONTEXT  pSocket,
+    IN WDFREQUEST       Request
+)
+{
+    NTSTATUS status;
+
+    WdfSpinLockAcquire(pSocket->RxLock);
+    status = VIOSockPendedRequestSetResume(pSocket, Request);
+    WdfSpinLockRelease(pSocket->RxLock);
+
+    return status;
+}
+
 NTSTATUS
 VIOSockBoundListInit(
     IN WDFDEVICE hDevice

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -409,41 +409,21 @@ VIOSockPendedRequestSetEx(
 #define VIOSockPendedRequestSet(s,r,t) VIOSockPendedRequestSetEx(s,r,t,FALSE)
 
 _Requires_lock_not_held_(pSocket->RxLock)
-__inline
 NTSTATUS
 VIOSockPendedRequestSetLocked(
     IN PSOCKET_CONTEXT  pSocket,
     IN WDFREQUEST Request,
     IN LONGLONG Timeout
-)
-{
-    NTSTATUS status;
-
-    WdfSpinLockAcquire(pSocket->RxLock);
-    status = VIOSockPendedRequestSet(pSocket, Request, Timeout);
-    WdfSpinLockRelease(pSocket->RxLock);
-
-    return status;
-}
+);
 
 #define VIOSockPendedRequestSetResume(s,r) VIOSockPendedRequestSetEx(s,r,0,TRUE)
 
 _Requires_lock_not_held_(pSocket->RxLock)
-__inline
 NTSTATUS
 VIOSockPendedRequestSetResumeLocked(
     IN PSOCKET_CONTEXT  pSocket,
     IN WDFREQUEST       Request
-)
-{
-    NTSTATUS status;
-
-    WdfSpinLockAcquire(pSocket->RxLock);
-    status = VIOSockPendedRequestSetResume(pSocket, Request);
-    WdfSpinLockRelease(pSocket->RxLock);
-
-    return status;
-}
+);
 
 _Requires_lock_held_(pSocket->RxLock)
 NTSTATUS
@@ -452,22 +432,14 @@ VIOSockPendedRequestGet(
     OUT WDFREQUEST      *Request
 );
 
-__inline
+
 _Requires_lock_not_held_(pSocket->RxLock)
+__declspec(noinline)
 NTSTATUS
 VIOSockPendedRequestGetLocked(
     IN PSOCKET_CONTEXT  pSocket,
     OUT WDFREQUEST      *Request
-)
-{
-    NTSTATUS status;
-
-    WdfSpinLockAcquire(pSocket->RxLock);
-    status = VIOSockPendedRequestGet(pSocket, Request);
-    WdfSpinLockRelease(pSocket->RxLock);
-
-    return status;
-}
+);
 
 NTSTATUS
 VIOSockAcceptInitSocket(


### PR DESCRIPTION
Spin locks are operated at IRQL >= `DISPATCH_LEVEL`, thus, such code must not be paged. Otherwise, it can be paged out during its execution which provides the user with a `IRQL_NOT_LESS_OR_EQUAL` bug check. Virtio Socket driver wraps some of its spinlock usage into several inline functions:
- `VIOSockPendedRequestSetLocked`,
- `VIOSockPendedRequestSetResumeLocked`,
- `VIOSockPendedRequestGetLocked`.

However, these functions are than called from routines marked as pageable code which can trigger the bug check. This commit makes the functions not inline, thus, making them reside in nonpaged memory.