### PR TITLE
Balloon: Cope with the unresponsive host

### DIFF
--- a/Balloon/sys/Device.c
+++ b/Balloon/sys/Device.c
@@ -747,12 +747,23 @@ BalloonRoutine(
                 diff = BalloonGetSize(Device);
                 if (diff > 0)
                 {
-                    BalloonFill(Device, (size_t)(diff));
+                    status = BalloonFill(Device, (size_t)(diff));
                 }
                 else if (diff < 0)
                 {
-                    BalloonLeak(Device, (size_t)(-diff));
+                    status = BalloonLeak(Device, (size_t)(-diff));
                 }
+
+                if (status == STATUS_TIMEOUT || status == STATUS_NO_MORE_ENTRIES)
+                {
+                    TraceEvents(TRACE_LEVEL_WARNING, DBG_HW_ACCESS, "Failed to inform the host\n");
+                    if (diff != 0)
+                    {
+                        TraceEvents(TRACE_LEVEL_WARNING, DBG_HW_ACCESS, "Operation is in progress, continuing\n");
+                        KeSetEvent(&devCtx->WakeUpThread, IO_NO_INCREMENT, FALSE);
+                    }
+                }
+
                 BalloonSetSize(Device, devCtx->num_pages);
             }
         }

--- a/Balloon/sys/ProtoTypes.h
+++ b/Balloon/sys/ProtoTypes.h
@@ -168,13 +168,13 @@ BalloonTerm(
     IN WDFOBJECT    WdfDevice
     );
 
-VOID
+NTSTATUS
 BalloonFill(
     IN WDFOBJECT WdfDevice,
     IN size_t num
     );
 
-VOID
+NTSTATUS
 BalloonLeak(
     IN WDFOBJECT WdfDevice,
     IN size_t num
@@ -185,7 +185,7 @@ BalloonMemStats(
     IN WDFOBJECT WdfDevice
     );
 
-VOID
+NTSTATUS
 BalloonTellHost(
     IN WDFOBJECT WdfDevice,
     IN PVIOQUEUE vq


### PR DESCRIPTION
When the balloon size change is requested, the driver is filling/leaking the balloon in steps of 512 pages. The host is informed after every step and the driver always watis for an ACK. However, if none is delivered within 1000 ms timeout (iva an interrupt), the driver stops performing the operation. It would be better to finish the operation even in case the timeout expires.