### PR TITLE
[vioscsi] SendSRB minor refactor

### DIFF
--- a/VirtIO/VirtIORing-Packed.c
+++ b/VirtIO/VirtIORing-Packed.c
@@ -288,7 +288,7 @@ static int virtqueue_add_buf_packed(
         DPrintf(5, "Added buffer head @%i+%d to Q%d\n", head, descs_used, vq->vq.index);
     }
 
-    return 0;
+    return VQ_ADD_BUFFER_SUCCESS;
 }
 
 static void detach_buf_packed(struct virtqueue_packed *vq, unsigned int id)

--- a/VirtIO/VirtIORing.c
+++ b/VirtIO/VirtIORing.c
@@ -296,7 +296,7 @@ static int virtqueue_add_buf_split(
     vring->avail->idx = ++vq->master_vring_avail.idx;
     vq->num_added_since_kick++;
 
-    return 0;
+    return VQ_ADD_BUFFER_SUCCESS;
 }
 
 /* Gets the opaque pointer associated with a returned buffer, or NULL if no buffer is available */

--- a/VirtIO/virtio_ring.h
+++ b/VirtIO/virtio_ring.h
@@ -44,6 +44,8 @@
 * at the end of the used ring. Guest should ignore the used->flags field. */
 #define VIRTIO_RING_F_EVENT_IDX		29
 
+#define VQ_ADD_BUFFER_SUCCESS 0
+
 void vring_transport_features(VirtIODevice *vdev, u64 *features);
 unsigned long vring_size(unsigned int num, unsigned long align, bool packed);
 

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -49,6 +49,8 @@
 #define CACHE_LINE_SIZE 64
 #define ROUND_TO_CACHE_LINES(Size)  (((ULONG_PTR)(Size) + CACHE_LINE_SIZE - 1) & ~(CACHE_LINE_SIZE - 1))
 
+#define VQ_ADD_BUFFER_SUCCESS 0
+
 #include <srbhelper.h>
 
 // Note: SrbGetCdbLength is defined in srbhelper.h

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -40,6 +40,7 @@
 
 #include "osdep.h"
 #include "virtio_pci.h"
+#include "virtio_ring.h"
 #include "vioscsi.h"
 
 #define CHECKBIT(value, nbit) virtio_is_feature_enabled(value, nbit)
@@ -48,8 +49,6 @@
 
 #define CACHE_LINE_SIZE 64
 #define ROUND_TO_CACHE_LINES(Size)  (((ULONG_PTR)(Size) + CACHE_LINE_SIZE - 1) & ~(CACHE_LINE_SIZE - 1))
-
-#define VQ_ADD_BUFFER_SUCCESS 0
 
 #include <srbhelper.h>
 


### PR DESCRIPTION
The `virtqueue_add_buf()` routine will return 0 on `SUCCESS` or otherwise a negative number, usually -28 (`ENOSPC`), i.e no space for buffer. An inline comment is added for edification. Refactored `virtqueue_add_buf()` handling to only process the SRB if `virtqueue_add_buf()` returns `SUCCESS`. Presently, other positive return codes would be processed.

Variable renames:
`res` to `add_buffer_req_status`
`index` to `vq_req_idx`
`MessageID` to `MessageId`
 -- Also cleaned up variable init table

New definitions:
`VQ_ADD_BUFFER_SUCCESS` is defined in `vioscsi\helper.h` header file.
 -- Used to initialize `add_buffer_req_status` variable. (Credit: @JonKohler)

To ensure valid data is reported we also move the trace event on failure to above the call to `CompleteRequest()` and wrap the line for improved readability.
 -- Add `add_buffer_req_status` content to trace output on error (Credit: @JonKohler)