### PR TITLE
viostor: adapt to size_max

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1263,6 +1263,8 @@ VirtIoBuildIo(
     ULONG                 dummy;
     ULONG                 sgElement;
     ULONG                 sgMaxElements;
+    ULONG                 sgLength;
+    ULONG                 sgOffset;
     PADAPTER_EXTENSION    adaptExt;
     PSRB_EXTENSION        srbExt;
     PSTOR_SCATTER_GATHER_LIST sgList;
@@ -1345,9 +1347,34 @@ VirtIoBuildIo(
 
     sgMaxElements = min((MAX_PHYS_SEGMENTS + 1), sgList->NumberOfElements);
 
-    for (i = 0, sgElement = 1; i < sgMaxElements; i++, sgElement++) {
-        srbExt->sg[sgElement].physAddr = sgList->List[i].PhysicalAddress;
-        srbExt->sg[sgElement].length   = sgList->List[i].Length;
+    if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_SIZE_MAX)) {
+        for (i = 0, sgElement = 1; i < sgMaxElements; i++) {
+            sgLength = sgList->List[i].Length;
+            sgOffset = 0;
+            while (sgLength > 0) {
+                if (sgElement > adaptExt->info.seg_max) {
+                    RhelDbgPrint(TRACE_LEVEL_ERROR, " wrong SGL, the numer of elements or the size is wrong\n");
+                    CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
+                    return FALSE;
+                }
+
+                srbExt->sg[sgElement].physAddr.QuadPart = sgList->List[i].PhysicalAddress.QuadPart + sgOffset;
+                if (sgLength > adaptExt->info.size_max) {
+                    srbExt->sg[sgElement].length = adaptExt->info.size_max;
+                    sgOffset += adaptExt->info.size_max;
+                    sgLength -= adaptExt->info.size_max;
+                } else {
+                    srbExt->sg[sgElement].length = sgLength;
+                    sgLength = 0;
+                }
+                sgElement ++;
+            }
+        }
+    } else {
+        for (i = 0, sgElement = 1; i < sgMaxElements; i++, sgElement++) {
+            srbExt->sg[sgElement].physAddr = sgList->List[i].PhysicalAddress;
+            srbExt->sg[sgElement].length   = sgList->List[i].Length;
+        }
     }
 
     srbExt->vbr.out_hdr.sector = lba;


### PR DESCRIPTION
according to the definitions of NumberOfPhysicalBreaks and MaximumTransferLength in the Microsoft documentation, as well as the calculation methods provided in commit cfbf9345 for these two variables, in a single io, the number of segments  will not exceed seg_max, and the total size of the io will not exceed seg_max*size_max. therefore, when building io, dirver can split any sgement larger than size_max into smaller requests.

fix https://github.com/virtio-win/kvm-guest-drivers-windows/pull/753/commits