### PR TITLE
NO-SDV [vioscsi] Tracing improvements

### DIFF
--- a/vioscsi/trace.h
+++ b/vioscsi/trace.h
@@ -30,8 +30,23 @@
 #ifndef ___TRACING_H___
 #define ___TRACING_H___
 
+/* RUN_UNCHECKED - NO DEBUG OR TRACING
+ * This option disables all debug messages and ETW for maximum performance.*/
+#define RUN_UNCHECKED 1
+#undef RUN_UNCHECKED // <== switch me here with comment
 
+/* RUN_MIN_CHECKED - MINIMUM DEBUG OR FULL TRACING
+ * This option includes select conditionally compiled debug messages.
+ * However, if ETW is enabled instead of DEBUG, all traces will be included 
+ * regardless of any compile-time conditional statements because the WPP will 
+ * scan for all events and will ignore compile-time conditional statements. */
+#define RUN_MIN_CHECKED 1
+#undef RUN_MIN_CHECKED // <== switch me here with comment
+
+/* EVENT_TRACING - CHOOSE BETWEEN DEBUG OR TRACING
+ * if EVENT_TRACING is undefined, DEBUG (DBG) will be enabled below... */
 #define EVENT_TRACING 1
+//#undef EVENT_TRACING  // <== switch me here with comment
 
 #include <ntddk.h>
 #include <storport.h>
@@ -45,7 +60,7 @@ char *DbgGetScsiOpStr(IN UCHAR opCode);
 void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING RegistryPath);
 
 #if !defined(EVENT_TRACING)
-#define define DBG 1
+#define DBG 1
 #define PRINT_DEBUG 1
 #if !defined(PRINT_DEBUG)
 #define COM_DEBUG 1
@@ -70,6 +85,18 @@ extern int nVioscsiDebugLevel;
 #define TRACE_LEVEL_RESERVED7   7
 #define TRACE_LEVEL_RESERVED8   8
 #define TRACE_LEVEL_RESERVED9   9
+#define TRACE_VQ                10
+#define TRACE_LOCKS             11
+#define TRACE_DPC               12
+#define TRACE_MSIX              13
+#define TRACE_ENTER_EXIT        14
+#define TRACE_NOTIFY            15
+#define TRACE_GUEST_FEATURES    16
+#define TRACE_PCI_CAP           17
+#define TRACE_MAPPING           18
+#define TRACE_MSIX_CPU_AFFINITY 19
+#define TRACE_REGISTRY          20
+#define TRACE_ALL               31
 #endif
 
 #if DBG
@@ -83,13 +110,21 @@ extern int nVioscsiDebugLevel;
 #define VioScsiDbgBreak()
 #endif
 
-#define ENTER_FN() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define ENTER_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
 #define EXIT_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
+#define ENTER_INL_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define EXIT_INL_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
 #define EXIT_ERR() RhelDbgPrint(TRACE_LEVEL_ERROR, " <--> %s (%d).\n", __FUNCTION__, __LINE__)
 #define ENTER_FN_SRB() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)
 #define EXIT_FN_SRB()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define ENTER_INL_FN_SRB() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define EXIT_INL_FN_SRB()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s Srb = 0x%p.\n",__FUNCTION__, Srb)
 #define LOG_SRB_INFO() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
+#define LOG_SRB_INFO_FROM_INLFN() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
 
+#else
+#if defined(RUN_UNCHECKED) && !defined(RUN_MIN_CHECKED)
+#undef EVENT_TRACING
 #else
 #pragma warning(disable: 28170)
 #pragma warning(disable: 28251)
@@ -105,60 +140,118 @@ extern int nVioscsiDebugLevel;
         WPP_DEFINE_BIT(TRACE_LEVEL_WARNING)            /* bit  3 = 0x00000008 */ \
         WPP_DEFINE_BIT(TRACE_LEVEL_INFORMATION)        /* bit  4 = 0x00000010 */ \
         WPP_DEFINE_BIT(TRACE_LEVEL_VERBOSE)            /* bit  5 = 0x00000020 */ \
