### PR TITLE
vioscsi: add DMAR support to the INF

### DIFF
--- a/vioscsi/vioscsi.inx
+++ b/vioscsi/vioscsi.inx
@@ -92,6 +92,8 @@ HKR,,TypesSupported,%REG_DWORD%,7
 [pnpsafe_pci_addreg]
 HKR, "Parameters\PnpInterface", "5", %REG_DWORD%, 0x00000001
 HKR, "Parameters", "BusType", %REG_DWORD%, 0x0000000A
+HKR, "Parameters", DmaRemappingCompatible,0x00010001,2
+
 
 [pnpsafe_pci_addreg_msix]
 HKR, "Interrupt Management",, 0x00000010


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-58680
Enable DMAR if driver verifier enabled