### PR TITLE
viogpusc: Fix the timeout issue when stopping viogpusc service

### DIFF
--- a/viogpu/viogpusc/Session.h
+++ b/viogpu/viogpusc/Session.h
@@ -48,6 +48,7 @@ public:
     HANDLE GetProcess(void) { return m_SessionInfo.hProcess; }
     void SetProcess(HANDLE Handle) { m_SessionInfo.hProcess = Handle; }
     ULONG GetId(void) { return m_SessionInfo.SessionId; }
+    HANDLE GetCreateProcess(void) { return m_ProcessInfo.hProcess; }
 private:
     bool PipeServerActive(void) { return (m_PipeServer != NULL); }
     bool CreateProcessInSession(const std::wstring & commandLine);
@@ -56,5 +57,7 @@ private:
     PipeServer* m_PipeServer;
     SESSION_INFORMATION m_SessionInfo;
     PROCESS_INFORMATION m_ProcessInfo;
+    HANDLE m_hToken;
+    LPVOID m_lpvEnv;
 };
 

--- a/viogpu/viogpusc/SessionMgr.cpp
+++ b/viogpu/viogpusc/SessionMgr.cpp
@@ -43,7 +43,18 @@ CSessionMgr::~CSessionMgr()
 
 DWORD WINAPI CSessionMgr::ServiceThread(CSessionMgr* prt)
 {
+    HANDLE hProcessHandle;
+    DWORD ExitCode;
+
     prt->Run();
+    for (Iterator it = prt->Sessions.begin(); it != prt->Sessions.end(); it++)
+    {
+        hProcessHandle = prt->GetSessioinCreateProcess((*it)->GetId());
+        WaitForSingleObject(hProcessHandle, INFINITE);
+        GetExitCodeProcess(hProcessHandle, &ExitCode);
+        PrintMessage(L"Process finished with code 0x%x\n", ExitCode);
+    }
+
     return 0;
 }
 
@@ -106,6 +117,7 @@ void CSessionMgr::Close()
 
     for (Iterator it = Sessions.begin(); it != Sessions.end(); it++)
     {
+        (*it)->Close();
         delete *it;
     }
 
@@ -133,6 +145,18 @@ void CSessionMgr::SetSessionStatus(UINT Indx, SESSION_STATUS status)
     if (ptr) {
         return (ptr)->SetStatus(status);
     }
+}
+
+HANDLE CSessionMgr::GetSessioinCreateProcess(UINT Indx)
+{
+    PrintMessage(L"%ws\n", __FUNCTIONW__);
+
+    CSession* ptr = FindSession(Indx);
+    if (ptr) {
+        return (ptr)->GetCreateProcess();
+    }
+
+    return (HANDLE)NULL;
 }
 
 HANDLE CSessionMgr::GetSessioinProcess(UINT Indx)

--- a/viogpu/viogpusc/SessionMgr.h
+++ b/viogpu/viogpusc/SessionMgr.h
@@ -44,6 +44,7 @@ public:
     void SetSessionStatus(UINT Indx, SESSION_STATUS status);
     HANDLE GetSessioinProcess(UINT Indx);
     void SetSessionProcess(UINT Indx, HANDLE Handle);
+    HANDLE GetSessioinCreateProcess(UINT Indx);
 private:
     CSession* FindSession(ULONG Indx, bool bCreate = false);
     void AddSession(CSession* session);


### PR DESCRIPTION
When the user stops the viogpusc service either through SCM or console command line, a timeout error is thrown out as the following,

From the console,
The service did not respond to the start or control request in a timely fashion.

From SCM
A timeout was reached while waiting for a transaction response from the viogpusc service.

This error is due to the incomplete initialization of the Session creating viogpuap process. This initialization is blocked until the process is terminated. When SCM or console command tries to stop the service, it always fails because the Session is waiting for the process to be terminated. Actually, the process is waiting for the service to trigger an event to terminate itself. This is a dead loop.

To fix this issue, the Session initialization should be completed, and the Session Manager should monitor the termination of the process and release the resources after the process is terminated.