### PR TITLE
Viosock: Implement Advanced Calls for the WSK Interface

### DIFF
--- a/viosock/viosock-wsk-test/test-messages.h
+++ b/viosock/viosock-wsk-test/test-messages.h
@@ -39,23 +39,29 @@
 
 #define VIOWSK_MSG_SIZE						64
 
+typedef struct _VIOWSK_MSG_HASH_OBJECT {
+	PVOID HashObject;
+	BCRYPT_HASH_HANDLE HashHandle;
+} VIOWSK_MSG_HASH_OBJECT, *PVIOWSK_MSG_HASH_OBJECT;
+
+
 NTSTATUS
 VioWskMessageGenerate(
-	_In_opt_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_Inout_opt_ PVIOWSK_MSG_HASH_OBJECT HashObject,
 	_Out_ PWSK_BUF WskBuffer,
 	_Out_ PVOID* FlatBuffer
 );
 
 NTSTATUS
 VIoWskMessageVerify(
-	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ PVIOWSK_MSG_HASH_OBJECT HashObject,
 	_In_ const WSK_BUF* WskBuf,
 	_Out_ PBOOLEAN Verified
 );
 
 NTSTATUS
 VIoWskMessageVerifyBuffer(
-	_In_ BCRYPT_HASH_HANDLE SHA256Handle,
+	_In_ PVIOWSK_MSG_HASH_OBJECT HashObject,
 	_In_ const void* Buffer,
 	_Out_ PBOOLEAN Verified
 );
@@ -72,6 +78,26 @@ VioWskMessageFree(
 	_In_opt_ PVOID FlatBuffer
 );
 
+NTSTATUS
+VioWskMessageCreateHashObject(
+	_Out_ PVIOWSK_MSG_HASH_OBJECT Object
+);
+
+NTSTATUS
+VioWskMessageRefreshHashObject(
+	_Inout_ PVIOWSK_MSG_HASH_OBJECT Object
+);
+
+void
+VIoWskMessageDestroyHashObject(
+	_In_ PVIOWSK_MSG_HASH_OBJECT Object
+);
+
+NTSTATUS
+VioWskMessageModuleInit();
+
+void
+VioWskMessageModuleFinit();
 
 
 

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -953,21 +953,18 @@ VioWskSendEx(
     PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
     DEBUG_ENTER_FUNCTION("Socket=0x%p; Buffer=0x%p; Flags=0x%x; ControlInfoLength=%u; ControlInfo=0x%p; Irp=0x%p", Socket, Buffer, Flags, ControlInfoLength, ControlInfo, Irp);
 
-    UNREFERENCED_PARAMETER(Buffer);
-    UNREFERENCED_PARAMETER(Flags);
-    UNREFERENCED_PARAMETER(ControlInfoLength);
-    UNREFERENCED_PARAMETER(ControlInfo);
-
-    Status = VioWskIrpAcquire(pSocket, Irp);
-    if (!NT_SUCCESS(Status))
+    if (ControlInfoLength)
     {
+        Status = STATUS_NOT_SUPPORTED;
         pSocket = NULL;
         goto CompleteIrp;
     }
 
-    Status = STATUS_NOT_IMPLEMENTED;
+    Status = VioWskSend(Socket, Buffer, Flags, Irp);
+    Irp = NULL;
 CompleteIrp:
-    VioWskIrpComplete(pSocket, Irp, Status, 0);
+    if (Irp)
+        VioWskIrpComplete(pSocket, Irp, Status, 0);
 
     DEBUG_EXIT_FUNCTION("0x%x", Status);
     return Status;

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -986,22 +986,18 @@ VioWskReceiveEx(
     PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
     DEBUG_ENTER_FUNCTION("Socket=0x%p; Buffer=0x%p; Flags=0x%x; ControlInfoLength=0x%p; ControlInfo=0x%p; ControlFlags=0x%p; Irp=0x%p", Socket, Buffer, Flags, ControlInfoLength, ControlInfo, ControlFlags, Irp);
 
-    UNREFERENCED_PARAMETER(Buffer);
-    UNREFERENCED_PARAMETER(Flags);
-    UNREFERENCED_PARAMETER(ControlInfoLength);
-    UNREFERENCED_PARAMETER(ControlInfo);
-    UNREFERENCED_PARAMETER(ControlFlags);
-
-    Status = VioWskIrpAcquire(pSocket, Irp);
-    if (!NT_SUCCESS(Status))
+    if (ControlInfoLength && *ControlInfoLength > 0)
     {
+        Status = STATUS_NOT_SUPPORTED;
         pSocket = NULL;
         goto CompleteIrp;
     }
 
-    Status = STATUS_NOT_IMPLEMENTED;
+    Status = VioWskReceive(Socket, Buffer, Flags, Irp);
+    Irp = NULL;
 CompleteIrp:
-    VioWskIrpComplete(pSocket, Irp, Status, 0);
+    if (Irp)
+        VioWskIrpComplete(pSocket, Irp, Status, 0);
 
     DEBUG_EXIT_FUNCTION("0x%x", Status);
     return Status;

--- a/viosock/wsk/socket.c
+++ b/viosock/wsk/socket.c
@@ -1017,6 +1017,7 @@ VioWskListen(
     _Inout_ PIRP     Irp
 )
 {
+    ULONG Backlog = 128;
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
     PVIOWSK_SOCKET pSocket = CONTAINING_RECORD(Socket, VIOWSK_SOCKET, WskSocket);
     DEBUG_ENTER_FUNCTION("Socket=0x%p; Irp=0x%p", Socket, Irp);
@@ -1028,9 +1029,12 @@ VioWskListen(
         goto CompleteIrp;
     }
 
-    Status = STATUS_NOT_IMPLEMENTED;
+    Status = VioWskSocketIOCTL(pSocket, IOCTL_SOCKET_LISTEN, &Backlog, sizeof(Backlog), NULL, 0, Irp, NULL);
+    Irp = NULL;
+
 CompleteIrp:
-    VioWskIrpComplete(pSocket, Irp, Status, 0);
+    if (Irp)
+        VioWskIrpComplete(pSocket, Irp, Status, 0);
 
     DEBUG_EXIT_FUNCTION("0x%x", Status);
     return Status;

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -54,6 +54,7 @@ typedef enum _EWSKState {
 typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
     volatile LONG ReferenceCount;
     PVIOWSK_SOCKET Socket;
+    PWSK_WORKITEM CloseWorkItem;
     PDEVICE_OBJECT DeviceObject;
     EWSKState State;
     PIRP MasterIrp;
@@ -67,7 +68,6 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
             PWSK_SOCKET Socket;
             PSOCKADDR LocalAddress;
             PSOCKADDR RemoteAddress;
-            PWSK_WORKITEM CloseWorkItem;
         } Accept;
         struct {
             PMDL NextMdl;
@@ -75,8 +75,11 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
             ULONG CurrentMdlSize;
             ULONG LastMdlSize;
         } Transfer;
+        struct {
+            PSOCKADDR RemoteAddress;
+        } BindConnect;
     } Specific;
-} VIOSOCKET_COMPLETION_CONTEXT, * PVIOSOCKET_COMPLETION_CONTEXT;
+} VIOSOCKET_COMPLETION_CONTEXT, *PVIOSOCKET_COMPLETION_CONTEXT;
 
 
 
