### PR TITLE
[netkvm] add a workaround for rx packet loss

### DIFF
--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -22,6 +22,8 @@ public:
         ReuseReceiveBufferNoLock(pBuffersDescriptor);
     }
 
+    BOOLEAN IsRxBuffersShortage() { return m_NetNofReceiveBuffers < m_MinRxBufferLimit; }
+
     VOID ProcessRxRing(CCHAR nCurrCpuReceiveQueue);
 
     BOOLEAN RestartQueue();
@@ -42,6 +44,7 @@ private:
     /* list of Rx buffers available for data (under VIRTIO management) */
     LIST_ENTRY              m_NetReceiveBuffers;
     UINT                    m_NetNofReceiveBuffers;
+    UINT                    m_MinRxBufferLimit;
 
     UINT m_nReusedRxBuffersCounter, m_nReusedRxBuffersLimit = 0;
 

--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -106,6 +106,7 @@ typedef struct _tagConfigurationEntries
     tConfigurationEntry USOv4Supported;
     tConfigurationEntry USOv6Supported;
 #endif
+    tConfigurationEntry MinRxBufferPercent;
 }tConfigurationEntries;
 
 static const tConfigurationEntries defaultConfiguration =
@@ -143,6 +144,7 @@ static const tConfigurationEntries defaultConfiguration =
     { "*UsoIPv4", 1, 0, 1},
     { "*UsoIPv6", 1, 0, 1},
 #endif
+    { "MinRxBufferPercent", PARANDIS_MIN_RX_BUFFER_PERCENT_DEFAULT, 0, 100},
 };
 
 static void ParaNdis_ResetVirtIONetDevice(PARANDIS_ADAPTER *pContext)
@@ -276,6 +278,7 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             GetConfigurationEntry(cfg, &pConfiguration->USOv4Supported);
             GetConfigurationEntry(cfg, &pConfiguration->USOv6Supported);
 #endif
+            GetConfigurationEntry(cfg, &pConfiguration->MinRxBufferPercent);
 
             bDebugPrint = pConfiguration->isLogEnabled.ulValue;
             virtioDebugLevel = pConfiguration->debugLevel.ulValue;
@@ -285,6 +288,7 @@ static void ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             pContext->uNumberOfHandledRXPacketsInDPC = pConfiguration->NumberOfHandledRXPacketsInDPC.ulValue;
             pContext->bDoSupportPriority = pConfiguration->PrioritySupport.ulValue != 0;
             pContext->Offload.flagsValue = 0;
+            pContext->MinRxBufferPercent = pConfiguration->MinRxBufferPercent.ulValue;
             // TX caps: 1 - TCP, 2 - UDP, 4 - IP, 8 - TCPv6, 16 - UDPv6
             if (pConfiguration->OffloadTxChecksum.ulValue & 1) pContext->Offload.flagsValue |= osbT4TcpChecksum | osbT4TcpOptionsChecksum;
             if (pConfiguration->OffloadTxChecksum.ulValue & 2) pContext->Offload.flagsValue |= osbT4UdpChecksum;
@@ -1528,7 +1532,7 @@ UpdateReceiveFailStatistics(PPARANDIS_ADAPTER pContext, UINT nCoalescedSegmentsC
     pContext->Statistics.ifInDiscards += nCoalescedSegmentsCount;
 }
 
-static void ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
+static BOOLEAN ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
                                 PULONG pnPacketsToIndicateLeft,
                                 PPARANDIS_RECEIVE_QUEUE pTargetReceiveQueue,
                                 PNET_BUFFER_LIST *indicate,
@@ -1536,6 +1540,7 @@ static void ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
                                 ULONG *nIndicate)
 {
     pRxNetDescriptor pBufferDescriptor;
+    BOOLEAN isRxBufferShortage = FALSE;
 
     while( (*pnPacketsToIndicateLeft > 0) &&
             (NULL != (pBufferDescriptor = ReceiveQueueGetBuffer(pTargetReceiveQueue))) )
@@ -1562,6 +1567,9 @@ static void ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
                 NET_BUFFER_LIST_NEXT_NBL(*indicateTail) = NULL;
                 (*pnPacketsToIndicateLeft)--;
                 (*nIndicate)++;
+
+                if (!isRxBufferShortage)
+                    isRxBufferShortage = pBufferDescriptor->Queue->IsRxBuffersShortage();
             }
             else
             {
@@ -1575,6 +1583,7 @@ static void ProcessReceiveQueue(PARANDIS_ADAPTER *pContext,
             pBufferDescriptor->Queue->ReuseReceiveBuffer(pBufferDescriptor);
         }
     }