+        WPP_DEFINE_BIT(TRACE_LEVEL_RESERVED6)          /* bit  6 = 0x00000040 */ \
+        WPP_DEFINE_BIT(TRACE_LEVEL_RESERVED7)          /* bit  7 = 0x00000080 */ \
+        WPP_DEFINE_BIT(TRACE_LEVEL_RESERVED8)          /* bit  8 = 0x00000100 */ \
+        WPP_DEFINE_BIT(TRACE_LEVEL_RESERVED9)          /* bit  9 = 0x00000200 */ \
+        WPP_DEFINE_BIT(TRACE_VQ)                       /* bit 10 = 0x00000400 */ \
+        WPP_DEFINE_BIT(TRACE_LOCKS)                    /* bit 11 = 0x00000800 */ \
+        WPP_DEFINE_BIT(TRACE_DPC)                      /* bit 12 = 0x00001000 */ \
+        WPP_DEFINE_BIT(TRACE_MSIX)                     /* bit 13 = 0x00002000 */ \
+        WPP_DEFINE_BIT(TRACE_ENTER_EXIT)               /* bit 14 = 0x00004000 */ \
+        WPP_DEFINE_BIT(TRACE_NOTIFY)                   /* bit 15 = 0x00008000 */ \
+        WPP_DEFINE_BIT(TRACE_GUEST_FEATURES)           /* bit 16 = 0x00008000 */ \
+        WPP_DEFINE_BIT(TRACE_PCI_CAP)                  /* bit 17 = 0x00010000 */ \
+        WPP_DEFINE_BIT(TRACE_MAPPING)                  /* bit 18 = 0x00020000 */ \
+        WPP_DEFINE_BIT(TRACE_MSIX_CPU_AFFINITY)        /* bit 19 = 0x00040000 */ \
+        WPP_DEFINE_BIT(TRACE_REGISTRY)                 /* bit 20 = 0x00080000 */ \
+        WPP_DEFINE_BIT(TRACE_ALL)                      /* bit LAST PLACEHLDR  */ \
         )
 
 // begin_wpp config
-// USEPREFIX (RhelDbgPrint, "%!STDPREFIX! %!FUNC!");
+// USEPREFIX (RhelDbgPrint, "%!STDPREFIX! ####\t\t[%!FUNC!] DEBUG:");
 // FUNC RhelDbgPrint(LEVEL, MSG, ...);
 // end_wpp
