### PR TITLE
netkvm: temporary report 6.89 when OS has 6.89

### DIFF
--- a/NetKVM/wlh/ParaNdis6_Driver.cpp
+++ b/NetKVM/wlh/ParaNdis6_Driver.cpp
@@ -1074,6 +1074,13 @@ static void SetRuntimeNdisVersion()
         major = NDIS_MINIPORT_MAJOR_VERSION;
         minor = NDIS_MINIPORT_MINOR_VERSION;
     }
+    else if (NDIS_MINIPORT_MINOR_VERSION == 86 && osMinor >= 89)
+    {
+        // temporary, to allow building driver
+        // suitable for HCK 2025 before complete
+        // EWDK environment is ready
+        minor = 89;
+    }
     else if (minor >= NDIS_MINIPORT_MINOR_VERSION)
     {
         minor = NDIS_MINIPORT_MINOR_VERSION;


### PR DESCRIPTION
This is temporary exception in NDIS revision negotiation for driver built as 6.86, in order to satisfy HLK expectations on Server 2025.