### PR TITLE
netkvm: filter RX packets as early as possible

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -1462,63 +1462,6 @@ VOID ParaNdis_OnShutdown(PARANDIS_ADAPTER *pContext)
     pContext->m_StateMachine.NotifyShutdown();
 }
 
-static ULONG ShallPassPacket(PARANDIS_ADAPTER *pContext, PNET_PACKET_INFO pPacketInfo)
-{
-    ULONG i;
-
-    if (pPacketInfo->dataLength > pContext->MaxPacketSize.nMaxFullSizeOsRx + ETH_PRIORITY_HEADER_SIZE)
-        return FALSE;
-
-    if ((pPacketInfo->dataLength > pContext->MaxPacketSize.nMaxFullSizeOsRx) && !pPacketInfo->hasVlanHeader)
-        return FALSE;
-
-    if (IsVlanSupported(pContext) && pPacketInfo->hasVlanHeader)
-    {
-        if (pContext->VlanId && pContext->VlanId != pPacketInfo->Vlan.VlanId)
-        {
-            return FALSE;
-        }
-    }
-
-    if (pContext->PacketFilter & NDIS_PACKET_TYPE_PROMISCUOUS)
-        return TRUE;
-
-    if(pPacketInfo->isUnicast)
-    {
-        ULONG Res;
-
-        if(!(pContext->PacketFilter & NDIS_PACKET_TYPE_DIRECTED))
-            return FALSE;
-
-        ETH_COMPARE_NETWORK_ADDRESSES_EQ_SAFE(pPacketInfo->ethDestAddr, pContext->CurrentMacAddress, &Res);
-        return !Res;
-    }
-
-    if(pPacketInfo->isBroadcast)
-        return (pContext->PacketFilter & NDIS_PACKET_TYPE_BROADCAST);
-
-    // Multi-cast
-
-    if(pContext->PacketFilter & NDIS_PACKET_TYPE_ALL_MULTICAST)
-        return TRUE;
-
-    if(!(pContext->PacketFilter & NDIS_PACKET_TYPE_MULTICAST))
-        return FALSE;
-
-    for (i = 0; i < pContext->MulticastData.nofMulticastEntries; i++)
-    {
-        ULONG Res;
-        PUCHAR CurrMcastAddr = &pContext->MulticastData.MulticastList[i*ETH_ALEN];
-
-        ETH_COMPARE_NETWORK_ADDRESSES_EQ_SAFE(pPacketInfo->ethDestAddr, CurrMcastAddr, &Res);
-
-        if(!Res)
-            return TRUE;
-    }
-
-    return FALSE;
-}
-
 static __inline
 CCHAR GetReceiveQueueForCurrentCPU(PARANDIS_ADAPTER *pContext)
 {
@@ -1599,7 +1542,7 @@ static void ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
     {
         PNET_PACKET_INFO pPacketInfo = &pBufferDescriptor->PacketInfo;
 
-        if(ParaNdis_IsTxRxPossible(pContext) && ShallPassPacket(pContext, pPacketInfo))
+        if(ParaNdis_IsTxRxPossible(pContext))
         {
             UINT nCoalescedSegmentsCount;
             PNET_BUFFER_LIST packet = ParaNdis_PrepareReceivedPacket(pContext, pBufferDescriptor, &nCoalescedSegmentsCount);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-20575

Currently the driver get RX descriptor from the rx virtQ, analyses it (L2/L3), calculates hash and delivers to the proper RSS queue. Later it extract the packet from the RSS queue and checks whether it passes RX filters.
Now we move the filtering to the earliest stage - just after basic analysis.
Note that in case of vhost there are no receive filters configured by the host and typically the host does not work in promiscuous mode, so it is redundant to calculate the hash and trigger the RSS queue for packets that should be dropped.