### PR TITLE
[CI-NO-BUILD] [build] Scrub the cleaners

### DIFF
--- a/Balloon/cleanAll.bat
+++ b/Balloon/cleanAll.bat
@@ -1,14 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=Balloon
+set _cln_subdirs_=app sys
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-cd app
-call cleanAll.bat
-cd ..
-
-cd sys
-call cleanAll.bat
-cd ..
-
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/NetKVM/CoInstaller/clean.bat
+++ b/NetKVM/CoInstaller/clean.bat
@@ -1,17 +1,2 @@
 @echo off
-goto start
-:rmdir
-if exist "%~1" rmdir "%~1" /s /q
-goto :eof
-
-:rmfiles
-if "%~1"=="" goto :eof
-if exist "%~1" del "%~1"
-shift
-goto rmfiles
-
-:start
-
-call :rmdir x64
-call :rmdir Win10Release
-call :rmdir Win10Debug
+call ..\..\build\clean.bat

--- a/NetKVM/Mof/clean.bat
+++ b/NetKVM/Mof/clean.bat
@@ -1,19 +1,2 @@
 @echo off
-goto start
-:rmdir
-if exist "%~1" rmdir "%~1" /s /q
-goto :eof
-
-:rmfiles
-if "%~1"=="" goto :eof
-if exist "%~1" del "%~1"
-shift
-goto rmfiles
-
-:start
-
-call :rmdir obj
-call :rmdir Win32
-call :rmdir x64
-
-call :rmfiles ..\Common\netkvmmof.h netkvm.bmf
+call ..\..\build\clean.bat

--- a/NetKVM/NotifyObject/clean.bat
+++ b/NetKVM/NotifyObject/clean.bat
@@ -1,2 +1,2 @@
 @echo off
-for %%d in (x64 x86 arm64 install) do rmdir /q /s %%d
+call ..\..\build\clean.bat

--- a/NetKVM/ProtocolService/clean.bat
+++ b/NetKVM/ProtocolService/clean.bat
@@ -1,2 +1,2 @@
 @echo off
-for %%d in (x64 x86 arm64 Win32) do rmdir /q /s %%d
+call ..\..\build\clean.bat

--- a/NetKVM/clean_dvl_log.cmd
+++ b/NetKVM/clean_dvl_log.cmd
@@ -1,6 +1,32 @@
-setlocal
-call ..\build\SetVsEnv.bat
-rmdir /q /s sdv
-msbuild.exe NetKVM-VS2015.vcxproj /t:clean /p:Configuration="Win10 Release" /P:Platform=x64
-msbuild.exe NetKVM-VS2015.vcxproj /t:sdv /p:inputs="/clean" /p:Configuration="Win10 Release" /P:platform=x64
+@echo off
+if "%loglevel%"=="" (
+  if "%~1"=="-quiet" (set loglevel=0)
+  if "%~1"=="-debug" (set loglevel=2)
+  if "%~1"=="" (set loglevel=1)
+)
+if "%loglevel%"=="0" (
+  set _cln_verbs=quiet
+  call ..\build\SetVsEnv.bat > nul
+)
+if "%loglevel%"=="1" (
+  set _cln_verbs=normal
+  call ..\build\SetVsEnv.bat
+)
+if "%loglevel%"=="2" (
+  set _cln_verbs=detailed
+  call ..\build\SetVsEnv.bat
+)
+call :rmdir .\sdv
+msbuild.exe NetKVM-VS2015.vcxproj /t:clean /p:Configuration="Win10 Release" /P:Platform=x64  -Verbosity:%_cln_verbs%
+msbuild.exe NetKVM-VS2015.vcxproj /t:sdv /p:inputs="/clean" /p:Configuration="Win10 Release" /P:platform=x64 -Verbosity:%_cln_verbs%
 endlocal
+goto :eof
+
+:rmdir
+if exist "%~1" (
+  if %loglevel% NEQ 0 echo Removing %~1 directory tree...
+  rmdir "%~1" /s /q
+) else (
+  if %loglevel% EQU 2 echo We did not find any %~1 directory tree to remove.
+)
+goto :eof

