### PR TITLE
netkvm: declare DMAR compatibility in the INF file

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -238,6 +238,8 @@ HKR, , TypesSupported,   0x00010001, 7
 HKR,,TextModeFlags,0x00010001, 0x0001
 HKR,Parameters,DisableMSI,,"0"
 HKR,Parameters,EarlyDebug,,"3"
+HKR,Parameters,DmaRemappingCompatible,0x00010001,2
+
 
 [SourceDisksNames]
 1 = %DiskId1%,,,""


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-1215

Enable DMAR if driver verifier is enabled