### PR TITLE
NetKVM: ack VIRTIO_F_ORDER_PLATFORM

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -981,6 +981,11 @@ NDIS_STATUS ParaNdis_InitializeContext(
         {
             DPrintf(0, "[%s] Using PACKED ring\n", __FUNCTION__);
         }
+
+        if (AckFeature(pContext, VIRTIO_F_ORDER_PLATFORM))
+        {
+            DPrintf(0, "[%s] Ack VIRTIO_F_ORDER_PLATFORM to device\n", __FUNCTION__);
+        }
     }
 
     if (pContext->bControlQueueSupported)


### PR DESCRIPTION
NetKVM: ack VIRTIO_F_ORDER_PLATFORM

According to commit 48aeb261, add VIRTIO_F_ORDER_PLATFORM to NetKVM.