### PR TITLE
Viosock: Fix Issues With WSAEventSelect and WSAEnumNetworkEvents

### DIFF
--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -1711,17 +1711,18 @@ VIOSockListen(
     return status;
 }
 __inline
-PKEVENT
+NTSTATUS
 VIOSockGetEventFromHandle(
-    IN HANDLE hEvent
+    IN HANDLE hEvent,
+    OUT PKEVENT *pEvent
 )
 {
-    PKEVENT pEvent = NULL;
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
 
-    ObReferenceObjectByHandle(hEvent, STANDARD_RIGHTS_REQUIRED, *ExEventObjectType,
-        KernelMode, (PVOID)&pEvent, NULL);
+    status = ObReferenceObjectByHandle(hEvent, STANDARD_RIGHTS_REQUIRED, *ExEventObjectType,
+        KernelMode, (PVOID)pEvent, NULL);
 
-    return pEvent;
+    return status;
 }
 
 _Requires_lock_not_held_(pSocket->StateLock)
@@ -1822,11 +1823,11 @@ VIOSockEnumNetEvents(
 
     if (hEvent)
     {
-        pEvent = VIOSockGetEventFromHandle(hEvent);
-        if (!pEvent)
+        status = VIOSockGetEventFromHandle(hEvent, &pEvent);
+        if (!NT_SUCCESS(status))
         {
-            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetEventFromHandle failed\n");
-            return STATUS_INVALID_PARAMETER;
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetEventFromHandle failed: 0x%x\n", status);
+            return status;
         }
     }
 
@@ -1931,11 +1932,11 @@ VIOSockEventSelect(
             return STATUS_INVALID_PARAMETER;
         }
 
-        pEvent = VIOSockGetEventFromHandle(hEvent);
-        if (!pEvent)
+        status = VIOSockGetEventFromHandle(hEvent, &pEvent);
+        if (!NT_SUCCESS(status))
         {
-            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetEventFromHandle failed\n");
-            return STATUS_INVALID_PARAMETER;
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetEventFromHandle failed: 0x%x\n", status);
+            return status;
         }
     }
 

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -1880,8 +1880,11 @@ VIOSockEventRegister(
     pSocket->EventsMask = lNetworkEvents;
     if (pSocket->EventObject)
         ObDereferenceObject(pSocket->EventObject);
-    pSocket->Events = 0;
+ 
     pSocket->EventObject = pEvent;
+    if (pSocket->EventObject && (pSocket->Events & pSocket->EventsMask) != 0)
+        KeSetEvent(pSocket->EventObject, IO_NO_INCREMENT, FALSE);
+
     WdfSpinLockRelease(pSocket->StateLock);
 }
 


### PR DESCRIPTION
This PR fixes several issues:
- `WSAEventSelect` should not erase previously recorded network events. Rather, it should set the newly associated event object to signaled state if such events are currently recorded.
- `WSAEnumNetworkEvents` must not disassociate the event object with the socket. Its purpose is just to erase the recorded events (after copying them to the user) and reset the event object.
- The `ObReferenceObjectByHandle` function used to translate event object handle to pointer increases object's reference count. This was not reverted in some cases.