### PR TITLE
viogpu: Decouple DBG from WPP

### DIFF
--- a/viogpu/common/bitops.cpp
+++ b/viogpu/common/bitops.cpp
@@ -1,5 +1,5 @@
 #include "bitops.h"
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "bitops.tmh"
 #endif
 

--- a/viogpu/common/viogpu_idr.cpp
+++ b/viogpu/common/viogpu_idr.cpp
@@ -29,7 +29,7 @@
 
 #include "helper.h"
 #include "baseobj.h"
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "viogpu_idr.tmh"
 #endif
 

--- a/viogpu/common/viogpu_pci.cpp
+++ b/viogpu/common/viogpu_pci.cpp
@@ -25,7 +25,7 @@
 #include "helper.h"
 #include "viogpu.h"
 #include "..\viogpudo\viogpudo.h"
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "viogpu_pci.tmh"
 #endif
 

--- a/viogpu/common/viogpu_queue.cpp
+++ b/viogpu/common/viogpu_queue.cpp
@@ -29,7 +29,7 @@
 
 #include "viogpu_queue.h"
 #include "baseobj.h"
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "viogpu_queue.tmh"
 #endif
 

--- a/viogpu/viogpudo/driver.cpp
+++ b/viogpu/viogpudo/driver.cpp
@@ -32,7 +32,7 @@
 #include "helper.h"
 #include "baseobj.h"
 
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "driver.tmh"
 #endif
 

--- a/viogpu/viogpudo/trace.h
+++ b/viogpu/viogpudo/trace.h
@@ -2,6 +2,7 @@
 #include "kdebugprint.h"
 
 //#define DBG 1
+#define EVENT_TRACING 1
 
 #ifndef TRACE_LEVEL_INFORMATION
 #define TRACE_LEVEL_NONE        0   // Tracing is not on
@@ -31,6 +32,7 @@
 #define VioGpuDbgBreak()\
     if (KD_DEBUGGER_ENABLED && !KD_DEBUGGER_NOT_PRESENT && bBreakAlways) DbgBreakPoint();
 
+#undef EVENT_TRACING // DBG build excludes WPP
 #define WPP_INIT_TRACING(driver, regpath)  InitializeDebugPrints(driver, regpath);
 #define WPP_CLEANUP(driver)
 #else
@@ -64,5 +66,13 @@
 // DbgPrint{FLAG = TRACE_ALL}(LEVEL, (MSG, ...));
 // end_wpp
 //
+
+#ifndef EVENT_TRACING
+
+#define WPP_INIT_TRACING(driver, regpath)
+#define WPP_CLEANUP(driver)
+#define DbgPrint
+
+#endif
 
 #endif

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -35,7 +35,7 @@
 #include "viogpum.h"
 #include "edid.h"
 
-#if !DBG
+#if defined(EVENT_TRACING)
 #include "viogpudo.tmh"
 #endif
 
@@ -3411,6 +3411,8 @@ BOOLEAN VioGpuAdapter::CreateCursor(_In_ CONST DXGKARG_SETPOINTERSHAPE* pSetPoin
     UINT resid, format, size;
     VioGpuObj* obj;
     PAGED_CODE();
+    (void)pSetPointerShape; // unused
+    (void)pCurrentMode; // unused
     DbgPrint(TRACE_LEVEL_INFORMATION, ("---> %s - %d: (%d x %d - %d) (%d + %d)\n", __FUNCTION__, m_Id,
         pSetPointerShape->Width, pSetPointerShape->Height, pSetPointerShape->Pitch, pSetPointerShape->XHot, pSetPointerShape->YHot));
 


### PR DESCRIPTION
Previously `!DBG` meant event tracing which can be confusing.

Now with this PR it's possible to build these combinations:
* `DBG 1` - debug build
* `EVENT_TRACING 1` - WPP build (default)
* neither