-
 #define WPP_Flags_LEVEL_LOGGER(Flags, level) WPP_LEVEL_LOGGER(Flags)
 #define WPP_Flags_LEVEL_ENABLED(Flags, level) \
     (WPP_LEVEL_ENABLED(Flags) && \
     WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
 
 // begin_wpp config
-// USEPREFIX (ENTER_FN, "%!STDPREFIX! [%!FUNC!] --> entry");
-// FUNC ENTER_FN{ENTRYLEVEL=TRACE_LEVEL_VERBOSE}(...);
+// USEPREFIX (ENTER_FN, "%!STDPREFIX! ===>\t\t[%!FUNC!] X---X Working X---X");
+// FUNC ENTER_FN{ENTRYLEVEL=TRACE_ENTER_EXIT}(...);
 // end_wpp
-
 #define WPP_ENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_ENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
 
 // begin_wpp config
-// USEPREFIX (EXIT_FN, "%!STDPREFIX! [%!FUNC!] <-- exit");
-// FUNC EXIT_FN{EXITLEVEL=TRACE_LEVEL_VERBOSE}(...);
+// USEPREFIX (EXIT_FN, "%!STDPREFIX! <===\t\t[%!FUNC!] Processing complete.");
+// FUNC EXIT_FN{EXITLEVEL=TRACE_ENTER_EXIT}(...);
 // end_wpp
 #define WPP_EXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_EXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
 
 // begin_wpp config
-// USEPREFIX (EXIT_ERR, "%!STDPREFIX! <--> %!FUNC! ERROR line %d", __LINE__);
+// USEPREFIX (ENTER_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] X---X Working X---X", InlineFuncName);
+// FUNC ENTER_INL_FN{INLENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] Processing complete.", InlineFuncName);
+// FUNC EXIT_INL_FN{INLEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_ERR, "%!STDPREFIX! >>>>\t\t[%!FUNC!] ERROR line %d", __LINE__);
 // FUNC EXIT_ERR{ERRORLEVEL=TRACE_LEVEL_ERROR}(...);
 // end_wpp
 #define WPP_ERRORLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_ERRORLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
 
 // begin_wpp config
-// USEPREFIX (ENTER_FN_SRB(PVOID Srb), "%!STDPREFIX! ---> %!FUNC! 0x%p.", Srb);
-// FUNC ENTER_FN_SRB{SRBENTRYLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// USEPREFIX (ENTER_FN_SRB(PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC ENTER_FN_SRB{SRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
 // end_wpp
 #define WPP_SRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_SRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
 
 // begin_wpp config
-// USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <--- %!FUNC! 0x%p.", Srb);
-// FUNC EXIT_FN_SRB{SRBEXITLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC EXIT_FN_SRB{SRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
 // end_wpp
 #define WPP_SRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_SRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
 
 // begin_wpp config
-// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! %!FUNC! <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
 // FUNC LOG_SRB_INFO{SRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
 // end_wpp
 #define WPP_SRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
 #define WPP_SRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC ENTER_INL_FN_SRB{INLSRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC EXIT_INL_FN_SRB{INLSRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO_FROM_INLFN(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!]:[%s] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", InlineFuncName, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO_FROM_INLFN{INLSRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_INLSRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+//
+// Configure WPP macros for optimum performance
+// by disabling checking for 'WPP_INIT_TRACING'
+// as we call it in DriverEntry() anyway.
+//
+#define WPP_CHECK_INIT
+    
+#endif
 
 #endif
 

--- a/vioscsi/trace.h
+++ b/vioscsi/trace.h
@@ -61,7 +61,10 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING R
 
 #if !defined(EVENT_TRACING)
 #define DBG 1
+/* EVENT_TRACING - CHOOSE BETWEEN DEBUG TO STDIO OR SERIAL PORT
+ * if PRINT_DEBUG is undefined, output to the serial port (COM_DEBUG) will be enabled below... */
 #define PRINT_DEBUG 1
+//#undef PRINT_DEBUG  // <== switch me here with comment
 #if !defined(PRINT_DEBUG)
 #define COM_DEBUG 1
 #endif
@@ -99,20 +102,15 @@ extern int nVioscsiDebugLevel;
 #define TRACE_ALL               31
 #endif
 
-#if DBG
 #define RhelDbgPrint(Level, MSG, ...) \
     if ((!bDebugPrint) || Level > nVioscsiDebugLevel) {} \
     else VirtioDebugPrintProc (MSG, __VA_ARGS__)
 #define VioScsiDbgBreak()\
     if (KD_DEBUGGER_ENABLED && !KD_DEBUGGER_NOT_PRESENT) DbgBreakPoint();
-#else
-#define RhelDbgPrint(Level, MSG, ...)
-#define VioScsiDbgBreak()
-#endif
 
-#define ENTER_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define ENTER_FN() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
 #define EXIT_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
-#define ENTER_INL_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define ENTER_INL_FN() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
 #define EXIT_INL_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
 #define EXIT_ERR() RhelDbgPrint(TRACE_LEVEL_ERROR, " <--> %s (%d).\n", __FUNCTION__, __LINE__)
 #define ENTER_FN_SRB() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)

--- a/vioscsi/utils.c
+++ b/vioscsi/utils.c
@@ -101,30 +101,15 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING R
 #endif
 }
 
