### PR TITLE
[CI-NO-BUILD] Add 'input validation' to CollectSystemInfo and hot-fix for 'interruption handler'

### DIFF
--- a/Tools/debug/CollectSystemInfo.ps1
+++ b/Tools/debug/CollectSystemInfo.ps1
@@ -39,8 +39,19 @@
 #  Example:  .\CollectSystemInfo.ps1 -IncludeSensitiveData
 
 param (
-    [switch]$IncludeSensitiveData
+    [switch]$IncludeSensitiveData,
+    [switch]$Help
 )
+
+function Show-Help {
+    Write-Host "Usage: .\CollectSystemInfo.ps1 [-IncludeSensitiveData] [-Help]"
+    Write-Host ""
+    Write-Host "Parameters:"
+    Write-Host "  -IncludeSensitiveData  Include sensitive data (memory dump)"
+    Write-Host "  -Help                  Show this help message"
+    Write-Host ""
+    Write-Host "If no parameters are provided, the script will run with default behavior."
+}
 
 function Export-SystemConfiguration {
     try {
@@ -187,6 +198,20 @@ function StopTranscriptAndCloseFile {
     if ($transcriptStarted) {
         Stop-Transcript | Out-Null
         $transcriptStarted = $false
+    }
+}
+
+$validParams = @('IncludeSensitiveData', 'Help')
+if ($Help -or $args -contains '-?' -or $args -contains '--Help') {
+    Show-Help
+    return
+}
+
+foreach ($param in $args) {
+    if ($param -like '-*' -and $validParams -notcontains $param.TrimStart('-')) {
+        Write-Host "A parameter cannot be found that matches parameter name '$param'"
+        Show-Help
+        return
     }
 }
 

--- a/Tools/debug/README.md
+++ b/Tools/debug/README.md
@@ -24,6 +24,7 @@ The collected data is organized into a timestamped folder and then compressed in
       .\CollectSystemInfo.ps1 -IncludeSensitiveData
       ```
       - `-IncludeSensitiveData`: Optional switch to include memory dumps in the collection (use with caution).
+      - `-Help`: Provide basic usage of the script.
 
 3. **Output:**
    - A folder named `SystemInfo_YYYY-MM-DD_HH-MM-SS` will be created in the script's directory.


### PR DESCRIPTION
1. Input parameters that are missing, no mechanism for handling
    abnormal input, for now, if user type `.\CollectSystemInfo.ps1 -?
    (-help, --help)` or `.\CollectSystemInfo.ps1 noniput` , script
    always runs without any warning output to the users.
    It's not what we expected.

2. If user operate 'ctrl+c' or exit powershell to break the
    script-running, the Collecting_Status.txt would be opened and
    cause the folder couldn't be removed/cleaned.

Solves: https://issues.redhat.com/browse/RHEL-50330
Solves: https://issues.redhat.com/browse/RHEL-50169
Signed-off-by: Dehan Meng <demeng@redhat.com>