### PR TITLE
viogpusc: Run viogpu service as a noninteractive service

### DIFF
--- a/viogpu/viogpusc/Service.cpp
+++ b/viogpu/viogpusc/Service.cpp
@@ -100,7 +100,7 @@ BOOL CService::SendStatusToSCM(DWORD dwCurrentState, DWORD dwWin32ExitCode, DWOR
 
     PrintMessage(L"%ws\n", __FUNCTIONW__);
 
-    serviceStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS | SERVICE_INTERACTIVE_PROCESS;
+    serviceStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
     serviceStatus.dwCurrentState = dwCurrentState;
 
     if (dwCurrentState == SERVICE_START_PENDING) {

--- a/viogpu/viogpusc/utils.cpp
+++ b/viogpu/viogpusc/utils.cpp
@@ -75,7 +75,7 @@ BOOL InstallService()
                              ServiceName,
                              DisplayName,
                              SERVICE_ALL_ACCESS,
-                             SERVICE_WIN32_OWN_PROCESS | SERVICE_INTERACTIVE_PROCESS,
+                             SERVICE_WIN32_OWN_PROCESS,
                              SERVICE_AUTO_START,
                              SERVICE_ERROR_NORMAL,
                              szBuffer,


### PR DESCRIPTION
Remove flag SERVICE_INTERACTIVE_PROCESS to run viogpu service as a noninteractive service.

https://github.com/virtio-win/kvm-guest-drivers-windows/issues/718