### PR TITLE
[CI-NO-BUILD] Fix dmp file missing issue

### DIFF
--- a/Tools/debug/CollectSystemInfo.ps1
+++ b/Tools/debug/CollectSystemInfo.ps1
@@ -176,9 +176,9 @@ function Export-NetworkConfiguration {
 
 function Export-WindowsMemoryDump {
     $memoryDumpPaths = @("$env:SystemRoot\MEMORY.DMP", "$env:SystemRoot\Minidump")
-    
+
     foreach ($dump in $memoryDumpPaths) {
-        Copy-Item -Path $dump -Destination $folderPath -ErrorAction SilentlyContinue
+        Copy-Item -Path $dump -Destination $folderPath -Recurse -ErrorAction SilentlyContinue
     }
     Write-Host 'Windows memory dump collection completed.'
 }


### PR DESCRIPTION
After running script with param 'IncludeSensitiveData', Only the Minidump directory was copied, the dmp file wasn't copied

Solves: https://issues.redhat.com/browse/RHEL-52479
Signed-off-by: Dehan Meng <demeng@redhat.com>