### PR TITLE
WSK: Do Not Access the Flags Parameter in send/recv Requests

### DIFF
--- a/viosock/wsk/wsk-utils.c
+++ b/viosock/wsk/wsk-utils.c
@@ -515,13 +515,17 @@ VioWskSocketBuildReadWriteSingleMdl(
     switch (MajorFunction)
     {
         case IRP_MJ_READ:
+#ifdef _WIN64
             IrpStack->Parameters.Read.Flags = 0;
+#endif
             IrpStack->Parameters.Read.ByteOffset.QuadPart = 0;
             IrpStack->Parameters.Read.Key = 0;
             IrpStack->Parameters.Read.Length = Length;
             break;
         case IRP_MJ_WRITE:
+#ifdef _WIN64
             IrpStack->Parameters.Write.Flags = 0;
+#endif
             IrpStack->Parameters.Write.ByteOffset.QuadPart = 0;
             IrpStack->Parameters.Write.Key = 0;
             IrpStack->Parameters.Write.Length = Length;


### PR DESCRIPTION
This member does not exist on 32-bit versions of Windows. Although such platforms are probably no longer supported, it would be nice to ease the life of those of the community that would need to compile the drivers for these platforms (especially when such change is very simple).

This change should not be dependent on #1066.