### PR TITLE
[vioscsi] Add missing HW_INITIALIZATION_DATA Members

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -395,6 +395,7 @@ DriverEntry(
     hwInitData.MapBuffers               = STOR_MAP_NON_READ_WRITE_BUFFERS;
 
     hwInitData.SrbTypeFlags = SRB_TYPE_FLAG_STORAGE_REQUEST_BLOCK;
+    hwInitData.AddressTypeFlags         = ADDRESS_TYPE_FLAG_BTL8;
 
     initResult = StorPortInitialize(DriverObject,
                                     RegistryPath,


### PR DESCRIPTION
Add missing StorPort HW_INITIALIZATION_DATA Members [per MS docs](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/storport/ns-storport-_hw_initialization_data-r1)

1. AddressTypeFlags = ADDRESS_TYPE_FLAG_BTL8

Split from PR #1215.