### PR TITLE
[virtio] RHEL-23315: Remove legacy DMA code in the WDF library

### DIFF
--- a/VirtIO/WDF/VirtIOWdf.c
+++ b/VirtIO/WDF/VirtIOWdf.c
@@ -49,7 +49,6 @@ NTSTATUS VirtIOWdfInitialize(PVIRTIO_WDF_DRIVER pWdfDriver,
 
     RtlZeroMemory(pWdfDriver, sizeof(*pWdfDriver));
     pWdfDriver->MemoryTag = MemoryTag;
-    pWdfDriver->bLegacyMode = FALSE;
 
     /* get the PCI bus interface */
     status = WdfFdoQueryForInterface(

--- a/VirtIO/WDF/VirtIOWdf.h
+++ b/VirtIO/WDF/VirtIOWdf.h
@@ -61,7 +61,7 @@ typedef struct virtio_wdf_driver {
     WDFDMAENABLER           DmaEnabler;
     WDFCOLLECTION           MemoryBlockCollection;
     WDFSPINLOCK             DmaSpinlock;
-    BOOLEAN                 bLegacyMode;
+
     
 } VIRTIO_WDF_DRIVER, *PVIRTIO_WDF_DRIVER;
 


### PR DESCRIPTION
Solves: https://issues.redhat.com/browse/RHEL-23315

There is unused code in the WDF library. Cleaning as part of the effort to remove pre-Win10 code from the code base.