### PR TITLE
[build] Fix and extend build scripting

### DIFF
--- a/build/SetVsEnv.bat
+++ b/build/SetVsEnv.bat
@@ -7,11 +7,13 @@ if not "%EnterpriseWDK%"=="" goto ready
 if "%1"=="Win11" (
     if "%EWDK11_24H2_DIR%"=="" set EWDK11_24H2_DIR=c:\ewdk11_24h2
     call %EWDK11_24H2_DIR%\BuildEnv\SetupBuildEnv.cmd
+    @echo off
     goto :eof
 ) else (
     if "%EWDK11_DIR%"=="" set EWDK11_DIR=c:\ewdk11
     :: call :add_path "%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Redist\MSVC\14.28.29910\onecore\x86\Microsoft.VC142.OPENMP\vcomp140.dll"
     call %EWDK11_DIR%\BuildEnv\SetupBuildEnv.cmd
+    @echo off
     goto :eof
 )
 
@@ -23,5 +25,10 @@ set path=%path%;%~dp1
 goto :eof
 
 :ready
-echo We are already in EWDK version: %Version_Number%
+for /f "tokens=4 usebackq delims=\'" %%i in (`echo %%VSINSTALLDIR%%`) do @set vs_year=%%i
+echo **********************************************************************
+echo ** We are already in an Enterprise WDK build environment
+echo ** Version %BuildLab% ^| %Version_Number%
+echo ** Visual Studio %vs_year% Developer Command Prompt v%VSCMD_VER%
+echo **********************************************************************
 goto :eof

--- a/build/build.bat
+++ b/build/build.bat
@@ -11,13 +11,16 @@ rem   Debug, dbg, chk       .. to build Debug rather than the default release fl
 rem   amd64, x64, 64        .. to build only 64-bit driver
 rem   x86, 32               .. to build only 32-bit driver
 rem   /Option               .. build command to pass to VS, for example /Rebuild
-rem   Win10   .. target OS version
+rem   Win10, Win11          .. target OS version
 rem
 rem By default the script performs an incremental build of both 32-bit and 64-bit
 rem release drivers for all supported target OSes.
 rem
-rem To do a Static Driver Verifier build, append _SDV to the target OS version, for
-rem example Win10_SDV.
+rem To do a Static Driver Verifier build, append the _SDV tag to the target OS version,
+rem for example Win10_SDV. Where SDV is deprecated, we rely on CodeQL, defaulting to
+rem the WHCP_24H2 configuration. To use an earlier configuration specify WHCP_LEGACY.
+rem We also continue to run Code Analysis (CA) and Driver Verifier Log (DVL) builds 
+rem for use with HCK / WHCP.
 rem ================================================================================
 
 rem This is a list of supported build target specifications A_B where A is the
@@ -38,6 +41,46 @@ set BUILD_SPEC=
 set BUILD_ARCH=
 set BUILD_FAILED=
 
+rem We have version 24H2 epoch buildtime conditions
+rem Paramaters / Arguments:
+set WHCP_LEVEL=
+rem VSCMD_VER version splits:
+set VSCMD_VER_MAJOR=
+set VSCMD_VER_MINOR=
+set VSCMD_VER_BUILD=
+rem VSCMD_VER version specific buildtime vars
+set VSCMD_WHCP_LEVEL=
+set VIOSOCK_PREBUILD_X86_LIBS=
+
+rem Here we set the Git repo commit hash for our desired CodeQL suites
+rem Latest is 99de004870cf44628b6f8c8e28bb2e0c7e3217f0 dated 2024-02-02
+set CODEQL_DRIVER_SUITES_REPO_HASH=99de004870cf44628b6f8c8e28bb2e0c7e3217f0
+rem We can also use HEAD [44a75acab6decc2676d0e0f045de47a20a238c3c] dated 2024-07-31
+rem set CODEQL_DRIVER_SUITES_REPO_HASH=44a75acab6decc2676d0e0f045de47a20a238c3c
+rem We will compare against LOCAL_REPO_HASH later
+set CODEQL_DRIVER_SUITES_LOCAL_REPO_HASH=
+rem If necessary, set CODEQL_OFFLINE_ONLY or CODEQL_RUN_BLIND in the environment before
+rem calling this script. Use CODEQL_OFFLINE_ONLY to prevent CodeQL from getting new suites
+rem or packages. Use CODEQL_RUN_BLIND to also skip suite and package version checks.
+rem
+rem WARNING : Setting CODEQL_OFFLINE_ONLY together with WHCP_LEGACY will result in loss
+rem           of WHCP_24H2 CodeQL packages. Use with caution.
+rem
+rem set CODEQL_OFFLINE_ONLY=
+rem set CODEQL_RUN_BLIND=
+set CODEQL_VER=
+set CODEQL_VER_MAJOR=
+set CODEQL_VER_MINOR=
+set CODEQL_VER_BUILD=
+set CODEQL_VER_SPEC=
+set CODEQL_SARIF_FMT=sarifv2.1.0
+set CODEQL_PACK_GET=
+set CODEQL_PACK_DEL=
+set CODEQL_PACK_OP_FAILED=
+set WDK_DEV_SUPP_TOOLS_FAILED=
+set CODEQL_FAILED=
+set SDV_FAILED=
+
 rem Parse arguments
 :argloop
 shift /2
@@ -56,6 +99,18 @@ if /I "%ARG%"=="32" set BUILD_ARCH=x86& goto :argloop
 if /I "%ARG%"=="x86" set BUILD_ARCH=x86& goto :argloop
 if /I "%ARG%"=="ARM64" set BUILD_ARCH=ARM64& goto :argloop
 
+rem WHCP_LEGACY is not necessary. Here for completeness and templating for WHCP_NEXT.
+if /I "%ARG%"=="WHCP_LEGACY" set WHCP_LEVEL=WHCP_LEGACY& goto :argloop
+if /I "%ARG%"=="WHCP_21H2" set WHCP_LEVEL=WHCP_LEGACY& goto :argloop
+if /I "%ARG%"=="WHCP_21H2" set WHCP_LEVEL=WHCP_LEGACY& goto :argloop
+rem WHCP_23H2 is a non-existent repo branch. Included here for completeness.
+if /I "%ARG%"=="WHCP_23H2" set WHCP_LEVEL=WHCP_LEGACY& goto :argloop
+rem WHCP_24H2 is the default. Set below during SDV builds only.
+if /I "%ARG%"=="WHCP_24H2" set WHCP_LEVEL=WHCP_24H2& goto :argloop
+
+rem Enable ANSI palette support
+call :prepare_palette
+
 rem Assume that this is target OS version and split off the tag
 call :split_target_tag "%ARG%"
 
@@ -66,15 +121,21 @@ for %%N in (%SUPPORTED_BUILD_SPECS%) do (
   set FOUND_MATCH=
 
   for %%A in ("!T:_=" "!") do (
-    if /I %%A=="%TARGET%" set CANDIDATE_SPEC=!T!!TAG!
+    if /I %%A=="%TARGET%" (
+      set CANDIDATE_SPEC=!T!!TAG!
+    )
     for %%B in (%BUILD_TARGETS%) do (
-      if /I %%B==%%~A!TAG! set FOUND_MATCH=1
+      if /I %%B==%%~A!TAG! (
+        set FOUND_MATCH=1
+      )
     )
   )
 
-  if not "!FOUND_MATCH!"=="" if not "!CANDIDATE_SPEC!"=="" (
-    set BUILD_SPEC=!CANDIDATE_SPEC!
-    goto :argloop
+  if not "!FOUND_MATCH!"=="" (
+    if not "!CANDIDATE_SPEC!"=="" (
+      set BUILD_SPEC=!CANDIDATE_SPEC!
+      goto :argloop
+    )
   )
 )
 
@@ -99,11 +160,12 @@ if "%BUILD_SPEC%"=="" (
       set T=%%N
       set BUILD_SPEC=
       for %%A in ("!T:_=" "!") do (
-        if /I %%A=="!TARGET!" set BUILD_SPEC=!T!!TAG!
+        if /I %%A=="!TARGET!" (
+          set BUILD_SPEC=!T!!TAG!
+        )
       )
       if not "!BUILD_SPEC!"=="" (
         call :build_target !BUILD_SPEC!
-        if not "!BUILD_FAILED!"=="" goto :fail
       )
     )
   )
