### PR TITLE
RHEL-22354: netkvm: request to respawn the DPC if TX queue is not empty

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -782,6 +782,9 @@ bool CParaNdisTX::DoPendingTasks(CNBL *nblHolder)
                 m_VirtQueue.ProcessTXCompletions(nbToFree);
                 bRestartQueueStatus = SendMapped(true, completedNBLs);
             }
+
+            bRestartQueueStatus |= !m_SendQueue.IsEmpty();
+
         } else
         {
             // the call initiated by Send(), we can give up


### PR DESCRIPTION
In the crash of Mini6RSSSendRecv test found a situation when there is one packet is still in the SendQueue when the protocol driver waits for unfinished packet completion. Try to solve it by requesting additional DPC also in case when the TX queue is not empty (currently we request it only when there are completed packets in Tx queue and we can't enable interrupts for the queue).