### PR TITLE
[viofs] Fix MDL structure memory leak

### DIFF
--- a/viofs/pci/viofs.c
+++ b/viofs/pci/viofs.c
@@ -238,6 +238,7 @@ void FreeVirtFsRequest(IN PVIRTIO_FS_REQUEST Request)
     if (Request->InputBuffer != NULL)
     {
         MmFreePagesFromMdl(Request->InputBuffer);
+        ExFreePool(Request->InputBuffer);
         Request->InputBuffer = NULL;
         Request->InputBufferLength = 0;
     }
@@ -245,6 +246,7 @@ void FreeVirtFsRequest(IN PVIRTIO_FS_REQUEST Request)
     if (Request->OutputBuffer != NULL)
     {
         MmFreePagesFromMdl(Request->OutputBuffer);
+        ExFreePool(Request->OutputBuffer);
         Request->OutputBuffer = NULL;
         Request->OutputBufferLength = 0;
     }


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-19069
Resolves: https://github.com/virtio-win/kvm-guest-drivers-windows/issues/1004

Remarks from https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex

The caller must use MmFreePagesFromMdl to release the memory pages that are described by an MDL that was created by MmAllocatePagesForMdlEx. After calling MmFreePagesFromMdl, the caller must also call ExFreePool to release the memory that is allocated for the MDL structure.