### PR TITLE
fwcfg: disable DMAR in the INF file

### DIFF
--- a/fwcfg64/fwcfg.inf
+++ b/fwcfg64/fwcfg.inf
@@ -63,7 +63,10 @@ ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
 StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %INX_PLATFORM_DRIVERS_DIR%\fwcfg.sys
+AddReg         = Dmar.AddReg
 
+[Dmar.AddReg]
+HKR,Parameters,DmaRemappingCompatible,0x00010001,0
 
 [FwCfg_Device.NT.Wdf]
 KmdfService =  FwCfg, FwCfg_wdfsect


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-58378
The driver provides physical memory addresses to the device but the QEMU implementation uses DMAR-incompatible access to the memory.