--- a/NetKVM/clean_inx.cmd
+++ b/NetKVM/clean_inx.cmd
@@ -1,0 +1,19 @@
+@echo off
+if "%loglevel%"=="" (
+  if "%~1"=="-quiet" (set loglevel=0)
+  if "%~1"=="-debug" (set loglevel=2)
+  if "%~1"=="" (set loglevel=1)
+)
+call :rmfiles *.inx
+goto :eof
+
+:rmfiles
+if "%~1"=="" goto :eof
+if exist "%~1" (
+  if %loglevel% NEQ 0 echo Removing the %~1 file...
+  del /f "%~1"
+) else (
+  if %loglevel% EQU 2 echo We did not find any %~1 file^(s^) to remove.
+)
+shift
+goto rmfiles

--- a/Q35/clean.bat
+++ b/Q35/clean.bat
@@ -1,2 +1,2 @@
-if exist Install rmdir /s /q Install
-if exist smbus.cat del /f /s /q smbus.cat
+@echo off
+call ..\build\clean.bat %*

--- a/VirtIO/WDF/clean.bat
+++ b/VirtIO/WDF/clean.bat
@@ -1,6 +1,2 @@
 @echo off
-
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-
-del /F *.log *.wrn *.err
+call ..\..\build\clean.bat

--- a/VirtIO/clean.bat
+++ b/VirtIO/clean.bat
@@ -1,9 +1,39 @@
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-rmdir /S /Q x64
+@echo off
+set _cln_tgt_=VirtIO
+set _cln_subdirs_=WDF
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-del /F *.log *.wrn *.err
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-cd WDF
-call clean.bat
-cd ..
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/build/clean.bat
+++ b/build/clean.bat
@@ -1,27 +1,55 @@
 @echo off
+if "%loglevel%"=="" (
+  if "%~1"=="-quiet" (set loglevel=0)
+  if "%~1"=="-debug" (set loglevel=2)
+  if "%~1"=="" (set loglevel=1)
+)
 
-for /D %%D IN (objchk_*) do call :rmdir %%D
-for /D %%D IN (objfre_*) do call :rmdir %%D
+for /D %%D IN (objchk_*) do @call :rmdir %%D
+for /D %%D IN (objfre_*) do @call :rmdir %%D
 
+call :rmdir .\Install
+call :rmdir .\Release
+call :rmdir .\Debug
+call :rmdir .\Install_Debug
+call :rmdir .\Win10Release
+call :rmdir .\Win10Debug
+call :rmdir .\Win11Release
+call :rmdir .\Win11Debug
 call :rmdir .\ARM64
 call :rmdir .\Win32
 call :rmdir .\x64
-
+call :rmdir .\x86
+call :rmdir .\obj
 call :rmdir .\sdv
 call :rmdir .\sdv.temp
 call :rmdir .\codeql_db
 call :rmfiles *.dvl.xml *.dvl-compat.xml
 call :rmfiles sdv-map.h sdv-user.sdv SDV-default.xml
+call :rmfiles smvstats.txt smvbuild.log vc.nativecodeanalysis.all.xml
 call :rmfiles *.sarif codeql.build.bat
-call :rmfiles *.log *.wrn *.err
+call :rmfiles build.sdv.config
+call :rmfiles *.log *.wrn *.err *.sdf
+call :rmfiles qemufwcfg.cat
+call :rmfiles ..\Common\netkvmmof.h netkvm.bmf
 goto :eof
 
 :rmdir
-if exist "%~1" rmdir "%~1" /s /q
+if exist "%~1" (
+  if %loglevel% NEQ 0 echo Removing %~1 directory tree...
+  rmdir "%~1" /s /q
+) else (
+  if %loglevel% EQU 2 echo We did not find any %~1 directory tree to remove.
+)
 goto :eof
 
 :rmfiles
 if "%~1"=="" goto :eof
