### PR TITLE
PVPanic: Fixed pvpanic-pci.inf to pass validation

### DIFF
--- a/pvpanic/pvpanic/pvpanic-pci.inf
+++ b/pvpanic/pvpanic/pvpanic-pci.inf
@@ -24,7 +24,7 @@ CatalogFile     = pvpanic-pci.cat
 PnpLockdown     = 1
 
 [DestinationDirs]
-DefaultDestDir = 13
+DefaultDestDir = INX_PLATFORM_DRIVERS_DIR
 
 [SourceDisksNames]
 1 = %DiskName%,,,""
@@ -60,7 +60,7 @@ DisplayName    = %PVPanic.Service%
 ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
 StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
-ServiceBinary  = %13%\pvpanic.sys
+ServiceBinary  = %INX_PLATFORM_DRIVERS_DIR%\pvpanic.sys
 LoadOrderGroup = Extended Base
 
 [PVPanic_Device.NT.Wdf]


### PR DESCRIPTION
This is a follow-up to d27499191cd9 fixing the `pvpanic-pci.inf` as well. Discovered by my colleague Konstantin Vlasov.