### PR TITLE
viogpu: Fix recursive includes

### DIFF
--- a/viogpu/common/baseobj.cpp
+++ b/viogpu/common/baseobj.cpp
@@ -1,4 +1,5 @@
 #include "baseobj.h"
+#include "viogpu.h"
 
 _When_((PoolType & NonPagedPoolMustSucceed) != 0,
     __drv_reportError("Must succeed pool allocations are forbidden. "

--- a/viogpu/common/bitops.cpp
+++ b/viogpu/common/bitops.cpp
@@ -1,4 +1,6 @@
 #include "bitops.h"
+#include "viogpu.h"
+
 #if !DBG
 #include "bitops.tmh"
 #endif

--- a/viogpu/common/helper.h
+++ b/viogpu/common/helper.h
@@ -65,10 +65,6 @@ extern "C" {
     #include <dispmprt.h>
 
     #include "trace.h"
-    #include "virtio_pci.h"
-    #include "viogpu_pci.h"
-    #include "viogpu_idr.h"
-    #include "viogpum.h"
 }
 
 #define MAX_CHILDREN               1
@@ -84,8 +80,6 @@ extern "C" {
 #define NOM_HEIGHT_SIZE            768
 
 #define VIOGPUTAG                  'OIVg'
-
-extern VirtIOSystemOps VioGpuSystemOps;
 
 #define VIOGPU_LOG_ASSERTION0(Msg) NT_ASSERT(FALSE)
 #define VIOGPU_LOG_ASSERTION1(Msg,Param1) NT_ASSERT(FALSE)

--- a/viogpu/common/viogpu.h
+++ b/viogpu/common/viogpu.h
@@ -29,7 +29,17 @@
 
 #pragma once
 #include "helper.h"
-#include "virtio.h"
+
+extern "C" {
+    #include "virtio_pci.h"
+    #include "virtio.h"
+}
+
+#include "viogpu_pci.h"
+#include "viogpu_idr.h"
+#include "viogpum.h"
+
+extern VirtIOSystemOps VioGpuSystemOps;
 
 enum virtio_gpu_ctrl_type {
     VIRTIO_GPU_UNDEFINED = 0,

--- a/viogpu/common/viogpu_idr.cpp
+++ b/viogpu/common/viogpu_idr.cpp
@@ -27,7 +27,7 @@
  * SUCH DAMAGE.
  */
 
-#include "helper.h"
+#include "viogpu.h"
 #include "baseobj.h"
 #if !DBG
 #include "viogpu_idr.tmh"

--- a/viogpu/common/viogpu_idr.h
+++ b/viogpu/common/viogpu_idr.h
@@ -27,7 +27,6 @@
  * SUCH DAMAGE.
  */
 #pragma once
-#include "helper.h"
 
 class VioGpuIdr
 {

--- a/viogpu/common/viogpu_pci.cpp
+++ b/viogpu/common/viogpu_pci.cpp
@@ -22,7 +22,6 @@
   * the COPYING file in the top-level directory.
   *
  **********************************************************************/
-#include "helper.h"
 #include "viogpu.h"
 #include "..\viogpudo\viogpudo.h"
 #if !DBG

--- a/viogpu/common/viogpu_pci.h
+++ b/viogpu/common/viogpu_pci.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "helper.h"
 
 #define REDHAT_PCI_VENDOR_ID       0x1AF4
 

--- a/viogpu/common/viogpu_queue.h
+++ b/viogpu/common/viogpu_queue.h
@@ -28,7 +28,6 @@
  */
 
 #pragma once
-#include "helper.h"
 #include "viogpu.h"
 
 #pragma pack(1)

--- a/viogpu/viogpudo/viogpudo.h
+++ b/viogpu/viogpudo/viogpudo.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#include "helper.h"
+#include "viogpu.h"
 #include "viogpu_queue.h"
 
 #pragma pack(push)


### PR DESCRIPTION
Currently there are several includes that cause recursive including - it still works because of include guards but it's not good idea for this to happen in first place and sometimes it can cause quite puzzling errors.

Some examples:
* helper.h -> viogpu_pci.h -> helper.h
* helper.h -> viogpu_idr.h -> helper.h