-if exist "%~1" del /f "%~1"
+if exist "%~1" (
+  if %loglevel% NEQ 0 echo Removing the %~1 file...
+  del /f "%~1"
+) else (
+  if %loglevel% EQU 2 echo We did not find any %~1 file^(s^) to remove.
+)
 shift
 goto rmfiles

--- a/build/clean.bat
+++ b/build/clean.bat
@@ -24,7 +24,8 @@ call :rmdir .\obj
 call :rmdir .\sdv
 call :rmdir .\sdv.temp
 call :rmdir .\codeql_db
-call :rmfiles *.dvl.xml *.dvl-compat.xml
+call :rmfiles *.dvl.xml *.dvl-compat.xml *.dvl-win1*.xml
+call :rmfiles *.legacy_dvl_result.txt
 call :rmfiles sdv-map.h sdv-user.sdv SDV-default.xml
 call :rmfiles smvstats.txt smvbuild.log vc.nativecodeanalysis.all.xml
 call :rmfiles *.sarif codeql.build.bat

--- a/clean.bat
+++ b/clean.bat
@@ -3,7 +3,7 @@ if "%~1"=="-quiet" (set loglevel=0)
 if "%~1"=="-debug" (set loglevel=2)
 if "%~1"=="" (set loglevel=1)
 set _cln_tgt_=Repo Root
-set _cln_subdirs_=NetKVM viostor vioscsi VirtIO Balloon vioserial viorng vioinput viofs pvpanic viosock viogpu viomem viocrypt ivshmem pciserial Q35 packaging fwcfg fwcfg64
+set _cln_subdirs_=NetKVM viostor vioscsi VirtIO Balloon vioserial viorng vioinput viofs pvpanic viosock viogpu viomem viocrypt ivshmem pciserial Q35 fwcfg fwcfg64
 echo Cleaning %_cln_tgt_% ...
 call .\build\clean.bat %*
 echo.

--- a/clean.bat
+++ b/clean.bat
@@ -1,13 +1,50 @@
 @echo off
-for %%D in (VirtIO NetKVM viostor vioscsi Balloon vioserial viorng vioinput viofs pvpanic pciserial fwcfg packaging Q35 ivshmem fwcfg64 viosock viogpu) do (
-  pushd %%D
-  if exist cleanall.bat (
-    call cleanall.bat
-  ) else (
-    call clean.bat
-  )
-  popd
-)
+if "%~1"=="-quiet" (set loglevel=0)
+if "%~1"=="-debug" (set loglevel=2)
+if "%~1"=="" (set loglevel=1)
+set _cln_tgt_=Repo Root
+set _cln_subdirs_=NetKVM viostor vioscsi VirtIO Balloon vioserial viorng vioinput viofs pvpanic viosock viogpu viomem viocrypt ivshmem pciserial Q35 packaging fwcfg fwcfg64
+echo Cleaning %_cln_tgt_% ...
+call .\build\clean.bat %*
+echo.
+call :subdir %_cln_subdirs_%
+echo CLEANING COMPLETE.
+goto :eof
 
-if exist buildfre_*.log del buildfre_*.log
-if exist buildchk_*.log del buildchk_*.log
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
+
+:do_clean
+if not exist "%~dp0%~1" (
+  echo The %~1 directory was not available for cleaning.
+  echo.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  echo Cleaning %~1 ...
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    echo Cleaning %~1 ...
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      echo Cleaning %~1 ...
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        echo Cleaning %~1 ...
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %~1 directory could not be found.
+      )
+    )
+  )
+)
+echo.
+popd
+goto :eof

--- a/fwcfg/clean.bat
+++ b/fwcfg/clean.bat
@@ -1,2 +1,2 @@
-if exist Install rmdir /s /q Install
-if exist qemufwcfg.cat del /f /s /q qemufwcfg.cat
+@echo off
+call ..\build\clean.bat %*

--- a/fwcfg64/cleanAll.bat
+++ b/fwcfg64/cleanAll.bat
@@ -1,4 +1,2 @@
 @echo off
-
-rmdir /S /Q Install
 call ..\build\clean.bat

