### PR TITLE
vioscsi: disable DMAR in the iNF file

### DIFF
--- a/vioscsi/vioscsi.inx
+++ b/vioscsi/vioscsi.inx
@@ -92,7 +92,7 @@ HKR,,TypesSupported,%REG_DWORD%,7
 [pnpsafe_pci_addreg]
 HKR, "Parameters\PnpInterface", "5", %REG_DWORD%, 0x00000001
 HKR, "Parameters", "BusType", %REG_DWORD%, 0x0000000A
-HKR, "Parameters", DmaRemappingCompatible,0x00010001,2
+HKR, "Parameters", DmaRemappingCompatible,0x00010001,0
 
 
 [pnpsafe_pci_addreg_msix]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-62318
https://issues.redhat.com/browse/RHEL-58680
Disable DMAR for storage drivers for now.