@@ -116,14 +178,13 @@ rem Figure out which archs we're building
 :build_target
 if "%BUILD_ARCH%"=="" (
   call :build_arch %1 x86
-  if not "!BUILD_FAILED!"=="" goto :eof
   call :build_arch %1 amd64
 ) else (
   call :build_arch %1 %BUILD_ARCH%
 )
 goto :eof
 
-rem Invoke Visual Studio
+rem Invoke Visual Studio and CodeQL as needed...
 :build_arch
 setlocal
 set BUILD_ARCH=%2
@@ -140,52 +201,291 @@ for /f "tokens=3 delims=_" %%T in ("%1") do (
 
 if /I "!TAG!"=="SDV" (
   rem There is no 32-bit SDV build
-  if %BUILD_ARCH%==x86 goto :eof
+  if %BUILD_ARCH%==x86 (
+    goto :build_arch_skip
+  )
   rem Check the SDV build suppression variable
   if not "%_BUILD_DISABLE_SDV%"=="" (
     echo Skipping %TARGET_PROJ_CONFIG% SDV build because _BUILD_DISABLE_SDV is set
-    goto :eof
+    goto :build_arch_skip
   )
 )
 
 rem Compose build log file name
-if %BUILD_FLAVOR%=="Debug" (
+if "%BUILD_FLAVOR%"=="Debug" (
   set BUILD_LOG_FILE=buildchk
 ) else (
   set BUILD_LOG_FILE=buildfre
 )
 set BUILD_LOG_FILE=%BUILD_LOG_FILE%_%TARGET_PLATFORM%_%BUILD_ARCH%.log
 
-if %BUILD_ARCH%==amd64 set BUILD_ARCH=x64
+if %BUILD_ARCH%==amd64 (
+  set BUILD_ARCH=x64
+)
 set TARGET_VS_CONFIG="%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%|%BUILD_ARCH%"
 
+rem We set up the Build Environment and get started...
+echo.
+call :clr_print %_c_Cyn% "Building : %BUILD_FILE%"
 pushd %BUILD_DIR%
-call "%~dp0\SetVsEnv.bat" %TARGET_PROJ_CONFIG%
+call "%~dp0SetVsEnv.bat" %TARGET_PROJ_CONFIG%
 
-if /I "!TAG!"=="SDV" (
-  echo Running SDV for %BUILD_FILE%, configuration %TARGET_VS_CONFIG%
-  call :runsdv "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
-  if exist "%CODEQL_BIN%" (
-    echo Running CodeQL for %BUILD_FILE%, configuration %TARGET_VS_CONFIG%
-    call :runql "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
-  ) else (
-      echo CodeQL binary is missing!
+rem Split MSBuild version... and check if we are Cobalt EWDK [21H2] or Germanium EWDK [24H2]...
+for /f "tokens=1,2,3 usebackq delims=." %%i in (`echo %%VSCMD_VER%%`) do @set VSCMD_VER_MAJOR=%%i && set VSCMD_VER_MINOR=%%j && set VSCMD_VER_BUILD=%%k
+rem MSBuild v17.8 and above are at least Germanium EWDK, so WHCP_24H2, everything below v17.8 is WHCP_LEGACY
+if %VSCMD_VER_MAJOR% GTR 16 (
+  if %VSCMD_VER_MAJOR% EQU 17 (
+    if not %VSCMD_VER_MINOR% LSS 8 (
+      set VSCMD_WHCP_LEVEL=WHCP_24H2
+    ) else (
+      set VSCMD_WHCP_LEVEL=WHCP_LEGACY
+    )
   )
-  call :runca "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
-  call :rundvl "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+  if %VSCMD_VER_MAJOR% GTR 17 (
+    set VSCMD_WHCP_LEVEL=WHCP_24H2
+  )
 ) else (
-  echo Building %BUILD_FILE%, configuration %TARGET_VS_CONFIG%, command %BUILD_COMMAND%
-  call :runbuild "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+  set VSCMD_WHCP_LEVEL=WHCP_LEGACY
 )
-popd
-endlocal
 
-IF ERRORLEVEL 1 (
-  set BUILD_FAILED=1
+rem Check for x86 viosock libraries and build them if needed...
+if "%BUILD_FILE%"=="virtio-win.sln" (
+  set VIOSOCK_PREBUILD_X86_LIBS=1
 )
+if "%BUILD_FILE%"=="viosock.sln" (
+  set VIOSOCK_PREBUILD_X86_LIBS=1
+)
+if "%VIOSOCK_PREBUILD_X86_LIBS%" EQU "1" (
+  if %BUILD_ARCH%==x64 (
+    if not exist "%BUILD_DIR%viosock\lib\x86\%TARGET%%BUILD_FLAVOR%\viosocklib.dll" (
+      echo.
+      call :clr_print %_c_Yel% "ATTENTION : Need to build x86 viosock libraries before building for amd64..."
+      setlocal
+      set VIRTIO_WIN_NO_ARM=1
+      if "%BUILD_FILE%"=="virtio-win.sln" (
+        pushd "%BUILD_DIR%viosock\lib"
+      )
+      if "%BUILD_FILE%"=="viosock.sln" (
+        pushd "%BUILD_DIR%\lib"
+      )
+      call ..\..\build\build.bat viosocklib.vcxproj %TARGET% x86
+      if ERRORLEVEL 1 (
+        set BUILD_FAILED=1
+      )
+      popd
+      if "%BUILD_FAILED%" EQU "1" (
+        goto :build_arch_done
+      )
+      call :clr_print %_c_Grn% "Successfully built the x86 viosock libraries."
+      echo.
+      call :clr_print %_c_Cyn% "Continuing with amd64 build..."
+      endlocal
+    )
+  )
+)
+
+rem Split builds between Code Analysis and No-Analyis...
+if /I "!TAG!"=="SDV" (
+  echo.
+  rem SDV is deprecated from Germanium EWDK and Windows 11 24H2. Making some allowances...
+  rem First, we permit environment variable SKIP_SDV_ACTUAL to truly skip SDV whilst continuing with CodeQL, CA and DVL.
+  if "%SKIP_SDV_ACTUAL%" EQU "1" (
+    call :clr_print %_c_Yel% "SKIP_SDV_ACTUAL is SET" %_c_Wht% " : Skipping Static Driver Verifier for %BUILD_FILE%"
+    echo Configuration ^: %TARGET_VS_CONFIG%
+    echo.
+  ) else (
+    rem We only do SDV for Win10 targets.
+    if "%TARGET%"=="Win10" (
+      rem Permit the Build Environment to be reconfigured if we have been called from Germanium+ EWDK
+      if not "%VSCMD_WHCP_LEVEL%"=="WHCP_LEGACY" (
+        echo Reconfiguring Build Environment to use Cobalt [21H2] EWDK Build Tools for a working Static Driver Verifier...
+        setlocal
+        if not "%EWDK11_DIR%"=="" (
+          rem set VSCMD_DEBUG=1
+          set EXTERNAL_INCLUDE=
+          set VS170COMNTOOLS=
+          set WDKBuildBinRoot=
+          set WDKToolRoot=
+          set WindowsSdkBinPath=
+          set WindowsTargetPlatformVersion=
+          set __VSCMD_PREINIT_VCToolsVersion=
+          set DevEnvDir=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\
+          set INCLUDE=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\ATLMFC\include;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include;%EWDK11_DIR%\Program Files\Windows Kits\10\include\shared;%EWDK11_DIR%\Program Files\Windows Kits\10\include\um;%EWDK11_DIR%\Program Files\Windows Kits\10\include\winrt;%EWDK11_DIR%\Program Files\Windows Kits\10\include\cppwinrt
+          set LIB=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\ATLMFC\lib\x86;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x86;%EWDK11_DIR%\Program Files\Windows Kits\10\lib\um\x86
+          set LIBPATH=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\ATLMFC\lib\x86;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x86;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x86\store\references;;C:\Windows\Microsoft.NET\Framework\v4.0.30319
+          set Path=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x86;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\VC\VCPackages;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\bin\Roslyn;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\devinit;x86;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\\MSBuild\Current\Bin;C:\Windows\Microsoft.NET\Framework\v4.0.30319;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\;%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd;C:\Users\Stripe\AppData\Local\Microsoft\WindowsApps;%EWDK11_DIR%\Program Files\Windows Kits\10\\bin\10.0.22000.0\x86;%EWDK11_DIR%\Program Files\Windows Kits\10\\Tools\bin\i386;%EWDK11_DIR%\Program Files\Windows Kits\10\\tools;%EWDK11_DIR%\Program Files\Windows Kits\10\\tools\x86;%EWDK11_DIR%\BuildEnv
+          set VCIDEInstallDir=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\VC\
+          set VCINSTALLDIR=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\
+          set VCToolsInstallDir=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\
+          set VCToolsRedistDir=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Redist\MSVC\14.29.30133\
+          set VCToolsVersion=14.29.30133
+          set VSINSTALLDIR=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\
+          set __devinit_path=%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\devinit\devinit.exe
+          call %EWDK11_DIR%\BuildEnv\SetupBuildEnv.cmd
+          call "%~dp0SetVsEnv.bat" %TARGET_PROJ_CONFIG%
+          echo.
+        ) else (
+          call :clr_print %_c_Yel% "The EWDK11_DIR environment variable is not set. Set this variable and try again."
+          set BUILD_FAILED=1
+          goto :build_arch_done
+        )
+      )
+      call :clr_print %_c_Cyn% "Running Static Driver Verifier build for %BUILD_FILE%."
+      echo Configuration ^: %TARGET_VS_CONFIG%
+      echo.
+      call :run_sdv "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+      if "%BUILD_FAILED%" EQU "1" (
+        call :clr_print %_c_Red% "Static Driver Verifier BUILD FAILED."
+        goto :build_arch_done
+      )
+      call :clr_print %_c_Grn% "Static Driver Verifier build for %BUILD_FILE% succeeded."
+      echo.
+      if not "%VSCMD_WHCP_LEVEL%"=="WHCP_LEGACY" (
+        endlocal
+      )
+    ) else (
+      call :clr_print %_c_Yel% "Skipping Static Driver Verifier for %BUILD_FILE%. SDV if for WHCP_LEGACY targets ONLY."
+      echo Configuration ^: %TARGET_VS_CONFIG%
+      echo.
+    )
+  )
+  rem Here we start our CodeQL run if we find our CodeQL CLI binary...
+  if exist "%CODEQL_BIN%" (
+    if "%WHCP_LEVEL%"=="" (
+      rem When no WHCP_LEVEL is provided, we presume analysis for WHCP_24H2.
+      rem Specify the WHCP_LEGACY argument for pre-WHCP_24H2 analysis.
+      rem Note: Technically Win10 should be WHCP_LEGACY but WHCP_24H2 still works.
+      set WHCP_LEVEL=WHCP_24H2
+    )
+    echo CodeQL ^: Checking CodeQL environment...
+    rem Get CodeQL verion...
+    for /f "tokens=5,6,7 usebackq delims=. " %%i in (`%CODEQL_BIN% --version ^| findstr /B "CodeQL"`) do @(
+      set CODEQL_VER=%%i.%%j.%%k
+      set CODEQL_VER_MAJOR=%%i
+      set CODEQL_VER_MINOR=%%j
+      set CODEQL_VER_BUILD=%%k
+    )
+    rem Cater for any CodeQL CLI breaking changes by setting CODEQL_VER_SPEC
+    if !CODEQL_VER_MAJOR! LSS 3 (
+      if !CODEQL_VER_MINOR! EQU 15 (
+        if !CODEQL_VER_BUILD! LEQ 3 (
+          set CODEQL_VER_SPEC=CODEQL_TOO_OLD
+        )
+        if !CODEQL_VER_BUILD! EQU 4 (
+          set CODEQL_VER_SPEC=CODEQL_MS_SPEC_V2_15_4
+        )
+        if !CODEQL_VER_BUILD! GTR 4 (
+          set CODEQL_VER_SPEC=CODEQL_PRE_SARIF_MINIFY
+        )        
+      ) else (
+        if !CODEQL_VER_MINOR! LSS 15 (
+          set CODEQL_VER_SPEC=CODEQL_TOO_OLD
+        ) else (
+          if !CODEQL_VER_MINOR! EQU 16 (
+            set CODEQL_VER_SPEC=CODEQL_PRE_SARIF_MINIFY
+          ) else (
+            if !CODEQL_VER_MINOR! EQU 17 (
+              if !CODEQL_VER_BUILD! LEQ 4 (
+                set CODEQL_VER_SPEC=CODEQL_PRE_SARIF_MINIFY
+              ) else (
+                set CODEQL_VER_SPEC=CODEQL_SARIF_MINIFY
+              )
+            ) else (
+              if !CODEQL_VER_MINOR! GEQ 18 (
+                set CODEQL_VER_SPEC=CODEQL_SARIF_MINIFY
+              )
+            )
+          )
+        )
+      )
+    ) else (
+      set CODEQL_VER_SPEC=CODEQL_FUTURE
+    )
+    if not "!CODEQL_VER_SPEC!"=="CODEQL_TOO_OLD" (
+      echo CodeQL ^: CodeQL CLI is version !CODEQL_VER!. Breaking change mitigation specification is !CODEQL_VER_SPEC!
+      echo.
+      call :clr_print %_c_Cyn% "CodeQL : Getting CodeQL suites for %BUILD_FILE%."
+      echo CodeQL ^: Configuration ^= %TARGET_VS_CONFIG%
+      echo CodeQL ^: WHCP_LEVEL    ^= !WHCP_LEVEL!
+      call :get_codeql_suites
+      if "!CODEQL_FAILED!" EQU "1" (
+        set BUILD_FAILED=1
+        call :clr_print %_c_Red% "CodeQL : BUILD FAILED" %_c_Wht% " - Resolve problem and try again."
+        goto :build_arch_done
+      )
+      echo.
+      call :clr_print %_c_Cyn% "CodeQL : Configuring CodeQL for %BUILD_FILE%."
+      echo CodeQL ^: Configuration ^= %TARGET_VS_CONFIG%
+      echo CodeQL ^: WHCP_LEVEL    ^= !WHCP_LEVEL!
+      call :config_ql_whcp
+      if "!CODEQL_FAILED!" EQU "1" (
+        set BUILD_FAILED=1
+        call :clr_print %_c_Red% "CodeQL : BUILD FAILED" %_c_Wht% " - Resolve problem and try again."
+        goto :build_arch_done
+      )
+      echo.
+      call :clr_print %_c_Cyn% "CodeQL : Performing CodeQL build for %BUILD_FILE%."
+      echo CodeQL ^: Configuration ^= %TARGET_VS_CONFIG%
+      echo CodeQL ^: WHCP_LEVEL    ^= !WHCP_LEVEL!
+      call :run_ql "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+      if "!CODEQL_FAILED!" EQU "1" (
+        set BUILD_FAILED=1
+        call :clr_print %_c_Red% "CodeQL : BUILD FAILED" %_c_Wht% " - Resolve problem and try again."
+        goto :build_arch_done
+      )
+      call :clr_print %_c_Grn% "CodeQL build for %BUILD_FILE% succeeded."
+      echo.
+    ) else (
+      call :clr_print %_c_Yel% "CodeQL CLI is too old at version !CODEQL_VER!..!"
+      set BUILD_FAILED=1
+    )
+  ) else (
+      call :clr_print %_c_Yel% "CodeQL binary is missing!"
+      @echo.
+  )
+  if "!BUILD_FAILED!" EQU "1" (
+    call :clr_print %_c_Red% "CodeQL : BUILD FAILED" %_c_Wht% " - Resolve problem and try again."
+    goto :build_arch_done
+  )
+  call :run_ca "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+  if "!BUILD_FAILED!" EQU "1" (
+    call :clr_print %_c_Red% "Code Analysis BUILD FAILED."
+    goto :build_arch_done
+  )
+  call :clr_print %_c_Grn% "Code Analysis build for %BUILD_FILE% succeeded."
+  echo.
+  call :run_dvl "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+  if "!BUILD_FAILED!" EQU "1" (
+    call :clr_print %_c_Red% "Driver Verifier Log BUILD FAILED."
+    goto :build_arch_done
+  )
+  call :clr_print %_c_Grn% "Driver Verifier Log build for %BUILD_FILE% succeeded."
+  echo.
+) else (
+  rem Do a build without analysis.
+  @echo.
+  @echo Build File    ^= %BUILD_FILE%
+  @echo Configuration ^= %TARGET_VS_CONFIG%
+  @echo Command       ^= %BUILD_COMMAND%
+  @echo.
+  call :run_build "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
+  if "!BUILD_FAILED!" EQU "1" (
+    call :clr_print %_c_Red% "NO-ANALYSIS BUILD FAILED."
+    goto :build_arch_done
+  )
+  call :clr_print %_c_Grn% "No-Analysis build for %BUILD_FILE% succeeded."
+  echo.
+)
+:build_arch_done
+popd
+:build_arch_skip
+if not "!BUILD_FAILED!"=="" (
+  goto :fail
+)
+endlocal
 goto :eof
 