--- a/ivshmem/cleanAll.bat
+++ b/ivshmem/cleanAll.bat
@@ -1,8 +1,39 @@
-@echo on
-
-rmdir /S /Q Install
+@echo off
+set _cln_tgt_=ivshmem
+set _cln_subdirs_=test
 call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-pushd test
-call cleanAll.bat
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
+
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
 popd
+goto :eof

--- a/packaging/clean.bat
+++ b/packaging/clean.bat
@@ -1,4 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
-
+@echo off
+call ..\build\clean.bat %*

--- a/pciserial/clean.bat
+++ b/pciserial/clean.bat
@@ -1,2 +1,2 @@
-if exist Install rmdir /s /q Install
-if exist qemupciserial.cat del /f /s /q qemupciserial.cat
+@echo off
+call ..\build\clean.bat %*

--- a/pvpanic/clean.bat
+++ b/pvpanic/clean.bat
@@ -1,34 +1,39 @@
 @echo off
-
-call :rmdir Install
-call :rmdir Install_Debug
-call :rmfiles *.log
-call :rmfiles *.err
-call :cleandir
-
-pushd pvpanic
-call :cleandir
-call ..\..\build\clean.bat
-popd
-
-pushd "PVPanic Package"
-call :cleandir
-popd
-
+set _cln_tgt_=pvpanic
+set _cln_subdirs_=pvpanic "PVPanic Package"
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
 goto :eof
 
-:rmdir
-if exist "%~1" rmdir "%~1" /s /q
-goto :eof
-
-:rmfiles
+:subdir
 if "%~1"=="" goto :eof
-if exist "%~1" del /f "%~1"
+call :do_clean %1
 shift
-goto rmfiles
+goto :subdir
 
-:cleandir
-call :rmdir Win32
-call :rmdir x64
-call :rmdir ARM64
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
 goto :eof

--- a/viocrypt/clean.bat
+++ b/viocrypt/clean.bat
@@ -1,8 +1,6 @@
 @echo off
-set _cln_tgt_=NetKVM
-set _cln_subdirs_=CoInstaller Mof NotifyObject ProtocolService
-call clean_dvl_log.cmd
-call clean_inx.cmd
+set _cln_tgt_=viocrypt
+set _cln_subdirs_=dll sys test package
 call ..\build\clean.bat
 call :subdir %_cln_subdirs_%
 goto :eof

--- a/viofs/clean.bat
+++ b/viofs/clean.bat
@@ -1,45 +1,39 @@
 @echo off
-
-call :rmdir Install
-call :rmdir Install_Debug
-call :rmdir Release
-call :rmdir pci\sdv
-call :rmfiles *.log
-call :rmfiles *.err
-call :cleandir
-del pci\smvbuild.log
-del pci\smvstats.txt
-del pci\viofs.DVL.XML
-del pci\viofs.DVL-compat.XML
-
-pushd pci
-call :cleandir
-for /D %%D IN (objchk_*) do call call :rmdir %%D
-for /D %%D IN (objfre_*) do call call :rmdir %%D
-popd
-
-pushd svc
-call :rmdir Release
-call :cleandir
-popd
-
-pushd "VirtFS Package"
-call :cleandir
-popd
-
+set _cln_tgt_=viofs
+set _cln_subdirs_=pci svc "VirtFS Package"
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
 goto :eof
 
-:rmdir
-if exist "%~1" rmdir "%~1" /s /q
-goto :eof
-
-:rmfiles
+:subdir
 if "%~1"=="" goto :eof
-if exist "%~1" del /f "%~1"
+call :do_clean %1
 shift
-goto rmfiles
+goto :subdir
 
-:cleandir
-call :rmdir Win32
-call :rmdir x64
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
 goto :eof

--- a/viogpu/cleanAll.bat
+++ b/viogpu/cleanAll.bat
@@ -1,19 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=viogpu
+set _cln_subdirs_=viogpudo viogpuap viogpusc
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
-rmdir /S /Q Debug
-rmdir /S /Q Release
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-cd viogpudo
-call clean.bat
-cd ..
-
-cd viogpuap
-call clean.bat
-cd ..
-
-cd viogpusc
-call clean.bat
-cd ..
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/viogpu/viogpuap/clean.bat
+++ b/viogpu/viogpuap/clean.bat
@@ -1,11 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
-rmdir /S /Q .\Debug
-rmdir /S /Q .\Release
-
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-
-del /F *.log *.wrn *.err *.sdf
-
+@echo off
+call ..\..\build\clean.bat

