### PR TITLE
[CI-NO-BUILD] Add interruption handler to CollectSystemInfo

### DIFF
--- a/Tools/debug/CollectSystemInfo.ps1
+++ b/Tools/debug/CollectSystemInfo.ps1
@@ -186,9 +186,12 @@ function Write-InformationToArchive {
 $timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
 $folderName = "SystemInfo_$timestamp"
 $folderPath = Join-Path -Path (Get-Location) -ChildPath $folderName
+$progressFile = "$folderPath\Collecting_Status.txt"
 New-Item -Path $folderPath -ItemType Directory | Out-Null
-Write-Host "Stating system info collecting into $folderPath"
+New-Item -Path $progressFile -ItemType File | Out-Null
+Write-Host "Starting system info collecting into $folderPath"
 
+Start-Transcript -Path $progressFile -Append
 Export-SystemConfiguration
 Export-EventLogs
 Export-DriversList
@@ -200,9 +203,11 @@ Export-RunningProcesses
 Export-InstalledApplications
 Export-InstalledKBs
 Export-NetworkConfiguration
+Stop-Transcript
 
 if ($IncludeSensitiveData) {
     Export-WindowsMemoryDump
 }
 
+Remove-Item -Path $progressFile -ErrorAction SilentlyContinue
 Write-InformationToArchive

--- a/Tools/debug/README.md
+++ b/Tools/debug/README.md
@@ -44,6 +44,7 @@ The collected data is organized into a timestamped folder and then compressed in
 - `InstalledKBs.csv`: List of installed Windows updates.
 - `NetworkInterfaces.txt` and `IPConfiguration.txt`: Network configuration details.
 - `MEMORY.DMP` and `Minidump` folder: Full or mini memory dumps (if `-IncludeSensitiveData` is used).
+- `Collecting_Status.txt`: Generated during data collection and deleted after completion. If the script is interrupted, this file indicates incomplete data collection.
 
 ## Contributing
 


### PR DESCRIPTION
Add an interruption handler. When the script is not finished running, the generated file name could be marked with the
ongoing process, such as Collecting_Status.txt. and it would be delete after completion. In this way, when the script is waiting to be interrupted, it will be clearer to the userwhich directory was interrupted.

Solves: https://issues.redhat.com/browse/RHEL-50169
Signed-off-by: Dehan Meng <demeng@redhat.com>