-:runbuild:
+:run_build
 :: %1 - configuration (as "Win10 Release")
 :: %2 - platform      (as x64)
 :: %3 - build command (as "/Build")
@@ -193,73 +493,299 @@ set __TARGET__=%BUILD_COMMAND:/=%
 ::(n)ormal(d)etailed,(disg)nostic
 set __VERBOSITY__=n
 msbuild.exe -maxCpuCount %BUILD_FILE% /t:%__TARGET__% /p:Configuration="%~1" /P:Platform=%2 -fileLoggerParameters:Verbosity=%__VERBOSITY__%;LogFile=%BUILD_LOG_FILE%
+if ERRORLEVEL 1 (
+  set BUILD_FAILED=1
+)
+echo.
 goto :eof
 
-:runsdv
-echo "Removing previously created SDV artifacts"
-rmdir /s/q sdv
-
-msbuild.exe -maxCpuCount %BUILD_FILE% /t:clean /p:Configuration="%~1" /P:Platform=%2
-
-IF ERRORLEVEL 1 (
-  set BUILD_FAILED=1
+:run_sdv
+if exist sdv (
+  call :clr_print %_c_Cyn% "Removing previously created SDV artifacts..."
+  rmdir /s /q sdv
+  echo.
 )
 
-msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/clean" /p:Configuration="%~1" /P:platform=%2
-
-IF ERRORLEVEL 1 (
+if "!SDV_FAILED!" NEQ "1" (
+  call :clr_print %_c_Cyn% "Build: Cleaning for %BUILD_FILE%..."
+  msbuild.exe -maxCpuCount %BUILD_FILE% /t:clean /p:Configuration="%~1" /P:Platform=%2
+  if ERRORLEVEL 1 (
+    set SDV_FAILED=1
+  )
+  echo.
+)
+if "!SDV_FAILED!" NEQ "1" (
+  call :clr_print %_c_Cyn% "Build: Cleaning SDV for %BUILD_FILE%..."
+  msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/clean" /p:Configuration="%~1" /P:platform=%2
+  if ERRORLEVEL 1 (
+    set SDV_FAILED=1
+  )
+  echo.
+)
+if "!SDV_FAILED!" NEQ "1" (
+  call :clr_print %_c_Cyn% "Build: Performing SDV checks for %BUILD_FILE%..."
+  msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/check /devenv" /p:Configuration="%~1" /P:platform=%2
+  if ERRORLEVEL 1 (
+    set SDV_FAILED=1
+  )
+  echo.
+)
+if "!SDV_BUILD_FAILED!" EQU "1" (
   set BUILD_FAILED=1
 )
-
-msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/check /devenv" /p:Configuration="%~1" /P:platform=%2
-
-IF ERRORLEVEL 1 (
-  set BUILD_FAILED=1
-)
-
 goto :eof
 
-:runql
+:run_ql
+rem Prepare CodeQL build...
+echo call "%~dp0SetVsEnv.bat" %~1 > %~dp1codeql.build.bat
+echo msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:rebuild /p:Configuration="%~1" /P:Platform=%2 >> %~dp1codeql.build.bat
 
-echo "Removing previously created rules database"
-rmdir /s/q codeql_db
-
-echo call "%~dp0\SetVsEnv.bat" %~1 > %~dp1\codeql.build.bat
-echo msbuild.exe -maxCpuCount %~dp1\%BUILD_FILE% /t:rebuild /p:Configuration="%~1" /P:Platform=%2 >> %~dp1\codeql.build.bat
-
-call %CODEQL_BIN% database create -l=cpp -s=%~dp1 -c "%~dp1\codeql.build.bat" %~dp1\codeql_db -j 0
-
-IF ERRORLEVEL 1 (
+rem Create the CodeQL database...
+call %CODEQL_BIN% database create -l=cpp -s=%~dp1 -c "%~dp1codeql.build.bat" %~dp1codeql_db -j 0
+if ERRORLEVEL 1 (
   set CODEQL_FAILED=1
-  set BUILD_FAILED=1
 )
 
 IF "%CODEQL_FAILED%" NEQ "1" (
-  call %CODEQL_BIN% database analyze %~dp1\codeql_db %CODEQL_DRIVER_SUITES%\windows_driver_recommended.qls %CODEQL_DRIVER_SUITES%\windows_driver_mustfix.qls --format=sarifv2.1.0 --output=%~dp1\%BUILD_NAME%.sarif -j 0
+  rem Do the analysis...
+  rem CodeQL versions after v2.17.5 [2024-06-12] use a minified SARIF file. Here we make sure this does not occur.
+  if "!CODEQL_VER_SPEC!"=="CODEQL_SARIF_MINIFY" (
+    call %CODEQL_BIN% database analyze %~dp1codeql_db %CODEQL_DRIVER_SUITES%\windows_driver_recommended.qls --format=%CODEQL_SARIF_FMT% --output=%~dp1%BUILD_NAME%.sarif --no-sarif-minify -j 0
+    if ERRORLEVEL 1 (
+      set CODEQL_FAILED=1
+    )
+  ) else (
+    call %CODEQL_BIN% database analyze %~dp1codeql_db %CODEQL_DRIVER_SUITES%\windows_driver_recommended.qls --format=%CODEQL_SARIF_FMT% --output=%~dp1%BUILD_NAME%.sarif -j 0
+    if ERRORLEVEL 1 (
+      set CODEQL_FAILED=1
+    )
+  )
 )
-
-IF ERRORLEVEL 1 (
-  set BUILD_FAILED=1
-)
-
 goto :eof
 
-:runca
-msbuild.exe -maxCpuCount %BUILD_FILE% /p:Configuration="%~1" /P:Platform=%2 /P:RunCodeAnalysisOnce=True -fileLoggerParameters:LogFile=%~dp1\%BUILD_NAME%.CodeAnalysis.log
-
-IF ERRORLEVEL 1 (
+:run_ca
+call :clr_print %_c_Cyn% "Performing Code Analysis build of %BUILD_FILE%."
+msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /p:Configuration="%~1" /P:Platform=%2 /P:RunCodeAnalysisOnce=True -fileLoggerParameters:LogFile=%~dp1%BUILD_NAME%.CodeAnalysis.log
+if ERRORLEVEL 1 (
   set BUILD_FAILED=1
 )
-
 goto :eof
 
-:rundvl
-msbuild.exe -maxCpuCount %BUILD_FILE% /t:dvl /p:Configuration="%~1" /P:platform=%2
-
-IF ERRORLEVEL 1 (
+:run_dvl
+call :clr_print %_c_Cyn% "Performing Driver Verfier Log build of %BUILD_FILE%."
+msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:dvl /p:Configuration="%~1" /P:platform=%2
+if ERRORLEVEL 1 (
   set BUILD_FAILED=1
 )
+goto :eof
 
+:get_codeql_suites
+echo CodeQL ^: Checking if the WDK Developer Supplemental Tools are available...
+if exist "%CODEQL_HOME%\Windows-Driver-Developer-Supplemental-Tools" (
+  if not "%CODEQL_RUN_BLIND%"=="" (
+    call :clr_print %_c_Yel% "CodeQL : CODEQL_RUN_BLIND is set. Presuming WDK Developer Supplemental Tools are at the correct revision for desired CodeQL suites."
+    goto :eof
+  )
+  echo CodeQL ^: Checking WDK Developer Supplemental Tools are at the correct revision for desired CodeQL suites...
+  pushd "%CODEQL_HOME%\Windows-Driver-Developer-Supplemental-Tools"
+  for /f "tokens=1 usebackq" %%i in (`git show -s head --format^=format:%%H`) do @set CODEQL_DRIVER_SUITES_LOCAL_REPO_HASH=%%i
+  echo CodeQL ^: WDK Developer Supplemental Tools are at commit hash !CODEQL_DRIVER_SUITES_LOCAL_REPO_HASH!.
+  if not "!CODEQL_DRIVER_SUITES_LOCAL_REPO_HASH!"=="%CODEQL_DRIVER_SUITES_REPO_HASH%" (
+    call :clr_print %_c_Yel% "CodeQL : Incorrect revision of WDK Developer Supplemental Tools found. Updating to main branch..."
+    if "%CODEQL_OFFLINE_ONLY%"=="" (
+      git pull origin main 1> nul 2>&1
+      IF ERRORLEVEL 1 (
+        set WDK_DEV_SUPP_TOOLS_FAILED=1
+        call :clr_print %_c_Yel% "CodeQL : Error updating WDK Developer Supplemental Tools to main branch."
+      ) else (
+        echo CodeQL ^: Reverting WDK Developer Supplemental Tools to commit %CODEQL_DRIVER_SUITES_REPO_HASH%.
+        git checkout %CODEQL_DRIVER_SUITES_REPO_HASH% 1> nul 2>&1
+        IF ERRORLEVEL 1 (
+          set WDK_DEV_SUPP_TOOLS_FAILED=1
+          call :clr_print %_c_Yel% "CodeQL : Error setting WDK Developer Supplemental Tools to correct commit."
+        ) else (
+          call :clr_print %_c_Grn% "CodeQL : WDK Developer Supplemental Tools are at the correct revision for desired CodeQL suites."
+        )
+      )
+    ) else (
+      call :clr_print %_c_Yel% "CodeQL : ERROR        : Failed to update the WDK Developer Supplemental Tools as CODEQL_OFFLINE_ONLY is set."
+      call :clr_print %_c_Cyn% "CodeQL : RESOLUTION   : Manually update the WDK Developer Supplemental Tools to commit %CODEQL_DRIVER_SUITES_REPO_HASH% and try again."
+      set WDK_DEV_SUPP_TOOLS_FAILED=1
+      goto :get_codeql_suites_fail
+    )
+  ) else (
+    call :clr_print %_c_Grn% "CodeQL : WDK Developer Supplemental Tools are at the correct revision for desired CodeQL suites."
+  )
+) else (
+  if not "%CODEQL_OFFLINE_ONLY%"=="" (
+    call :clr_print %_c_Yel% "CodeQL : ERROR        : CODEQL_OFFLINE_ONLY is set and the WDK Developer Supplemental Tools were NOT found."
+    call :clr_print %_c_Cyn% "CodeQL : RESOLUTION   : Manually install the WDK Developer Supplemental Tools to commit %CODEQL_DRIVER_SUITES_REPO_HASH% and try again."
+    set WDK_DEV_SUPP_TOOLS_FAILED=1
+    goto :get_codeql_suites_fail
+  )
+  if not "%CODEQL_RUN_BLIND%"=="" (
+    call :clr_print %_c_Yel% "CodeQL : ERROR        : CODEQL_RUN_BLIND is set and the WDK Developer Supplemental Tools were NOT found."
+    call :clr_print %_c_Cyn% "CodeQL : RESOLUTION   : Manually install the WDK Developer Supplemental Tools to commit %CODEQL_DRIVER_SUITES_REPO_HASH% and try again."
+    set WDK_DEV_SUPP_TOOLS_FAILED=1
+    goto :get_codeql_suites_fail
+  )
+  call :clr_print %_c_Yel% "CodeQL : WDK Developer Supplemental Tools are NOT present. Cloning..."
+  pushd "%CODEQL_HOME%"
+  git clone https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools.git --recursive -b main 1> nul 2>&1
+  IF ERRORLEVEL 1 (
+    set WDK_DEV_SUPP_TOOLS_FAILED=1
+    call :clr_print %_c_Yel% "CodeQL : Error cloning the WDK Developer Supplemental Tools."
+  ) else (
+    pushd "%CODEQL_HOME%\Windows-Driver-Developer-Supplemental-Tools"
+    echo CodeQL ^: Reverting WDK Developer Supplemental Tools to commit %CODEQL_DRIVER_SUITES_REPO_HASH%.
+    git checkout %CODEQL_DRIVER_SUITES_REPO_HASH% 1> nul 2>&1
+    IF ERRORLEVEL 1 (
+      set WDK_DEV_SUPP_TOOLS_FAILED=1
+      call :clr_print %_c_Yel% "CodeQL : Error setting WDK Developer Supplemental Tools to correct commit."
+    ) else (
+      call :clr_print %_c_Grn% "CodeQL : WDK Developer Supplemental Tools are now at the correct revision for desired CodeQL suites."
+    )
+    popd
+  )
+)
+:get_codeql_suites_fail
+popd
+IF "!WDK_DEV_SUPP_TOOLS_FAILED!" EQU "1" (
+  set CODEQL_FAILED=1
+)
+goto :eof
+
+:config_ql_whcp
+if exist %~dp1codeql_db (
+  echo CodeQL ^: Removing previously created rules database...
+  rmdir /s /q %~dp1codeql_db
+)
+
+rem Make sure the codeql-workspace.yml file is removed [renamed] from the repo
+rem so that CodeQL ignores the repo and relies on the cache instead
+if exist "%CODEQL_DRIVER_SUITES%\..\codeql-workspace.yml" (
+  echo CodeQL ^: Renaming YAML mapping file so we use the CodeQL cache and not the repo...
+  rem del %CODEQL_DRIVER_SUITES%\..\codeql-workspace.yml
+  ren %CODEQL_DRIVER_SUITES%\..\codeql-workspace.yml codeql-workspace.yml.bak
+)
+
+rem Unfortunately, use of --model-packs=<name@range> [introduced in v2.17.5 2024-06-12] 
+rem is ignored and the most recent pack in the cache is always used.
+rem Therefore, we must prepare the cache depending on the WHCP_LEVEL variable.
+rem From CodeQL CLI v2.15.4 on we use :
+rem   [a] microsoft/windows-drivers@1.0.13 for everything below WHCP_24H2
+rem   [b] microsoft/windows-drivers@1.1.0 for WHCP_24H2 [and potentially newer WHCP configs once released]
+rem   [c] codeql/cpp-queries@0.9.0 for all configurations [and potentially newer WHCP configs once released]
+rem NOTE    : This should also work with more recent versions of CodeQL CLI [tested to v2.19.3]
+rem WARNING : Setting CODEQL_OFFLINE_ONLY together with WHCP_LEGACY will result in loss of WHCP_24H2 packages.
+if "%WHCP_LEVEL%"=="WHCP_LEGACY" (
+  set CODEQL_PACK_DEL=microsoft/windows-drivers@1.1.0
+  set CODEQL_PACK_GET=codeql/cpp-queries@0.9.0,microsoft/windows-drivers@1.0.13
+)
+if "%WHCP_LEVEL%"=="WHCP_24H2" (
+  set CODEQL_PACK_DEL=
+  set CODEQL_PACK_GET=codeql/cpp-queries@0.9.0,microsoft/windows-drivers@1.1.0
+)
+if "%WHCP_LEVEL%"=="WHCP_NEXT" (
+  rem USE THIS AS A TEMPLATE FOR FUTURE VERSIONS
+  rem NOTE: Remember to populate the CODEQL_PACK_DEL variable for all WHCP_LEVELS above with __NEXTRANGE__ packs [per WHCP_LEGACY example]...
+  set CODEQL_PACK_DEL=
+  set CODEQL_PACK_GET=codeql/cpp-queries@__NEXTRANGE__,microsoft/windows-drivers@__NEXTRANGE__
+)
+if not "%CODEQL_RUN_BLIND%"=="" (
+  call :clr_print %_c_Yel% "CodeQL : Skipping checking of CodeQL package cache as CODEQL_RUN_BLIND is set."
+  goto :eof
+)
+echo CodeQL ^: Configuring CodeQL package cache for the !WHCP_LEVEL! configuration...
+call :ql_pack_ops
+goto :eof
+
+:ql_pack_ops
+if "!CODEQL_PACK_DEL!" NEQ "" for /f "tokens=1,2,3,4,5* usebackq delims=, " %%i in (`echo !CODEQL_PACK_DEL!`) do @call :ql_pack_del %%i %%j,%%k,%%l,%%m
+if "%CODEQL_PACK_OP_FAILED%" EQU "1" (
+  set CODEQL_FAILED=1
+  goto :eof
+)
+if "!CODEQL_PACK_DEL!" NEQ "" (
+  goto :ql_pack_ops
+)
+if "!CODEQL_PACK_GET!" NEQ "" for /f "tokens=1,2,3,4,5* usebackq delims=, " %%i in (`echo !CODEQL_PACK_GET!`) do @call :ql_pack_get %%i %%j,%%k,%%l,%%m
+if "%CODEQL_PACK_OP_FAILED%" EQU "1" (
+  set CODEQL_FAILED=1
+  goto :eof
+)
+if "!CODEQL_PACK_GET!" NEQ "" (
+  goto :ql_pack_ops
+)
+goto :eof
+
+:ql_pack_get
+if "%1" NEQ "" (
+  for /f "tokens=1,2,3 delims=/@" %%i in ("%1") do @(
+    echo CodeQL ^: Checking if needed CodeQL pack ^(%%i/%%j@%%k^) is in the package cache...
+    if not exist "%USERPROFILE%\.codeql\packages\%%i\%%j\%%k" (
+      call :clr_print %_c_Yel% "CodeQL : The %%i/%%j@%%k CodeQL pack was NOT found in the package cache."
+      if not "%CODEQL_OFFLINE_ONLY%"=="" (
+        echo.
+        call :clr_print %_c_Yel% "CodeQL : ERROR        : CODEQL_OFFLINE_ONLY is set and the %%i/%%j@%%k CodeQL pack is missing."
+        call :clr_print %_c_Cyn% "CodeQL : RESOLUTION   : Manually install the %%i/%%j@%%k CodeQL pack and try again."
+        set CODEQL_PACK_OP_FAILED=1
+        set CODEQL_PACK_GET=
+        goto :ql_pack_get_fail
+      )
+      call :clr_print %_c_Cyn% "CodeQL : Downloading the %%i/%%j@%%k CodeQL pack."
+      call %CODEQL_BIN% pack download -v %%i/%%j@%%k
+      IF ERRORLEVEL 1 (
+        set CODEQL_PACK_OP_FAILED=1
+        set CODEQL_PACK_GET=
+        call :clr_print %_c_Yel% "CodeQL : Error downloading the %%i/%%j@%%k CodeQL pack."
+      ) else (
+        call :clr_print %_c_Grn% "CodeQL : Successfully downloaded the %%i/%%j@%%k CodeQL pack."
+      )
+    ) else (
+      call :clr_print %_c_Grn% "CodeQL : The %%i/%%j@%%k CodeQL pack is already in the cache."
+    )
+  )
+)
+if "%2"=="" (
+  set CODEQL_PACK_GET=
+) else (
+  set CODEQL_PACK_GET=%2,%3,%4,%5
+)
+:ql_pack_get_fail
+if "%CODEQL_PACK_OP_FAILED%" EQU "1" (
+  set CODEQL_PACK_GET=
+)
+goto :eof
+
+:ql_pack_del
+if "%1" NEQ "" (
+  for /f "tokens=1,2,3 delims=/@" %%i in ("%1") do @(
+    echo CodeQL ^: Checking if unwanted CodeQL pack ^(%%i/%%j@%%k^) is in the package cache...
+    if exist "%USERPROFILE%\.codeql\packages\%%i\%%j\%%k" (
+      call :clr_print %_c_Yel% "CodeQL : Found %%i/%%j@%%k in the CodeQL package cache."
+      echo CodeQL ^: Removing %%i/%%j@%%k...
+      rmdir /s /q "%USERPROFILE%\.codeql\packages\%%i\%%j\%%k"
+      IF ERRORLEVEL 1 (
+        call :clr_print %_c_Yel% "CodeQL : Error removing %%i/%%j@%%k."
+        set CODEQL_PACK_OP_FAILED=1
+      ) else (
+        call :clr_print %_c_Cyn% "CodeQL : Removed %%i/%%j@%%k."
+      )
+    ) else (
+      call :clr_print %_c_Grn% "CodeQL : The CodeQL package %%i/%%j@%%k was NOT found in the cache."
+    )
+  )
+)
+if "%2"=="" (
+  set CODEQL_PACK_DEL=
+) else (
+  set CODEQL_PACK_DEL=%2,%3,%4,%5
+)
+:ql_pack_del_fail
+if "%CODEQL_PACK_OP_FAILED%" EQU "1" (
+  set CODEQL_PACK_DEL=
+)
 goto :eof
 
 :split_target_tag
@@ -273,6 +799,21 @@ for /f "tokens=2 delims=_" %%T in (%1) do (
 )
 goto :eof
 
-:fail
+:clr_print
+@echo %z_esc%[%~1%~2%z_esc%[%~3%~4%z_esc%[%~5%~6%z_esc%[%~7%~8%z_esc%[0m
+goto :eof
 
+:prepare_palette
+rem Colour mods should work from ABRACADABRA_WIN10_TH2
+rem Get the ANSI ESC character [0x27]
+for /f "tokens=2 usebackq delims=#" %%i in (`"prompt #$H#$E# & echo on & for %%i in (1) do rem"`) do @set z_esc=%%i
+rem Prepare pallette
+set "_c_Red="40;91m""
+set "_c_Grn="40;92m""
+set "_c_Yel="40;93m""
+set "_c_Cyn="40;96m""
+set "_c_Wht="40;37m""
+goto :eof
+
+:fail
 exit /B 1

--- a/build/build.bat
+++ b/build/build.bat
@@ -115,16 +115,16 @@ rem Assume that this is target OS version and split off the tag
 call :split_target_tag "%ARG%"
 
 rem Verify that this target OS is supported and valid
-for %%N in (%SUPPORTED_BUILD_SPECS%) do (
+for %%N in (%SUPPORTED_BUILD_SPECS%) do @(
   set T=%%N
   set CANDIDATE_SPEC=
   set FOUND_MATCH=
 
-  for %%A in ("!T:_=" "!") do (
+  for %%A in ("!T:_=" "!") do @(
     if /I %%A=="%TARGET%" (
       set CANDIDATE_SPEC=!T!!TAG!
     )
-    for %%B in (%BUILD_TARGETS%) do (
+    for %%B in (%BUILD_TARGETS%) do @(
       if /I %%B==%%~A!TAG! (
         set FOUND_MATCH=1
       )
@@ -154,12 +154,12 @@ goto :eof
 rem Figure out which targets we're building
 :argend
 if "%BUILD_SPEC%"=="" (
-  for %%B in (%BUILD_TARGETS%) do (
+  for %%B in (%BUILD_TARGETS%) do @(
     call :split_target_tag "%%B"
-    for %%N in (%SUPPORTED_BUILD_SPECS%) do (
+    for %%N in (%SUPPORTED_BUILD_SPECS%) do @(
       set T=%%N
       set BUILD_SPEC=
-      for %%A in ("!T:_=" "!") do (
+      for %%A in ("!T:_=" "!") do @(
         if /I %%A=="!TARGET!" (
           set BUILD_SPEC=!T!!TAG!
         )
@@ -189,15 +189,9 @@ rem Invoke Visual Studio and CodeQL as needed...
 setlocal
 set BUILD_ARCH=%2
 set TAG=
-for /f "tokens=1 delims=_" %%T in ("%1") do (
-  set TARGET_PROJ_CONFIG=%%T
-)
-for /f "tokens=2 delims=_" %%T in ("%1") do (
-  set TARGET_PLATFORM=%%T
-)
-for /f "tokens=3 delims=_" %%T in ("%1") do (
-  set TAG=%%T
-)
+for /f "tokens=1 delims=_" %%T in ("%1") do @set TARGET_PROJ_CONFIG=%%T
+for /f "tokens=2 delims=_" %%T in ("%1") do @set TARGET_PLATFORM=%%T
+for /f "tokens=3 delims=_" %%T in ("%1") do @set TAG=%%T
 
 if /I "!TAG!"=="SDV" (
   rem There is no 32-bit SDV build
@@ -266,7 +260,7 @@ if "%VIOSOCK_PREBUILD_X86_LIBS%" EQU "1" (
         pushd "%BUILD_DIR%viosock\lib"
       )
       if "%BUILD_FILE%"=="viosock.sln" (
-        pushd "%BUILD_DIR%\lib"
+        pushd "%BUILD_DIR%lib"
       )
       call ..\..\build\build.bat viosocklib.vcxproj %TARGET% x86
       if ERRORLEVEL 1 (
@@ -492,7 +486,7 @@ goto :eof
 set __TARGET__=%BUILD_COMMAND:/=%
 ::(n)ormal(d)etailed,(disg)nostic
 set __VERBOSITY__=n
-msbuild.exe -maxCpuCount %BUILD_FILE% /t:%__TARGET__% /p:Configuration="%~1" /P:Platform=%2 -fileLoggerParameters:Verbosity=%__VERBOSITY__%;LogFile=%BUILD_LOG_FILE%
+msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:%__TARGET__% /p:Configuration="%~1" /P:Platform=%2 -fileLoggerParameters:Verbosity=%__VERBOSITY__%;LogFile=%~dp1%BUILD_LOG_FILE%
 if ERRORLEVEL 1 (
   set BUILD_FAILED=1
 )
@@ -508,7 +502,7 @@ if exist sdv (
 
 if "!SDV_FAILED!" NEQ "1" (
   call :clr_print %_c_Cyn% "Build: Cleaning for %BUILD_FILE%..."
-  msbuild.exe -maxCpuCount %BUILD_FILE% /t:clean /p:Configuration="%~1" /P:Platform=%2
+  msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:clean /p:Configuration="%~1" /P:Platform=%2
   if ERRORLEVEL 1 (
     set SDV_FAILED=1
   )
@@ -516,7 +510,7 @@ if "!SDV_FAILED!" NEQ "1" (
 )
 if "!SDV_FAILED!" NEQ "1" (
   call :clr_print %_c_Cyn% "Build: Cleaning SDV for %BUILD_FILE%..."
-  msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/clean" /p:Configuration="%~1" /P:platform=%2
+  msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:sdv /p:inputs="/clean" /p:Configuration="%~1" /P:platform=%2
   if ERRORLEVEL 1 (
     set SDV_FAILED=1
   )
@@ -524,13 +518,13 @@ if "!SDV_FAILED!" NEQ "1" (
 )
 if "!SDV_FAILED!" NEQ "1" (
   call :clr_print %_c_Cyn% "Build: Performing SDV checks for %BUILD_FILE%..."
-  msbuild.exe -maxCpuCount %BUILD_FILE% /t:sdv /p:inputs="/check /devenv" /p:Configuration="%~1" /P:platform=%2
+  msbuild.exe -maxCpuCount %~dp1%BUILD_FILE% /t:sdv /p:inputs="/check /devenv" /p:Configuration="%~1" /P:platform=%2
   if ERRORLEVEL 1 (
     set SDV_FAILED=1
   )
   echo.
 )
-if "!SDV_BUILD_FAILED!" EQU "1" (
+if "!SDV_FAILED!" EQU "1" (
   set BUILD_FAILED=1
 )
 goto :eof
@@ -791,12 +785,8 @@ goto :eof
 :split_target_tag
 set TARGET=
 set TAG=
-for /f "tokens=1 delims=_" %%T in (%1) do (
-    set TARGET=%%T
-)
-for /f "tokens=2 delims=_" %%T in (%1) do (
-    set TAG=_%%T
-)
+for /f "tokens=1 delims=_" %%T in (%1) do @set TARGET=%%T
+for /f "tokens=2 delims=_" %%T in (%1) do @set TAG=_%%T
 goto :eof
 
 :clr_print

--- a/build/clean_build_log.bat
+++ b/build/clean_build_log.bat
@@ -1,0 +1,21 @@
+@echo off
+cd /d %~dp0
+cd ..
+if not exist ".\build_log.txt" goto :eof
+setlocal
+Title Clean Build Log
+echo Cleaning Build Log...
+timeout 3 1> nul 2>&1
+for /f "tokens=2 usebackq delims=#" %%i in (`"prompt #$H#$E# & echo on & for %%i in (1) do rem"`) do @set z_esc=%%i
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[0m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[40\;91m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[40\;92m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[40\;93m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[40\;96m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[40\;37m',''}|SC .\build_log.txt"
+@PowerShell "(GC .\build_log.txt)|%%{$_ -Replace '%z_esc%\[',''}|SC .\build_log.txt"
+echo Build Log successfully cleaned.
+echo Removing scheduled task...
+schtasks /delete /tn build_log_cleanup /f
+timeout 5
+endlocal

--- a/build/signAll.bat
+++ b/build/signAll.bat
@@ -9,7 +9,7 @@ endlocal
 
 setlocal
 echo Loading Windows 11 build env
-call "%~dp0\SetVsEnv.bat" Win10
+call "%~dp0\SetVsEnv.bat" Win11
 for /r "%~dp0\..\" %%i in (*.sys) do call :sign_if_win11 "%%i"
 for /r "%~dp0\..\" %%i in (*.cat) do call :sign_if_win11 "%%i"
 endlocal

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -44,7 +44,7 @@ if errorlevel 1 goto :fail
 call :prepare_palette
 
 path %path%;C:\Program Files (x86)\Windows Kits\10\bin\x86\
-for %%D in (pciserial fwcfg Q35 packaging) do @(
+for %%D in (pciserial fwcfg Q35) do @(
   echo.
   call :_color_echo %_c_Cyn% "Building : %%D"
   pushd %%D

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -39,13 +39,12 @@ if errorlevel 1 goto :fail
 call build\build.bat viomem\sys\viomem.vcxproj "Win10_SDV Win11_SDV" %*
 if errorlevel 1 goto :fail
 
-
 :nosdv2022
 
 call :prepare_palette
 
 path %path%;C:\Program Files (x86)\Windows Kits\10\bin\x86\
-for %%D in (pciserial fwcfg Q35 packaging) do (
+for %%D in (pciserial fwcfg Q35 packaging) do @(
   echo.
   call :_color_echo %_c_Cyn% "Building : %%D"
   pushd %%D
@@ -56,31 +55,110 @@ for %%D in (pciserial fwcfg Q35 packaging) do (
 )
 
 echo.
-call :_color_echo %_c_Cyn% "Processing DVL xml files..."
-for /R %%f in (*.dvl.xml) do call :process_xml %%f
-call :_color_echo %_c_Cyn% "All processing completed."
+call :_color_echo %_c_Cyn% "Processing DVL files to create COMPAT (Redstone 1 / 1607) version..."
+for /R %%f in (*.dvl.xml) do @call :process_xml %%f
+if "%found_dvl_xml%"=="" (
+  call :_color_echo %_c_Yel% "WARNING : No DVL files were found."
+) else (
+  call :_color_echo %_c_Cyn% "Processing of DVL files is complete."
+)
+
+rem Report SDV and DVL creation status...
+for %%D in (NetKVM vioscsi viostor) do @call :check_sdv_dvl %%D
+
+:bld_success
 echo.
 call :_color_echo %_c_Grn% "BUILD COMPLETED SUCCESSFULLY."
-exit /B 0
+call :leave 0
+goto :eof
 
 :fail
 call :_color_echo %_c_Red% "BUILD FAILED."
 set BUILD_FAILED=
-exit /B 1
+call :leave 1
+goto :eof
 
 :process_xml
+set found_dvl_xml=Yes
 if not exist "%~dpn1-compat%~x1" (
   call :fudge_xml %1
 ) else (
-  rem NOTE: Here we retain the COMPAT version created by C:\DVL1903\dvl.exe
+  rem NOTE: Here we retain the Windows 10 version 1607 (build 14393) COMPAT DVL.
   call :_color_echo %_c_Grn% "The file already exists : %~dpn1-compat%~x1"
 )
 goto :eof
 
 :fudge_xml
 call :_color_echo %_c_Yel% "Auto-magically creating : %~dpn1-compat%~x1"
-rem NOTE: Here we also have to remove the ..General.Checksum because we modded the file and changed it.
+rem NOTE: Here we create a Windows 10 version 1607 (build 14393) COMPAT DVL.
 findstr /v /c:"General.Checksum" "%~1" | findstr /v /c:".Semmle." > "%~dpn1-compat%~x1"
+goto :eof
+
+:check_sdv_dvl
+echo.
+set drvr=%~1
+set results_file="%~dpn1\%~1.legacy_dvl_result.txt"
+set sdv_dir="%~dpn1\sdv"
+call :_color_echo %_c_Cyn% "%drvr% : Checking if the SDV directory exists..."
+if exist %sdv_dir% (
+  call :_color_echo %_c_Grn% "%drvr% : SUCCESS : The SDV directory exists."
+) else (
+  call :_color_echo %_c_Yel% "%drvr% : WARNING : The SDV directory does NOT exist."
+)
+echo.
+call :_color_echo %_c_Cyn% "%drvr% : Checking if the DVL build logged results..."
+if exist "%results_file%" (
+  call :_color_echo %_c_Cyn% "%drvr% : Reporting Driver Verification Log build results..."
+  if exist "%~dpn1\%~1.DVL-win10-latest.XML" (
+    call :_color_echo %_c_Grn% "%drvr% : SUCCESS : Latest Windows 10 DVL was created with the Cobalt EWDK."
+  ) else (
+    call :_color_echo %_c_Yel% "%drvr% : WARNING : Latest Windows 10 DVL was NOT created."
+  )
+  if exist "%~dpn1\%~1.DVL-win11-latest.XML" (
+    call :_color_echo %_c_Grn% "%drvr% : SUCCESS : Latest Windows 11 DVL was created."
+  ) else (
+    call :_color_echo %_c_Yel% "%drvr% : WARNING : Latest Windows 11 DVL was NOT created."
+  )
+  for /f "tokens=1,2 usebackq delims=," %%i in (`type %%results_file%%`) do @call :check_dvl_result %%i %%j
+  del /f "%results_file%"
+) else (
+  call :_color_echo %_c_Yel% "%drvr% : WARNING : No DVL build results were logged."
+)
+goto :eof
+
+:check_dvl_result
+set dvl_ver=%~1
+set dvl_outcome=%~2
+if "%dvl_ver%"=="%dvl_outcome%" (
+  if "%dvl_ver%"=="1607" (
+    call :_color_echo %_c_Grn% "%drvr% : SUCCESS : Windows 10 version %dvl_ver% DVL was created with the Redstone 1 EWDK."
+  ) else (
+    if "%dvl_ver%"=="1903" (
+      call :_color_echo %_c_Grn% "%drvr% : SUCCESS : Windows 10 version %dvl_ver% DVL was created with the Titanium EWDK."
+    ) else (
+      call :_color_echo %_c_Grn% "%drvr% : SUCCESS : Windows 10 version %dvl_ver% DVL was created with an EWDK of the same version."
+    )
+  )
+) else (
+  if "%dvl_ver%"=="1607" (
+    if "%dvl_outcome%"=="1903" (
+      call :_color_echo %_c_Yel% "%drvr% : WARNING : Windows 10 version %dvl_ver% DVL was derived from an alternate DVL created with the Titanium EWDK."
+    ) else (
+      if "%dvl_outcome%"=="latest" (
+        call :_color_echo %_c_Yel% "%drvr% : WARNING : Windows 10 version %dvl_ver% DVL was derived from an alternate DVL created with the Cobalt EWDK."
+      )
+    )
+  )
+  if "%dvl_outcome%"=="fail" (
+    if "%dvl_ver%"=="1607" (
+      call :_color_echo %_c_Red% "%drvr% : FAILURE : Windows 10 version %dvl_ver% DVL was NOT created. The %drvr%.DVL-compat.XML file will be missing."
+    ) else (
+      if "%dvl_ver%"=="1903" (
+        call :_color_echo %_c_Red% "%drvr% : FAILURE : Windows 10 version %dvl_ver% DVL was NOT created. The %drvr%.DVL-win10.XML file will be missing."
+      )
+    )
+  )
+)
 goto :eof
 
 :_color_echo
@@ -98,3 +176,11 @@ set "_c_Yel="40;93m""
 set "_c_Cyn="40;96m""
 set "_c_Wht="40;37m""
 goto :eof
+
+:leave
+if exist ".\build_log.txt" (
+  call schtasks /create /tn build_log_cleanup /tr "%comspec% /c %~dp0build\clean_build_log.bat" /sc ONCE /sd 01/01/1910 /st 00:00 1> nul 2>&1
+  call schtasks /run /tn build_log_cleanup 1> nul 2>&1
+)
+exit /B %1
+goto :eof :: never hit


### PR DESCRIPTION
1. Fixed various syntax issues, e.g. unquoted variables
2. Unwrapped nested `IF` statements to ensure no jumping out of loops
3. Extended colour pallette to `stdout`
4. Introduced environment variable `SKIP_SDV_ACTUAL` to skip _Static Driver Verifier (SDV)_ during analysis builds. _CodeQL, Code Analysis (CA)_ and _DVL_ operations are still executed. Default is to perform the SDV build (unchanged behaviour).
5. Make actual SDV build conditional (`Win10_SDV` only) f)
6. Introduced managed CodeQL package cache and test suite versioning control. If the CodeQL binary is detected at `CODEQL_BIN` a CodeQL build commences, otherwise it is skipped (unchanged behaviour). The package cache versions are set in the `:config_ql_whcp` function (new). Test suite versioning is via git hash of the WDK Developer Supplemental Tools repository (new, depends on `git`). The versions are determined by the value of the `WHCP_LEVEL` variable, which can be either `WHCP_LEGACY` or `WHCP_24H2`. Provision for future WHCP versions is templated as `WHCP_NEXT`.
7. Introduced environment variable `CODEQL_OFFLINE_ONLY` to perform package cache and suite version checking but NOT download any needed updates. Exits on error expecting resolution. Requires `git`.
8. Introduced environment variable `CODEQL_RUN_BLIND` to retain legacy behaviour and perform no package cache or suite version checking. It presumes the prerequisites are present. Removes `git` dependency.
9. Pre-builds x86 `viosock` libraries when building `virtio-win.sln` or `viosock.sln` for `amd64` in the circumstances the required x86 libraries do not already exist.
10. If running in a Germanium EWDK environment, the script will instantiate a Cobalt EWDK environment to build Win10 SDV operations, and will return to Germanium EWDK when done.
11. Use Germanium EWDK to sign Win11 drivers.
12. Enforce `echo off` after calling `SetupBuildEnv.cmd`
13. Provide some extra EWDK details when `EnterpriseWDK=True`
14. Prettify last leg of build and provide SUCCESS / FAIL feedback.