-tDebugPrintFunc VirtioDebugPrintProc;
 #else
+static void NoDebugPrintFunc(const char *format, ...) {} // This is NOT strictly required for ETW
 void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING RegistryPath)
 {
-    //
-    // We implement RhelDbgPrint() messages via ETW using WPP.
-    // Implementation is via FLAGS and LEVEL [nVioscsiDebugLevel() here] has no effect.
-    // This way RhelDbgPrint() messages match TRACE_LEVEL of WPP functions, which is very convenient.
-    // No need for DEBUG settings here - breaks are never sent...
-    //
-    // Note: Messages matching definitions in stortrce.h are logged to the Windows System Event Log instead.
-    //
-    
-    // TODO - Remove this code... ¯\_(ツ)_/¯
-    /*
-    bDebugPrint = 0;
-    virtioDebugLevel = 0;
-    nVioscsiDebugLevel = 3;// TRACE_LEVEL_WARNING
-    */
+    VirtioDebugPrintProc = NoDebugPrintFunc; // This is NOT strictly required for ETW - neither DbgPrint nor DbgPrintEx will be called when EVENT_TRACING is defined
 }
-
-tDebugPrintFunc VirtioDebugPrintProc;
 #endif
 
+tDebugPrintFunc VirtioDebugPrintProc; // This is necessary for compilation due to VirtIO\kdebugprint.h requisites
 
 #undef MAKE_CASE
 #define MAKE_CASE(scsiOpCode)    \

--- a/vioscsi/utils.c
+++ b/vioscsi/utils.c
@@ -88,7 +88,9 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING R
     //TBD - Read nDebugLevel and bDebugPrint from the registry
     bDebugPrint = 1;
     virtioDebugLevel = 0;
-    nVioscsiDebugLevel = TRACE_LEVEL_ERROR;
+#if !defined(RUN_UNCHECKED)
+    nVioscsiDebugLevel = TRACE_ALL;
+#endif
 
 #if defined(PRINT_DEBUG)
     VirtioDebugPrintProc = DebugPrintFunc;
@@ -103,13 +105,24 @@ tDebugPrintFunc VirtioDebugPrintProc;
 #else
 void InitializeDebugPrints(IN PDRIVER_OBJECT  DriverObject, IN PUNICODE_STRING RegistryPath)
 {
-    //TBD - Read nDebugLevel and bDebugPrint from the registry
+    //
+    // We implement RhelDbgPrint() messages via ETW using WPP.
+    // Implementation is via FLAGS and LEVEL [nVioscsiDebugLevel() here] has no effect.
+    // This way RhelDbgPrint() messages match TRACE_LEVEL of WPP functions, which is very convenient.
+    // No need for DEBUG settings here - breaks are never sent...
+    //
+    // Note: Messages matching definitions in stortrce.h are logged to the Windows System Event Log instead.
+    //
+    
+    // TODO - Remove this code... ¯\_(ツ)_/¯
+    /*
     bDebugPrint = 0;
     virtioDebugLevel = 0;
-    nVioscsiDebugLevel = 4;// TRACE_LEVEL_ERROR;
+    nVioscsiDebugLevel = 3;// TRACE_LEVEL_WARNING
+    */
 }
 
-tDebugPrintFunc VirtioDebugPrintProc = DbgPrint;
+tDebugPrintFunc VirtioDebugPrintProc;
 #endif
 
 


### PR DESCRIPTION
Includes:
a) New RUN_UNCHECKED and RUN_MIN_CHECKED definitions for compilation conditional tracing
b) DBG definition fix (remove superfluous "define")
c) Use keywords for WPP FLAGS
d) New INLINE function WPP definitions
e) WPP Optimisation
f) ETW Prettification
g) Suggestion to cull code for InitializeDebugPrints() when EVENT_TRACING