### PR TITLE
[CI-NO-BUILD] Hot-fix for RHEL50330: Add another situation

### DIFF
--- a/Tools/debug/CollectSystemInfo.ps1
+++ b/Tools/debug/CollectSystemInfo.ps1
@@ -208,7 +208,7 @@ if ($Help -or $args -contains '-?' -or $args -contains '--Help') {
 }
 
 foreach ($param in $args) {
-    if ($param -like '-*' -and $validParams -notcontains $param.TrimStart('-')) {
+    if ($param -notlike '-*' -or ($param -like '-*' -and $validParams -notcontains $param.TrimStart('-'))) {
         Write-Host "A parameter cannot be found that matches parameter name '$param'"
         Show-Help
         return


### PR DESCRIPTION
'.\CollectSystemInfo.ps1 wrongtype' without '-' still is a common input errors.  Previously, only the ones starting with '-' were filtered.

Solves: https://issues.redhat.com/browse/RHEL-50330
Signed-off-by: Dehan Meng <demeng@redhat.com>