### PR TITLE
Set TargetOSVersion in INF for Windows 11

### DIFF
--- a/Tools/Driver.Common.props
+++ b/Tools/Driver.Common.props
@@ -41,6 +41,7 @@ Common property definitions used by all drivers:
 
   <PropertyGroup Condition="'$(WIN10_INF_DIFX_COMPAT)'=='' OR '$(WIN10_INF_DIFX_COMPAT)'=='0'">
     <INF_ARCH_FOR_WIN10>10.0</INF_ARCH_FOR_WIN10>
+    <INF_ARCH_FOR_WIN11>10.0...16299</INF_ARCH_FOR_WIN11>
   </PropertyGroup>
 
   <!-- _NT_TARGET_MAJ is one of the components of driver version (always reflects target OS version) -->
@@ -57,7 +58,7 @@ Common property definitions used by all drivers:
     <_NT_TARGET_MAJ>100</_NT_TARGET_MAJ>
     <TargetOS>Win11</TargetOS>
 	  <DriverTargetPlatform>Universal</DriverTargetPlatform>
-    <InfArch>$(TargetArch).$(INF_ARCH_FOR_WIN10)</InfArch>
+    <InfArch>$(TargetArch).$(INF_ARCH_FOR_WIN11)</InfArch>
   </PropertyGroup>
 
 


### PR DESCRIPTION
HLK for Server 2025 fail INF Verification with the error:

The syntax 'DIRID 13 (CopyFiles)' was introduced in OS version 10.0.16299, but DDInstall sections utilizing the syntax will install on earlier OS versions. Those DDInstall sections should be restricted to only install on 10.0.16299 or higher using a TargetOSVersion decoration.

As Windows 10 before build 16299 is EOL and we don't support it. This is ok, to have DIRID 13 in Windows 10 INF without TargetOSVersion decoration.

Resolve: https://issues.redhat.com/browse/RHEL-1214