+    return isRxBufferShortage;
 }
 
 
@@ -1610,6 +1619,7 @@ BOOLEAN RxDPCWorkBody(PARANDIS_ADAPTER *pContext, CPUPathBundle *pathBundle, ULO
     ULONG nIndicate;
 
     CCHAR CurrCpuReceiveQueue = GetReceiveQueueForCurrentCPU(pContext);
+    BOOLEAN isRxBufferShortage = FALSE;
 
     indicate = nullptr;
     indicateTail = nullptr;
@@ -1626,7 +1636,7 @@ BOOLEAN RxDPCWorkBody(PARANDIS_ADAPTER *pContext, CPUPathBundle *pathBundle, ULO
 
         if (rxPathOwner)
         {
-            ProcessReceiveQueue(pContext, &nPacketsToIndicate, &pathBundle->rxPath.UnclassifiedPacketsQueue(),
+            isRxBufferShortage = ProcessReceiveQueue(pContext, &nPacketsToIndicate, &pathBundle->rxPath.UnclassifiedPacketsQueue(),
                                 &indicate, &indicateTail, &nIndicate);
         }
     }
@@ -1634,7 +1644,7 @@ BOOLEAN RxDPCWorkBody(PARANDIS_ADAPTER *pContext, CPUPathBundle *pathBundle, ULO
 #ifdef PARANDIS_SUPPORT_RSS
     if (CurrCpuReceiveQueue != PARANDIS_RECEIVE_NO_QUEUE)
     {
-        ProcessReceiveQueue(pContext, &nPacketsToIndicate, &pContext->ReceiveQueues[CurrCpuReceiveQueue],
+        isRxBufferShortage = ProcessReceiveQueue(pContext, &nPacketsToIndicate, &pContext->ReceiveQueues[CurrCpuReceiveQueue],
                             &indicate, &indicateTail, &nIndicate);
         res |= ReceiveQueueHasBuffers(&pContext->ReceiveQueues[CurrCpuReceiveQueue]);
     }
@@ -1644,8 +1654,27 @@ BOOLEAN RxDPCWorkBody(PARANDIS_ADAPTER *pContext, CPUPathBundle *pathBundle, ULO
     {
         if(pContext->m_RxStateMachine.RegisterOutstandingItems(nIndicate))
         {
-            NdisMIndicateReceiveNetBufferLists(pContext->MiniportHandle,
-                                                indicate, 0, nIndicate, NDIS_RECEIVE_FLAGS_DISPATCH_LEVEL);
+            if (!isRxBufferShortage)
+            {
+                NdisMIndicateReceiveNetBufferLists(pContext->MiniportHandle,
+                    indicate, 0, nIndicate,
+                    NDIS_RECEIVE_FLAGS_DISPATCH_LEVEL);
+            }
+            else
+            {
+                /* If the number of available RX buffers is insufficient, we set the
+                NDIS_RECEIVE_FLAGS_RESOURCES flag so that the RX buffers can be immediately
+                reclaimed once the call to NdisMIndicateReceiveNetBufferLists returns. */
+
+                NdisMIndicateReceiveNetBufferLists(pContext->MiniportHandle,
+                    indicate, 0, nIndicate,
+                    NDIS_RECEIVE_FLAGS_DISPATCH_LEVEL | NDIS_RECEIVE_FLAGS_RESOURCES);
+
+                NdisInterlockedAddLargeStatistic(&pContext->extraStatistics.rxIndicatesWithResourcesFlag, nIndicate);
+                ParaNdis_ReuseRxNBLs(indicate);
+                pContext->m_RxStateMachine.UnregisterOutstandingItems(nIndicate);
+            }
+            NdisInterlockedAddLargeStatistic(&pContext->extraStatistics.totalRxIndicates, nIndicate);
         }
         else
         {

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -203,6 +203,8 @@ struct CPUPathBundle : public CPlacementAllocatable {
 
 #define PARANDIS_UNLIMITED_PACKETS_TO_INDICATE  (~0ul)
 
+#define PARANDIS_MIN_RX_BUFFER_PERCENT_DEFAULT 0
+
 static const ULONG PARANDIS_PACKET_FILTERS =
     NDIS_PACKET_TYPE_DIRECTED |
     NDIS_PACKET_TYPE_MULTICAST |
@@ -445,6 +447,7 @@ struct _PARANDIS_ADAPTER : public CNdisAllocatable<_PARANDIS_ADAPTER, 'DCTX'>
     ULONG                   ulCurrentVlansFilterSet = false;
     tMulticastData          MulticastData = {};
     UINT                    uNumberOfHandledRXPacketsInDPC = 0;
+    UINT                    MinRxBufferPercent;
     LONG                    counterDPCInside = 0;
     ULONG                   ulPriorityVlanSetting = 0;
     ULONG                   VlanId = 0;
@@ -483,6 +486,9 @@ struct _PARANDIS_ADAPTER : public CNdisAllocatable<_PARANDIS_ADAPTER, 'DCTX'>
         ULONG framesRSSError;
         ULONG minFreeTxBuffers;
         ULONG droppedTxPackets;
+        ULONG minFreeRxBuffers;
+        LARGE_INTEGER totalRxIndicates;
+        LARGE_INTEGER rxIndicatesWithResourcesFlag;
     } extraStatistics = {};
 
     /* initial number of free Tx descriptor(from cfg) - max number of available Tx descriptors */

--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -205,6 +205,13 @@ HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "2",    0,      %Rx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "1",    0,      %Tx%
 HKR, Ndi\Params\*UDPChecksumOffloadIPv6\enum,   "0",    0,      %Disable%
 
+HKR, Ndi\params\MinRxBufferPercent,         ParamDesc,  0,          %MinRxBufferPercent%
+HKR, Ndi\params\MinRxBufferPercent,         type,       0,          "int"
+HKR, Ndi\params\MinRxBufferPercent,         default,    0,          "0"
+HKR, Ndi\params\MinRxBufferPercent,         min,        0,          "0"
+HKR, Ndi\params\MinRxBufferPercent,         max,        0,          "100"
+HKR, Ndi\params\MinRxBufferPercent,         step,       0,          "1"
+
 [kvmnet6.CopyFiles]
 netkvm.sys,,,2
 
@@ -290,6 +297,7 @@ TCPUDPAll = "TCP/UDP(v4,v6)"
 All = "All"
 IPv4 = "IPv4"
 Maximal = "Maximal"
+MinRxBufferPercent = "MinRxBufferPercent"
 
 [kvmnet6.Reg] 
 HKR,    ,                         BusNumber,           0, "0"

--- a/NetKVM/wlh/ParaNdis6_Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6_Oid.cpp
@@ -405,13 +405,16 @@ static NDIS_STATUS OnSetVendorSpecific1(PARANDIS_ADAPTER *pContext, tOidDesc *pO
 static NDIS_STATUS OnSetVendorSpecific2(PARANDIS_ADAPTER *pContext, tOidDesc *pOid)
 {
     ULONG dummy = 0;
+    ULONG oldMinFreeRxBuffers;
     NDIS_STATUS status;
     status = ParaNdis_OidSetCopy(pOid, &dummy, sizeof(dummy));
 
     // do not clear this minFreeTxBuffers
     dummy = pContext->extraStatistics.minFreeTxBuffers;
+    oldMinFreeRxBuffers = pContext->extraStatistics.minFreeRxBuffers;
     RtlZeroMemory(&pContext->extraStatistics, sizeof(pContext->extraStatistics));
     pContext->extraStatistics.minFreeTxBuffers = dummy;
+    pContext->extraStatistics.minFreeRxBuffers = oldMinFreeRxBuffers;
     return status;
 }
 


### PR DESCRIPTION
Implemented a workaround for rx packet loss encountered with TCP_NODELAY. By default, this feature is turned off to minimize the impact on CPU performance and network bandwidth.

To activate the feature, go to the network card properties and set the MinRxBufferPercent to a value above 0. A good starting point is to set MinRxBufferPercent to 25% and then monitor for any packet loss. If packet loss continues, incrementally adjust the value to 50%, then 75%, and if necessary, up to the maximum of 100%.

In extreme cases, it may be required to not only adjust the  MinRxBufferPercent but also to increase the number of queues and the size of each queue (queue_size).

It is important to note that this feature is only applicable to rx packet loss.

For more details, see [this thread](https://github.com/virtio-win/kvm-guest-drivers-windows/issues/1012).