### PR TITLE
[VirtIO] Redefine ENOSPC to common Linux errno

### DIFF
--- a/VirtIO/osdep.h
+++ b/VirtIO/osdep.h
@@ -17,7 +17,7 @@
 #include <ntddk.h>
 
 #if !defined(ENOSPC)
-#define ENOSPC 1
+#define ENOSPC 28
 #endif
 
 #if !defined(__cplusplus) && !defined(bool)


### PR DESCRIPTION
The `VirtIO\osdep.h` header file defines `ENOSPC` as 1. On Windows this equates to `ERROR_INVALID_FUNCTION`.

This commit redefines `ENOSPC` to use the more typical Linux definition of 28.