### PR TITLE
netkvmco: fix command handler prototype

### DIFF
--- a/NetKVM/CoInstaller/NetKVMCo.h
+++ b/NetKVM/CoInstaller/NetKVMCo.h
@@ -71,7 +71,7 @@ typedef struct _NS_CONTEXT_ATTRIBUTES
 
 } NS_CONTEXT_ATTRIBUTES, * PNS_CONTEXT_ATTRIBUTES;
 
-typedef DWORD(FN_HANDLE_CMD)(
+typedef DWORD(WINAPI FN_HANDLE_CMD)(
     IN      LPCWSTR   pwszMachine,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
     IN      DWORD     dwCurrentIndex,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-28542
Due to prototype mismatch there is exception on application exit and wrong return value of the application (x86 only)