--- a/viogpu/viogpudo/clean.bat
+++ b/viogpu/viogpudo/clean.bat
@@ -1,16 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
-
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-rmdir /S /Q .\sdv
-rmdir /S /Q .\sdv.temp
-rmdir /S /Q .\codeql_db
-
-del /F *.log *.wrn *.err *.sdf *.sdv *.xml
-del viogpudo.dvl.xml
-del viogpudo.dvl-compat.xml
-del build.sdv.config
-del sdv-map.h
-
+@echo off
+call ..\..\build\clean.bat

--- a/viogpu/viogpusc/clean.bat
+++ b/viogpu/viogpusc/clean.bat
@@ -1,11 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
-rmdir /S /Q .\Debug
-rmdir /S /Q .\Release
-
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-
-del /F *.log *.wrn *.err *.sdf
-
+@echo off
+call ..\..\build\clean.bat

--- a/vioinput/cleanAll.bat
+++ b/vioinput/cleanAll.bat
@@ -1,13 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=vioinput
+set _cln_subdirs_=sys hidpassthrough package
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-cd sys
-call cleanAll.bat
-cd ..\hidpassthrough
-call cleanAll.bat
-cd ..\package
-call cleanAll.bat
-cd ..
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/viomem/cleanAll.bat
+++ b/viomem/cleanAll.bat
@@ -1,14 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=viomem
+set _cln_subdirs_=app sys
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-cd app
-call cleanAll.bat
-cd ..
-
-cd sys
-call cleanAll.bat
-cd ..
-
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/viomem/cleanAll.bat
+++ b/viomem/cleanAll.bat
@@ -1,6 +1,6 @@
 @echo off
 set _cln_tgt_=viomem
-set _cln_subdirs_=app sys
+set _cln_subdirs_=sys
 call ..\build\clean.bat
 call :subdir %_cln_subdirs_%
 goto :eof

--- a/viorng/clean.bat
+++ b/viorng/clean.bat
@@ -1,6 +1,6 @@
 @echo off
 set _cln_tgt_=viorng
-set _cln_subdirs_=cng\um coinstaller test viorng "VirtRNG Package"
+set _cln_subdirs_=cng\um test viorng "VirtRNG Package"
 call ..\build\clean.bat
 call :subdir %_cln_subdirs_%
 goto :eof

--- a/viorng/clean.bat
+++ b/viorng/clean.bat
@@ -1,44 +1,39 @@
 @echo off
-
-call :rmdir Install
-call :rmdir Install_Debug
-call :rmfiles *.log
-call :rmfiles *.err
-call :cleandir
-
-pushd cng\um
-call :cleandir
-popd
-
-pushd coinstaller
-call :cleandir
-popd
-
-pushd test
-call :cleandir
-popd
-
-pushd viorng
-call ..\..\build\clean.bat
-popd
-
-pushd "VirtRNG Package"
-call :cleandir
-popd
-
+set _cln_tgt_=viorng
+set _cln_subdirs_=cng\um coinstaller test viorng "VirtRNG Package"
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
 goto :eof
 
-:rmdir
-if exist "%~1" rmdir "%~1" /s /q
-goto :eof
-
-:rmfiles
+:subdir
 if "%~1"=="" goto :eof
-if exist "%~1" del /f "%~1"
+call :do_clean %1
 shift
-goto rmfiles
+goto :subdir
 
-:cleandir
-call :rmdir Win32
-call :rmdir x64
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
 goto :eof

--- a/vioscsi/clean.bat
+++ b/vioscsi/clean.bat
@@ -1,4 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
+@echo off
 call ..\build\clean.bat

--- a/vioserial/app/cleanAll.bat
+++ b/vioserial/app/cleanAll.bat
@@ -1,9 +1,2 @@
 @echo off
 call ..\..\build\clean.bat
