### PR TITLE
virtio: add VIRTIO_F_ORDER_PLATFORM feature

### DIFF
--- a/VirtIO/linux/virtio_config.h
+++ b/VirtIO/linux/virtio_config.h
@@ -67,6 +67,12 @@
 /* This feature indicates support for the packed virtqueue layout. */
 #define VIRTIO_F_RING_PACKED            34
 
+/*
+ * This feature indicates that memory accesses by the driver and the
+ * device are ordered in a way described by the platform.
+ */
+#define VIRTIO_F_ORDER_PLATFORM         36
+
 // if this number is not equal to desc size, queue creation fails
 #define SIZE_OF_SINGLE_INDIRECT_DESC    16
 

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -683,6 +683,10 @@ RhelSetGuestFeatures(
         guestFeatures |= (1ULL << VIRTIO_BLK_F_WRITE_ZEROES);
     }
 
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_ORDER_PLATFORM)) {
+        guestFeatures |= (1ULL << VIRTIO_F_ORDER_PLATFORM);
+    }
+
     if (!NT_SUCCESS(virtio_set_features(&adaptExt->vdev, guestFeatures))) {
         RhelDbgPrint(TRACE_LEVEL_FATAL, " virtio_set_features failed\n");
         return;


### PR DESCRIPTION
VIRTIO_F_ORDER_PLATFORM may be required for devices implemented in hardware.
However when adding buffers in vring KeMemoryBarrier is used which prevents both the compiler and the processor from moving operations across the barrier. So just add this feature in guest_feature.