@@ -104,6 +107,10 @@ WskCompContextSendIrp(
     _In_ PIRP                             Irp
 );
 
+NTSTATUS
+WskCompContextAllocCloseWorkItem(
+    PVIOSOCKET_COMPLETION_CONTEXT CompContext
+);
 
 
 #endif

--- a/viosock/wsk/wsk-completion.h
+++ b/viosock/wsk/wsk-completion.h
@@ -47,6 +47,7 @@ typedef enum _EWSKState {
     wsksAcceptRemote,
     wsksBind,
     wsksListen,
+    wsksConnectEx,
     wsksFinished,
 } EWSKState, * PEWSKState;
 
@@ -70,6 +71,7 @@ typedef struct _VIOSOCKET_COMPLETION_CONTEXT {
         } Accept;
         struct {
             PMDL NextMdl;
+            ULONG CurrentMdlOffset;
             ULONG CurrentMdlSize;
             ULONG LastMdlSize;
         } Transfer;


### PR DESCRIPTION
This PR implements more advanced calls for the WSK interface:
- `WskSocketConnect` (`WskSocket` + `WskBind` + `WskConnect` in one call),
- `WskConnectEx` (`WskConnect` + `WskSend`),
- `WskSendEx` (the same as `WskSend` for our socket case),
- `WskReceiveEx` (the same as `WskReceive` for our socket case).

The test driver has been updated to test also these calls.

**NOTE:** WSK callbacks (namely the accept and receive ones) are still not implemented since their implementation requires modification of the Socket driver whereas the current goal was to implement the WSK interface without any need to modify the Socket driver (apart from fixing various bugs).
