### PR TITLE
Handle disk removal in vioscsi

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -63,6 +63,12 @@ ENTER_FN_SRB();
     if (!Srb)
         return;
 
+    if (adaptExt->bRemoved) {
+        SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
+        CompleteRequest(DeviceExtension, Srb);
+        return;
+    }
+
     LOG_SRB_INFO();
 
     if (adaptExt->num_queues > 1) {

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -338,6 +338,7 @@ typedef struct _ADAPTER_EXTENSION {
     ACTION_ON_RESET       action_on_reset;
     ULONGLONG             fw_ver;
     ULONG                 resp_time;
+    BOOLEAN               bRemoved;
 } ADAPTER_EXTENSION, * PADAPTER_EXTENSION;
 
 #ifndef PCIX_TABLE_POINTER


### PR DESCRIPTION
The two patches handle the disk removal in vioscsi driver. The details is the following,

vioscsi: Process PnP actions for the adapter
When the vioscsi device is deleted on the host side, the driver
should handle the removal I/O properly. Any new SCSI Request
Blocks are completed with SRB_STATUS_NO_DEVICE.

vioscsi: Implement HwUnitControl routine
If multiple LUNs exist in the same storage controler, the
HwUnitControl routine needs to be implemented. This routine
handles operations occurring on LUNs.
When the disk is deleted on the host, the HwUnitControl
routine completes the pending I/Os for the deleted disk.