### PR TITLE
viogpu_queue: rearrange virtio_gpu_vbuffer struct to reduce size by 8 bytes

### DIFF
--- a/viogpu/common/viogpu_queue.h
+++ b/viogpu/common/viogpu_queue.h
@@ -41,16 +41,17 @@ typedef struct virtio_gpu_config {
 
 //#pragma pack(1)
 typedef struct virtio_gpu_vbuffer {
-    char *buf;
-    int size;
+    LIST_ENTRY list_entry;
+    PKEVENT event;
 
     void *data_buf;
     u32 data_size;
 
+    int size;
+    char *buf;
+
     char *resp_buf;
     int resp_size;
-    PKEVENT event;
-    LIST_ENTRY list_entry;
 }GPU_VBUFFER, *PGPU_VBUFFER;
 //#pragma pack()
 


### PR DESCRIPTION
Signed-off-by: sharkautarch <128002472+sharkautarch@users.noreply.github.com>

Note that this change only makes a difference for x86_64 and ARM64 targets; the size of the struct will remain the same for x86.

This struct isn't packed, so padding/alignment of each member can increase the size.
Reduces size of the struct from 72 bytes to 64 bytes.
tested in godbolt: https://godbolt.org/z/M7abMvYhh


Rearrangement is based off of the idea of ordering the members of a struct from biggest to smallest. (I learned about that trick from a comment in this video about padding/alignment: https://www.youtube.com/watch?v=E0QhZ6tNoRg)

**EDIT**: I just realized that `u32` is actually `unsigned long` (defined in [VirtIO/linux/types.h](https://github.com/virtio-win/kvm-guest-drivers-windows/blob/4a388316733fd1e077262d5dfb534642f5abc5fb/VirtIO/linux/types.h#L9)), but it is still only 32 bits (same size as `unsigned int` because apparently `long` is 32 bits on 64bit windows). which I guess is why it is called u32
updated godbolt: https://godbolt.org/z/ffeGh4nvT
clang now prints out 72 bytes for both, but the assembly for msvc x64 shows that the size is still reduced to 64 bytes  