### PR TITLE
[vioscsi] Reduce spinlock management complexity

### DIFF
--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -171,28 +171,10 @@ VioScsiCompleteDpcRoutine(
 );
 
 VOID
-ProcessQueue(
+ProcessBuffer(
     IN PVOID DeviceExtension,
-    IN ULONG MessageID,
-    IN BOOLEAN isr
-    );
-
-VOID
-//FORCEINLINE
-VioScsiVQLock(
-    IN PVOID DeviceExtension,
-    IN ULONG MessageID,
-    IN OUT PSTOR_LOCK_HANDLE LockHandle,
-    IN BOOLEAN isr
-    );
-
-VOID
-//FORCEINLINE
-VioScsiVQUnlock(
-    IN PVOID DeviceExtension,
-    IN ULONG MessageID,
-    IN PSTOR_LOCK_HANDLE LockHandle,
-    IN BOOLEAN isr
+    IN ULONG MessageId,
+    IN STOR_SPINLOCK LockMode
     );
 
 VOID


### PR DESCRIPTION
Spinlocks are now primarily of the DpcLock type, without which the driver will not properly operate. Fallback to an InterruptLock type spinlock is limited, perhaps even cosmetic.

This commit removes the VioScsiVQLock() and VioScsiVQUnlock() wrapper routines to use the native functions instead, i.e. StorPortAcquireSpinLock() and StorPortReleaseSpinLock(). VioScsiVQLock() contained a superfluous MSI-X and QueueNumber check and VioScsiVQUnlock() did not release non-DpcLock type spinlocks. Removing the wrapper routines also resolves these two issues.

Refactoring includes:
* Renaming of ProcessQueue() to ProcessBuffer(). Whilst technically more accurate, this also provides space for a new ProcessQueue() routine, via which the HW_MESSAGE_SIGNALLED_INTERRUPT_ROUTINE and HW_INTERRUPT routines can then be consolidated.
* Where necessary, changing BOOLEAN isr to STOR_SPINLOCK LockMode
* CamelCase / conformity correction of MessageID to MessageId
* Conformity correction of QueuNum to QueneNumber
* Removal of unnecessary use of MsgID and MessageID or MessageId in area of focus (11 instances of MessageID remain in other vioscsi.c routines)
* Mnemonic rename of:
  * CompletePendingRequests() to CompletePendingRequestsOnReset()
  * index to vq_req_idx
* Syntactic correction of if statement (added braces)