### PR TITLE
vioser: add DMAR compatibility support to the INF

### DIFF
--- a/vioserial/sys/vioser.inx
+++ b/vioserial/sys/vioser.inx
@@ -76,6 +76,10 @@ ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
 StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %INX_PLATFORM_DRIVERS_DIR%\vioser.sys
+AddReg         = Dmar.AddReg
+
+[Dmar.AddReg]
+HKR,Parameters,DmaRemappingCompatible,0x00010001,2
 
 [VirtioSerial_Device.NT.Wdf]
 KmdfService =  VirtioSerial, VirtioSerial_wdfsect


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-58379
Enable DMAR when driver verifier is enabled.