-
-rmdir /S /Q Release\x86
-rmdir /S /Q Release\amd64
-rmdir /S /Q Release
-rmdir /S /Q Debug\x86
-rmdir /S /Q Debug\amd64
-rmdir /S /Q Debug

--- a/vioserial/cleanAll.bat
+++ b/vioserial/cleanAll.bat
@@ -1,15 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=vioserial
+set _cln_subdirs_=app sys
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-cd app
-call cleanAll.bat
-cd ..
-
-cd sys
-call cleanAll.bat
-cd ..
-
-
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
+popd
+goto :eof

--- a/viosock/cleanAll.bat
+++ b/viosock/cleanAll.bat
@@ -1,39 +1,39 @@
-@echo on
+@echo off
+set _cln_tgt_=viosock
+set _cln_subdirs_=lib sys wsk viosock-wsk-test viosock-test viosocklib-test ViosockPackage wspsvc
+call ..\build\clean.bat
+call :subdir %_cln_subdirs_%
+goto :eof
 
-rmdir /S /Q Install
-rmdir /S /Q Install_Debug
+:subdir
+if "%~1"=="" goto :eof
+call :do_clean %1
+shift
+goto :subdir
 
-del /F *.log *.wrn *.err
-
-pushd lib
-call cleanAll.bat
+:do_clean
+echo Cleaning %_cln_tgt_% ^| %~1 ...
+if not exist "%~dp0%~1" (
+  echo The %_cln_tgt_%^\%~1 directory was not available for cleaning.
+  goto :eof
+)
+pushd "%~dp0%~1"
+if exist ".\cleanall.bat" (
+  call cleanall.bat
+) else (
+  if exist ".\clean.bat" (
+    call clean.bat
+  ) else (
+    if exist "..\..\build\clean.bat" (
+      call ..\..\build\clean.bat
+    ) else (
+      if exist "..\..\..\build\clean.bat" (
+        call ..\..\..\build\clean.bat
+      ) else (
+        echo A cleaner for the %_cln_tgt_%^\%~1 directory could not be found.
+      )
+    )
+  )
+)
 popd
-
-pushd sys
-call cleanAll.bat
-popd
-
-pushd wsk
-call cleanAll.bat
-popd
-
-pushd viosock-wsk-test
-call cleanAll.bat
-popd
-
-pushd viosock-test
-call cleanAll.bat
-popd
-
-pushd viosocklib-test
-call cleanAll.bat
-popd
-
-
-pushd "ViosockPackage"
-call cleanAll.bat
-popd
-
-pushd wsk
-call cleanAll.bat
-popd
+goto :eof

--- a/viostor/clean.bat
+++ b/viostor/clean.bat
@@ -1,14 +1,2 @@
-@echo on
-
-rmdir /S /Q .\Install
-
-for /d %%x in (objfre_*) do rmdir /S /Q %%x
-for /d %%x in (objchk_*) do rmdir /S /Q %%x
-rmdir /S /Q .\sdv
-rmdir /S /Q .\sdv.temp
-
-del /F *.log *.wrn *.err *.sdf
-del viostor.dvl.xml
-del viostor.dvl-compat.xml
-del sdv-map.h
-
+@echo off
+call ..\build\clean.bat


### PR DESCRIPTION
Refactoring:
a) Standardised cleaner routines
b) Introduced `-quiet` and `-debug` parameters when run from repo root
c) Moved from `FOR` loop to a `SHIFT` loop to more reliably support a wider variety of directory formats and characters
d) Created `NetKVM\clean_inx.cmd` to delete `*.inx` files in `NetKVM`
e) Updated `NetKVM\clean_dvl_log.cmd` to use standardised routines
f) Moved all other custom clean operations to `build\clean.bat`
g) Added missing cleaner to `viocrypt`
h) Added missing entries for `viomem` and `viocrypt` to list of directories to clean

Remove the following missing sub-directories from cleaning:
a) `viomem\app`
b) `viorng\coinstaller`