### PR TITLE
[vioscsi] Implement cold and hot tracing paths

### DIFF
--- a/vioscsi/buildAll.bat
+++ b/vioscsi/buildAll.bat
@@ -1,6 +1,15 @@
 @echo off
+
+rem Uncomment the following to enable ETW or debug for the hot path too. Defaults to cold path ETW only.
+rem set RUN_WPP_ALL_PATHS=Yes
+
+rem Uncomment the following to compile without ETW or debug support.
+rem set FORCE_RUN_UNCHECKED=Yes
+rem Uncomment the following to enable debug instead of ETW.
+rem set FORCE_RUN_DEBUG=Yes
+
 if "%VIRTIO_WIN_NO_ARM%"=="" call ..\build\build.bat vioscsi.sln "Win10 Win11" ARM64
 if errorlevel 1 goto :eof
 call ..\build\build.bat vioscsi.sln "Win10 Win11" %*
 if errorlevel 1 goto :eof
-call ..\build\build.bat vioscsi.vcxproj "Win11_SDV" %*
+call ..\build\build.bat vioscsi.vcxproj "Win10_SDV Win11_SDV" %*

--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -32,7 +32,7 @@
 #include "trace.h"
 #include "helper.h"
 
-#if defined(EVENT_TRACING)
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
 #include "helper.tmh"
 #endif
 
@@ -46,6 +46,10 @@ SendSRB(
     IN PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_SRB_HP();
+    #endif
+
     PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     PSRB_EXTENSION      srbExt   = NULL;
     PVOID               va = NULL;
@@ -60,8 +64,6 @@ SendSRB(
     PREQUEST_LIST       element;
     ULONG               vq_req_idx;
 
-ENTER_FN_SRB();
-
     if (!Srb)
         return;
 
@@ -71,7 +73,9 @@ ENTER_FN_SRB();
         return;
     }
 
-    LOG_SRB_INFO();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    LOG_SRB_INFO_HP();
+    #endif
 
     if (adaptExt->num_queues > 1) {
         STARTIO_PERFORMANCE_PARAMETERS param;
@@ -83,14 +87,18 @@ ENTER_FN_SRB();
                 QueueNumber %= adaptExt->num_queues;
             }
         } else {
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_ERROR, " StorPortGetStartIoPerfParams failed srb 0x%p status 0x%x MessageNumber %d.\n", Srb, status, param.MessageNumber);
+            #endif
         }
     }
 
     srbExt = SRB_EXTENSION(Srb);
 
     if (!srbExt) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " No SRB Extenstion for SRB 0x%p \n", Srb);
+        #endif
         return;
     }
 
@@ -98,7 +106,9 @@ ENTER_FN_SRB();
     LockContext = &adaptExt->dpc[vq_req_idx];
 
     if (adaptExt->reset_in_progress) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Reset is in progress, completing SRB 0x%p with SRB_STATUS_BUS_RESET.\n", Srb);
+        #endif
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BUS_RESET);
         CompleteRequest(DeviceExtension, Srb);
         return;
@@ -122,9 +132,11 @@ ENTER_FN_SRB();
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BUSY);
         SRB_SET_SCSI_STATUS(Srb, ScsiStatus);
         StorPortBusy(DeviceExtension, 10);
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_WARNING, 
                      " Could not put an SRB into a VQ due to error %s (%i). To be completed with SRB_STATUS_BUSY. QueueNumber = %lu, SRB = 0x%p, Lun = %d, TimeOut = %d.\n", 
                      (add_buffer_req_status == -ENOSPC) ? "ENOSPC" : "UNKNOWN", add_buffer_req_status, QueueNumber, srbExt->Srb, SRB_LUN(Srb), Srb->TimeOutValue);
+        #endif
         CompleteRequest(DeviceExtension, Srb);
     }
     StorPortReleaseSpinLock(DeviceExtension, &LockHandle);
@@ -132,7 +144,9 @@ ENTER_FN_SRB();
         virtqueue_notify(adaptExt->vq[QueueNumber]);
     }
 
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_FN_SRB_HP();
+    #endif
 }
 
 BOOLEAN
@@ -141,25 +155,32 @@ SynchronizedTMFRoutine(
     IN PVOID Context
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     PSCSI_REQUEST_BLOCK Srb      = (PSCSI_REQUEST_BLOCK) Context;
     PSRB_EXTENSION      srbExt   = SRB_EXTENSION(Srb);
     PVOID               va;
     ULONGLONG           pa;
 
-ENTER_FN();
     SET_VA_PA();
     if (virtqueue_add_buf(adaptExt->vq[VIRTIO_SCSI_CONTROL_QUEUE],
                      srbExt->psgl,
                      srbExt->out, srbExt->in,
                      &srbExt->cmd, va, pa) >= 0){
         virtqueue_kick(adaptExt->vq[VIRTIO_SCSI_CONTROL_QUEUE]);
-EXIT_FN();
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return TRUE;
     }
     SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BUSY);
     StorPortBusy(DeviceExtension, adaptExt->queue_depth);
-EXIT_ERR();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_ERR();
+    #endif
     return FALSE;
 }
 
@@ -169,9 +190,13 @@ SendTMF(
     IN PSCSI_REQUEST_BLOCK Srb
     )
 {
-ENTER_FN();
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
     return StorPortSynchronizeAccess(DeviceExtension, SynchronizedTMFRoutine, (PVOID)Srb);
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
 
 BOOLEAN
@@ -179,6 +204,10 @@ DeviceReset(
     IN PVOID DeviceExtension
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     PSCSI_REQUEST_BLOCK   Srb = &adaptExt->tmf_cmd.Srb;
     PSRB_EXTENSION        srbExt = adaptExt->tmf_cmd.SrbExtension;
@@ -186,8 +215,10 @@ DeviceReset(
     ULONG                 fragLen;
     ULONG                 sgElement;
 
-ENTER_FN();
     if (adaptExt->dump_mode) {
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return TRUE;
     }
     ASSERT(adaptExt->tmf_infly == FALSE);
@@ -215,9 +246,15 @@ ENTER_FN();
     StorPortPause(DeviceExtension, 60);
     if (!SendTMF(DeviceExtension, Srb)) {
         StorPortResume(DeviceExtension);
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return FALSE;
     }
     adaptExt->tmf_infly = TRUE;
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return TRUE;
 }
 
@@ -226,9 +263,13 @@ ShutDown(
     IN PVOID DeviceExtension
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     ULONG index;
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-ENTER_FN();
+
     virtio_device_reset(&adaptExt->vdev);
     virtio_delete_queues(&adaptExt->vdev);
     for (index = VIRTIO_SCSI_CONTROL_QUEUE; index < adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0; ++index) {
@@ -236,7 +277,9 @@ ENTER_FN();
     }
 
     virtio_device_shutdown(&adaptExt->vdev);
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
 
 VOID
@@ -244,53 +287,49 @@ GetScsiConfig(
     IN PVOID DeviceExtension
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-ENTER_FN();
 
     adaptExt->features = virtio_get_features(&adaptExt->vdev);
     adaptExt->indirect = CHECKBIT(adaptExt->features, VIRTIO_RING_F_INDIRECT_DESC);
 
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, seg_max),
                       &adaptExt->scsi_config.seg_max, sizeof(adaptExt->scsi_config.seg_max));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " seg_max %lu\n", adaptExt->scsi_config.seg_max);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, num_queues),
                       &adaptExt->scsi_config.num_queues, sizeof(adaptExt->scsi_config.num_queues));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " num_queues %lu\n", adaptExt->scsi_config.num_queues);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, max_sectors),
                       &adaptExt->scsi_config.max_sectors, sizeof(adaptExt->scsi_config.max_sectors));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_sectors %lu\n", adaptExt->scsi_config.max_sectors);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, cmd_per_lun),
                       &adaptExt->scsi_config.cmd_per_lun, sizeof(adaptExt->scsi_config.cmd_per_lun));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " cmd_per_lun %lu\n", adaptExt->scsi_config.cmd_per_lun);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, event_info_size),
                       &adaptExt->scsi_config.event_info_size, sizeof(adaptExt->scsi_config.event_info_size));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " event_info_size %lu\n", adaptExt->scsi_config.event_info_size);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, sense_size),
                       &adaptExt->scsi_config.sense_size, sizeof(adaptExt->scsi_config.sense_size));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " sense_size %lu\n", adaptExt->scsi_config.sense_size);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, cdb_size),
                       &adaptExt->scsi_config.cdb_size, sizeof(adaptExt->scsi_config.cdb_size));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " cdb_size %lu\n", adaptExt->scsi_config.cdb_size);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, max_channel),
                       &adaptExt->scsi_config.max_channel, sizeof(adaptExt->scsi_config.max_channel));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_channel %u\n", adaptExt->scsi_config.max_channel);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, max_target),
                       &adaptExt->scsi_config.max_target, sizeof(adaptExt->scsi_config.max_target));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_target %u\n", adaptExt->scsi_config.max_target);
-
     virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(VirtIOSCSIConfig, max_lun),
                       &adaptExt->scsi_config.max_lun, sizeof(adaptExt->scsi_config.max_lun));
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_lun %lu\n", adaptExt->scsi_config.max_lun);
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " seg_max : %lu \n", adaptExt->scsi_config.seg_max);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_sectors : %lu \n", adaptExt->scsi_config.max_sectors);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " num_queues : %lu \n", adaptExt->scsi_config.num_queues);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " cmd_per_lun : %lu \n", adaptExt->scsi_config.cmd_per_lun);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " event_info_size : %lu \n", adaptExt->scsi_config.event_info_size);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " sense_size : %lu \n", adaptExt->scsi_config.sense_size);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " cdb_size : %lu \n", adaptExt->scsi_config.cdb_size);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_channel : %u  \n", adaptExt->scsi_config.max_channel);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_target : %u  \n", adaptExt->scsi_config.max_target);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_lun : %lu \n", adaptExt->scsi_config.max_lun);
+    EXIT_FN();
+    #endif
 }
 
 
@@ -299,9 +338,12 @@ SetGuestFeatures(
     IN PVOID DeviceExtension
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     ULONGLONG          guestFeatures = 0;
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-ENTER_FN();
 
     if (CHECKBIT(adaptExt->features, VIRTIO_F_VERSION_1)) {
         guestFeatures |= (1ULL << VIRTIO_F_VERSION_1);
@@ -327,13 +369,32 @@ ENTER_FN();
     if (CHECKBIT(adaptExt->features, VIRTIO_SCSI_F_HOTPLUG)) {
         guestFeatures |= (1ULL << VIRTIO_SCSI_F_HOTPLUG);
     }
+
+    #if !defined(RUN_UNCHECKED)
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_F_VERSION_1 flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_F_VERSION_1)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_F_RING_PACKED flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_F_RING_PACKED)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_F_ANY_LAYOUT flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_F_ANY_LAYOUT)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_F_ACCESS_PLATFORM flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_F_ACCESS_PLATFORM)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_RING_F_EVENT_IDX flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_RING_F_EVENT_IDX)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_RING_F_INDIRECT_DESC flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_RING_F_INDIRECT_DESC)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_SCSI_F_CHANGE flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_SCSI_F_CHANGE)) ? "ON" : "OFF");
+    RhelDbgPrint(TRACE_GUEST_FEATURES, " VIRTIO_SCSI_F_HOTPLUG flag is : %s \n", (guestFeatures & (1ULL << VIRTIO_SCSI_F_HOTPLUG)) ? "ON" : "OFF");
+    #endif
+
     if (!NT_SUCCESS(virtio_set_features(&adaptExt->vdev, guestFeatures))) {
-        RhelDbgPrint(TRACE_LEVEL_FATAL, " virtio_set_features failed\n");
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_WARNING, " virtio_set_features() FAILED...!!!\n");
+        #endif
+    } else {
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_GUEST_FEATURES, " virtio_set_features() executed successfully.\n");
+        #endif
     }
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
-
 
 BOOLEAN
 InitVirtIODevice(
@@ -352,7 +413,9 @@ InitVirtIODevice(
         LogError(adaptExt,
                 SP_INTERNAL_ADAPTER_ERROR,
                 __LINE__);
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Failed to initialize virtio device, error %x\n", status);
+        #endif
         return FALSE;
     }
     return TRUE;
@@ -364,11 +427,14 @@ InitHW(
     IN PPORT_CONFIGURATION_INFORMATION ConfigInfo
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PACCESS_RANGE      accessRange;
     PADAPTER_EXTENSION adaptExt;
     ULONG pci_cfg_len, i;
 
-ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     adaptExt->system_io_bus_number = ConfigInfo->SystemIoBusNumber;
     adaptExt->slot_number = ConfigInfo->SlotNumber;
@@ -382,51 +448,212 @@ ENTER_FN();
         (PVOID)&adaptExt->pci_config_buf,
         sizeof(adaptExt->pci_config_buf));
 
+    #if !defined(RUN_UNCHECKED)
+    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " StorPortGetBusData returns: %lu \n", pci_cfg_len);
+    #endif
+
     if (pci_cfg_len != sizeof(adaptExt->pci_config_buf)) {
         LogError(DeviceExtension,
                 SP_INTERNAL_ADAPTER_ERROR,
                 __LINE__);
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " CANNOT READ PCI CONFIGURATION SPACE %d\n", pci_cfg_len);
+        EXIT_FN();
+        #endif
         return FALSE;
     }
+    
+    PPCI_COMMON_HEADER          pPciComHeader;
+    UCHAR                       CapOffset;
+    PPCI_CAPABILITIES_HEADER    pCapOffset;
+    PPCI_MSIX_CAPABILITY        pMsixCapOffset;
+    PVIRTIO_PCI_COMMON_CFG_CAP  pVirtioCommonCfgCap;
+    PVIRTIO_PCI_NOTIFY_CAP      pVirtioNotifyCap;
+    PVIRTIO_PCI_ISR_CAP         pVirtioIsrCap;
+    PVIRTIO_PCI_DEVICE_CAP      pVirtioDeviceCap;
+    PPCI_RHEL_QEMU_CAPABILITY   pQemuCapOffset;
+    ULONG                       max_cpus, idx;
 
+    pPciComHeader = &adaptExt->pci_config;
+    if ((pPciComHeader->Status & PCI_STATUS_CAPABILITIES_LIST) == 0)
     {
-        UCHAR CapOffset;
-        PPCI_MSIX_CAPABILITY pMsixCapOffset;
-        PPCI_COMMON_HEADER   pPciComHeader;
-        pPciComHeader = &adaptExt->pci_config;
-        if ((pPciComHeader->Status & PCI_STATUS_CAPABILITIES_LIST) == 0)
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " NO CAPABILITIES_LIST\n");
+        #endif
+    } else
+    {
+        if ((pPciComHeader->HeaderType & (~PCI_MULTIFUNCTION)) == PCI_DEVICE_TYPE)
         {
-            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " NO CAPABILITIES_LIST\n");
-        }
-        else
-        {
-            if ((pPciComHeader->HeaderType & (~PCI_MULTIFUNCTION)) == PCI_DEVICE_TYPE)
+            CapOffset = pPciComHeader->u.type0.CapabilitiesPtr;
+            while (CapOffset != 0)
             {
-                CapOffset = pPciComHeader->u.type0.CapabilitiesPtr;
-                while (CapOffset != 0)
+                pCapOffset = (PPCI_CAPABILITIES_HEADER)&adaptExt->pci_config_buf[CapOffset];
+                if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_MSIX)
                 {
                     pMsixCapOffset = (PPCI_MSIX_CAPABILITY)&adaptExt->pci_config_buf[CapOffset];
-                    if (pMsixCapOffset->Header.CapabilityID == PCI_CAPABILITY_ID_MSIX)
-                    {
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, "MessageControl.TableSize = %d\n", pMsixCapOffset->MessageControl.TableSize);
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, "MessageControl.FunctionMask = %d\n", pMsixCapOffset->MessageControl.FunctionMask);
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, "MessageControl.MSIXEnable = %d\n", pMsixCapOffset->MessageControl.MSIXEnable);
-
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MessageTable = %lu\n", pMsixCapOffset->MessageTable.TableOffset);
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " PBATable = %lu\n", pMsixCapOffset->PBATable.TableOffset);
-                        adaptExt->msix_enabled = (pMsixCapOffset->MessageControl.MSIXEnable == 1);
-                    } else
-                    {
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " CapabilityID = %x, Next CapOffset = %x\n", pMsixCapOffset->Header.CapabilityID, CapOffset);
+                    adaptExt->msix_enabled = (pMsixCapOffset->MessageControl.MSIXEnable == 1);
+                    #if !defined(RUN_UNCHECKED)
+                    RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_MSIX, Next Capability Offset : 0x%x", CapOffset);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : MessageControl.TableSize : %lu \n", pMsixCapOffset->MessageControl.TableSize);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : Number of Table Entries (Vectors) : %lu \n", pMsixCapOffset->MessageControl.TableSize + 1);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : MessageControl.FunctionMask : 0x%x \n", pMsixCapOffset->MessageControl.FunctionMask);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : MessageControl.MSIXEnable : %lu \n", pMsixCapOffset->MessageControl.MSIXEnable);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : Table Offset : %lu \n", pMsixCapOffset->MessageTable.TableOffset);
+                    RhelDbgPrint(TRACE_MSIX, " > MSI-X : Pending Bit Array (PBA) Offset : 0x%x \n", pMsixCapOffset->PBATable.TableOffset);
+                    RhelDbgPrint(TRACE_MSIX, " >> MSI-X is : %s [msix_enabled]\n", (adaptExt->msix_enabled) ? "ENABLED" : "DISABLED");
+                    #endif
+                } else if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_VENDOR_SPECIFIC) 
+                {
+                    #if !defined(RUN_UNCHECKED)
+                    RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_VENDOR_SPECIFIC, Next Capability Offset : 0x%x \n", CapOffset);
+                    u8 virtioCapType = adaptExt->pci_config_buf[CapOffset + offsetof(struct virtio_pci_cap, cfg_type)];
+                    switch (virtioCapType) {
+                    case VIRTIO_PCI_CAP_COMMON_CFG:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > VIRTIO Capability FOUND : VIRTIO_PCI_CAP_COMMON_CFG \n");
+                        pVirtioCommonCfgCap = (PVIRTIO_PCI_COMMON_CFG_CAP)&adaptExt->pci_config_buf[CapOffset];
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - BAR : %lu (0x%x) \n", pVirtioCommonCfgCap->cap.bar, pVirtioCommonCfgCap->cap.bar);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Offset : %lu (0x%x) \n", pVirtioCommonCfgCap->cap.offset, pVirtioCommonCfgCap->cap.offset);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Length : %lu (0x%x) \n", pVirtioCommonCfgCap->cap.length, pVirtioCommonCfgCap->cap.length);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                    " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Device Feature : %lu (0x%x) \n", 
+                                    pVirtioCommonCfgCap->device_feature, pVirtioCommonCfgCap->device_feature);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                    " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Number of Queues : %lu (0x%x) \n", 
+                                    pVirtioCommonCfgCap->num_queues, pVirtioCommonCfgCap->num_queues);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                    " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Config Gen : %lu (0x%x) \n", 
+                                    pVirtioCommonCfgCap->config_generation, pVirtioCommonCfgCap->config_generation);
+                        max_cpus = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                     " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Showing first %lu of %lu Virtqueues: \n",
+                                     min(pVirtioCommonCfgCap->num_queues, (max_cpus + VIRTIO_SCSI_REQUEST_QUEUE_0)), pVirtioCommonCfgCap->num_queues);
+                        for (idx = 0; idx < min(pVirtioCommonCfgCap->num_queues, (max_cpus + VIRTIO_SCSI_REQUEST_QUEUE_0)); ++idx) {
+                            pVirtioCommonCfgCap->queue_select = (u16)idx;
+                            RhelDbgPrint(TRACE_PCI_CAP, 
+                                        " >> VIRTIO_PCI_CAP_COMMON_CFG Capability - Virtqueue : %lu | Size : %lu Bytes (%lu KiB) \n", 
+                                        pVirtioCommonCfgCap->queue_select, pVirtioCommonCfgCap->queue_size, (pVirtioCommonCfgCap->queue_size / 1024));
+                        }
+                        break;
+                    case VIRTIO_PCI_CAP_NOTIFY_CFG:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > VIRTIO Capability FOUND : VIRTIO_PCI_CAP_NOTIFY_CFG \n");
+                        pVirtioNotifyCap = (PVIRTIO_PCI_NOTIFY_CAP)&adaptExt->pci_config_buf[CapOffset];
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_NOTIFY_CFG Capability - BAR : %lu (0x%x) \n", pVirtioNotifyCap->cap.bar, pVirtioNotifyCap->cap.bar);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_NOTIFY_CFG Capability - Offset : %lu (0x%x) \n", pVirtioNotifyCap->cap.offset, pVirtioNotifyCap->cap.offset);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_NOTIFY_CFG Capability - Length : %lu (0x%x) \n", pVirtioNotifyCap->cap.length, pVirtioNotifyCap->cap.length);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                     " >> VIRTIO_PCI_CAP_NOTIFY_CFG Capability - Notify Off Multiplier : %lu (0x%x) \n", 
+                                     pVirtioNotifyCap->notify_off_multiplier, pVirtioNotifyCap->notify_off_multiplier);
+                        break;
+                    case VIRTIO_PCI_CAP_ISR_CFG:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > VIRTIO Capability FOUND : VIRTIO_PCI_CAP_ISR_CFG \n");
+                        pVirtioIsrCap = (PVIRTIO_PCI_ISR_CAP)&adaptExt->pci_config_buf[CapOffset];
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_ISR_CFG Capability - BAR : %lu (0x%x) \n", pVirtioIsrCap->cap.bar, pVirtioIsrCap->cap.bar);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_ISR_CFG Capability - Offset : %lu (0x%x) \n", pVirtioIsrCap->cap.offset, pVirtioIsrCap->cap.offset);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_ISR_CFG Capability - Length : %lu (0x%x) \n", pVirtioIsrCap->cap.length, pVirtioIsrCap->cap.length);
+                        RhelDbgPrint(TRACE_PCI_CAP, 
+                                     " >> VIRTIO_PCI_CAP_ISR_CFG Capability - Interrupt Service Routine (ISR) : %lu (0x%x) \n", 
+                                     pVirtioIsrCap->isr, pVirtioIsrCap->isr);
+                        break;
+                    case VIRTIO_PCI_CAP_DEVICE_CFG:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > VIRTIO Capability FOUND : VIRTIO_PCI_CAP_DEVICE_CFG \n");
+                        pVirtioDeviceCap = (PVIRTIO_PCI_DEVICE_CAP)&adaptExt->pci_config_buf[CapOffset];
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_DEVICE_CFG Capability - BAR : %lu (0x%x) \n", pVirtioDeviceCap->cap.bar, pVirtioDeviceCap->cap.bar);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_DEVICE_CFG Capability - Offset : %lu (0x%x) \n", pVirtioDeviceCap->cap.offset, pVirtioDeviceCap->cap.offset);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_DEVICE_CFG Capability - Length : %lu (0x%x) \n", pVirtioDeviceCap->cap.length, pVirtioDeviceCap->cap.length);
+                        break;
+                    case VIRTIO_PCI_CAP_PCI_CFG:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > VIRTIO Capability FOUND : VIRTIO_PCI_CAP_PCI_CFG \n");
+                        PVIRTIO_PCI_CFG_CAP pVirtioCfgCap;
+                        pVirtioCfgCap = (PVIRTIO_PCI_CFG_CAP)&adaptExt->pci_config_buf[CapOffset];
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_PCI_CFG Capability - BAR : %lu (0x%x) \n", pVirtioCfgCap->cap.bar, pVirtioCfgCap->cap.bar);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_PCI_CFG Capability - Offset : %lu (0x%x) \n", pVirtioCfgCap->cap.offset, pVirtioCfgCap->cap.offset);
+                        RhelDbgPrint(TRACE_PCI_CAP, " >> VIRTIO_PCI_CAP_PCI_CFG Capability - Length : %lu (0x%x) \n", pVirtioCfgCap->cap.length, pVirtioCfgCap->cap.length);
+                        for (idx = 0; idx <= 3; ++idx) {
+                            RhelDbgPrint(TRACE_PCI_CAP, 
+                                         " >> VIRTIO_PCI_CAP_PCI_CFG Capability - BAR Access [%lu]: %lu (0x%x) \n", 
+                                         idx, pVirtioCfgCap->pci_cfg_data[idx], pVirtioCfgCap->pci_cfg_data[idx]);
+                        }
+                        break;
+                    case REDHAT_CAP_RESOURCE_RESERVE:
+                        // This will likely never get hit because we need to set REDHAT_CAP_RESOURCE_RESERVE=6 (normally =1) so as not to clobber VIRTIO_PCI_CAP_COMMON_CFG=1
+                        pQemuCapOffset = (PPCI_RHEL_QEMU_CAPABILITY)&adaptExt->pci_config_buf[CapOffset];
+                        if (pQemuCapOffset->Reservation.type == REDHAT_CAP_RESOURCE_RESERVE) 
+                        {
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Capability Type : 0x%x (%s) \n", 
+                                            pQemuCapOffset->Reservation.type, 
+                                            (pQemuCapOffset->Reservation.type == REDHAT_CAP_RESOURCE_RESERVE) ? "REDHAT_CAP_RESOURCE_RESERVE" : "UNKNOWN");                        
+                            if (pQemuCapOffset->Reservation.len < REDHAT_CAP_RESOURCE_RESERVE_SIZE)
+                            {
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : INVALID Capability Length : %lu | !!! WARNING !!! \n", 
+                                            pQemuCapOffset->Reservation.len);
+                            } else if (pQemuCapOffset->Reservation.type == REDHAT_CAP_RESOURCE_RESERVE)
+                            {
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Capability Length : %lu \n", pQemuCapOffset->Reservation.len);
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Minimum Bus Number : 0x%x \n", pQemuCapOffset->Reservation.bus_res);
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : IO Space : 0x%I64x \n", pQemuCapOffset->Reservation.io);
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Non-Prefetch Memory : 0x%x \n", pQemuCapOffset->Reservation.mem);
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Prefetch Memory (32-bit MMIO) : 0x%x \n", pQemuCapOffset->Reservation.prefetchable_32);
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : Prefetch Memory (64-bit MMIO) : 0x%I64x \n", pQemuCapOffset->Reservation.prefetchable_64);
+                            } else
+                            {
+                                RhelDbgPrint(TRACE_PCI_CAP, " QEMU Resource Reservation : UNKNOWN Capability Type | !!! WARNING !!! \n");
+                            }
+                        }
+                    default:
+                        RhelDbgPrint(TRACE_PCI_CAP, " > UNKNOWN VENDOR SPECIFIC Capability FOUND : %lu (0x%x) \n", virtioCapType, virtioCapType);
+                        break;
                     }
-                    CapOffset = pMsixCapOffset->Header.Next;
+                    #endif
+                } else
+                {
+                    #if !defined(RUN_UNCHECKED)
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_POWER_MANAGEMENT) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_POWER_MANAGEMENT, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_AGP) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_AGP, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_VPD) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_VPD, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_SLOT_ID) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_SLOT_ID, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_MSI) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_MSI, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_CPCI_HOTSWAP) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_CPCI_HOTSWAP, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_PCIX) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_PCIX, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_HYPERTRANSPORT) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_HYPERTRANSPORT, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_VENDOR_SPECIFIC) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_VENDOR_SPECIFIC, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_DEBUG_PORT) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_DEBUG_PORT, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_CPCI_RES_CTRL) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_CPCI_RES_CTRL, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_SHPC) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_SHPC, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_P2P_SSID) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_P2P_SSID, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_AGP_TARGET) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_AGP_TARGET, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_SECURE) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_SECURE capability, Next Capability Offset = 0x%x \n", CapOffset); }
+                    if (pCapOffset->CapabilityID == PCI_CAPABILITY_ID_PCI_EXPRESS) { 
+                        RhelDbgPrint(TRACE_PCI_CAP, " CapabilityID = PCI_CAPABILITY_ID_PCI_EXPRESS, Next Capability Offset = 0x%x \n", CapOffset); }
+                    #endif
                 }
-                RhelDbgPrint(TRACE_LEVEL_INFORMATION, " msix_enabled = %d\n", adaptExt->msix_enabled);
-            } else
-            {
-                RhelDbgPrint(TRACE_LEVEL_FATAL, " NOT A PCI_DEVICE_TYPE\n");
+                CapOffset = pCapOffset->Next;
             }
+        } else
+        {
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_FATAL, " NOT A PCI_DEVICE_TYPE\n");
+            #endif
+            // FIXME
+            // Should we not return on this error..?
+            //#if !defined(RUN_UNCHECKED)
+            //EXIT_FN();
+            //#endif
+            //return FALSE;
         }
     }
 
@@ -436,22 +663,36 @@ ENTER_FN();
         if (accessRange->RangeLength != 0) {
             int iBar = virtio_get_bar_index(&adaptExt->pci_config, accessRange->RangeStart);
             if (iBar == -1) {
-                RhelDbgPrint(TRACE_LEVEL_FATAL,
-                             " Cannot get index for BAR %I64d\n", accessRange->RangeStart.QuadPart);
+                #if !defined(RUN_UNCHECKED)
+                RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot get index for PCI Base Address Register (BAR) : %I64d \n", accessRange->RangeStart.QuadPart);
+                EXIT_FN();
+                #endif
                 return FALSE;
             }
             adaptExt->pci_bars[iBar].BasePA = accessRange->RangeStart;
             adaptExt->pci_bars[iBar].uLength = accessRange->RangeLength;
-            adaptExt->pci_bars[iBar].bPortSpace = !accessRange->RangeInMemory;
+            adaptExt->pci_bars[iBar].bMemorySpace = accessRange->RangeInMemory;
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PCI Base Address Register (BAR) : 0x%010I64x | Length : %+5lu (0x%04x) | MemorySpace : %s | IoSpace : %s \n", 
+                         adaptExt->pci_bars[iBar].BasePA.QuadPart, 
+                         adaptExt->pci_bars[iBar].uLength, adaptExt->pci_bars[iBar].uLength, 
+                         (adaptExt->pci_bars[iBar].bMemorySpace) ? "YES" : "NO",
+                         (!adaptExt->pci_bars[iBar].bMemorySpace) ? "YES" : "NO");
+            #endif
         }
     }
 
     /* initialize the virtual device */
     if (!InitVirtIODevice(DeviceExtension)) {
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return FALSE;
     }
-
-EXIT_FN();
+    
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return TRUE;
 }
 
@@ -461,24 +702,30 @@ SynchronizedKickEventRoutine(
     IN PVOID Context
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     PVirtIOSCSIEventNode eventNode   = (PVirtIOSCSIEventNode) Context;
     PVOID               va = NULL;
     ULONGLONG           pa = 0;
 
-ENTER_FN();
     if (virtqueue_add_buf(adaptExt->vq[VIRTIO_SCSI_EVENTS_QUEUE],
                      &eventNode->sg,
                      0, 1,
                      eventNode, va, pa) >= 0){
         virtqueue_kick(adaptExt->vq[VIRTIO_SCSI_EVENTS_QUEUE]);
-EXIT_FN();
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return TRUE;
     }
-EXIT_ERR();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_ERR();
+    #endif
     return FALSE;
 }
-
 
 BOOLEAN
 KickEvent(
@@ -486,16 +733,21 @@ KickEvent(
     IN PVirtIOSCSIEventNode EventNode
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION adaptExt;
     ULONG              fragLen;
 
-ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     RtlZeroMemory((PVOID)EventNode, sizeof(VirtIOSCSIEventNode));
     EventNode->sg.physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &EventNode->event, &fragLen);
     EventNode->sg.length   = sizeof(VirtIOSCSIEvent);
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return SynchronizedKickEventRoutine(DeviceExtension, (PVOID)EventNode);
-EXIT_FN();
 }
 
 VOID FirmwareRequest(
@@ -503,12 +755,16 @@ VOID FirmwareRequest(
     IN PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN_SRB();
+    #endif
+
     PADAPTER_EXTENSION  adaptExt;
     PSRB_EXTENSION      srbExt   = NULL;
     ULONG                   dataLen = 0;
     PSRB_IO_CONTROL         srbControl = NULL;
     PFIRMWARE_REQUEST_BLOCK firmwareRequest = NULL;
-ENTER_FN();
+
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     srbExt = SRB_EXTENSION(Srb);
     srbControl = (PSRB_IO_CONTROL)SRB_DATA_BUFFER(Srb);
@@ -516,8 +772,10 @@ ENTER_FN();
     if (dataLen < (sizeof(SRB_IO_CONTROL) + sizeof(FIRMWARE_REQUEST_BLOCK))) {
         srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
-        RhelDbgPrint(TRACE_LEVEL_ERROR,
-                         " FirmwareRequest Bad Block Length  %ul\n", dataLen);
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_ERROR, " FirmwareRequest Bad Block Length  %ul\n", dataLen);
+        EXIT_FN_SRB();
+        #endif
         return;
     }
 
@@ -527,8 +785,9 @@ ENTER_FN();
     case FIRMWARE_FUNCTION_GET_INFO: {
         PSTORAGE_FIRMWARE_INFO_V2   firmwareInfo;
         firmwareInfo = (PSTORAGE_FIRMWARE_INFO_V2)((PUCHAR)srbControl + firmwareRequest->DataBufferOffset);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
-                         " FIRMWARE_FUNCTION_GET_INFO \n");
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " FIRMWARE_FUNCTION_GET_INFO \n");
+        #endif
         if ((firmwareInfo->Version >= STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION_V2) ||
             (firmwareInfo->Size >= sizeof(STORAGE_FIRMWARE_INFO_V2))) {
             firmwareInfo->Version = STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION_V2;
@@ -555,8 +814,9 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_ERROR,
-                         " Wrong Version %ul or Size %ul\n", firmwareInfo->Version, firmwareInfo->Size);
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_ERROR, " Wrong Version %ul or Size %ul\n", firmwareInfo->Version, firmwareInfo->Size);
+            #endif
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
         }
@@ -565,8 +825,9 @@ ENTER_FN();
     case FIRMWARE_FUNCTION_DOWNLOAD: {
         PSTORAGE_FIRMWARE_DOWNLOAD_V2   firmwareDwnld;
         firmwareDwnld = (PSTORAGE_FIRMWARE_DOWNLOAD_V2)((PUCHAR)srbControl + firmwareRequest->DataBufferOffset);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
-            " FIRMWARE_FUNCTION_DOWNLOAD \n");
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " FIRMWARE_FUNCTION_DOWNLOAD \n");
+        #endif
         if ((firmwareDwnld->Version >= STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2) ||
             (firmwareDwnld->Size >= sizeof(STORAGE_FIRMWARE_DOWNLOAD_V2))) {
             firmwareDwnld->Version = STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2;
@@ -576,8 +837,9 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_ERROR,
-                " Wrong Version %ul or Size %ul\n", firmwareDwnld->Version, firmwareDwnld->Size);
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_ERROR, " Wrong Version %ul or Size %ul\n", firmwareDwnld->Version, firmwareDwnld->Size);
+            #endif
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
         }
@@ -594,20 +856,25 @@ ENTER_FN();
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
         }
         else {
-            RhelDbgPrint(TRACE_LEVEL_ERROR,
-                " Wrong Version %ul or Size %ul\n", firmwareActivate->Version, firmwareActivate->Size);
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_ERROR, " Wrong Version %ul or Size %ul\n", firmwareActivate->Version, firmwareActivate->Size);
+            #endif
             srbControl->ReturnCode = FIRMWARE_STATUS_INVALID_PARAMETER;
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_BAD_SRB_BLOCK_LENGTH);
         }
-        RhelDbgPrint(TRACE_LEVEL_VERBOSE,
-            " FIRMWARE_FUNCTION_ACTIVATE \n");
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " FIRMWARE_FUNCTION_ACTIVATE \n");
+        #endif
     }
     break;
     default:
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION,
-                     " Unsupported Function %ul\n", firmwareRequest->Function);
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Unsupported Function %ul\n", firmwareRequest->Function);
+        #endif
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_INVALID_REQUEST);
         break;
     }
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN_SRB();
+    #endif
 }

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -36,7 +36,7 @@
 #include <ntddk.h>
 #include <storport.h>
 #include <ntddscsi.h>
-
+#include <stddef.h>
 
 #include "osdep.h"
 #include "virtio_pci.h"
@@ -168,7 +168,7 @@ VioScsiCompleteDpcRoutine(
     IN PVOID Context,
     IN PVOID SystemArgument1,
     IN PVOID SystemArgument2
-);
+    );
 
 VOID
 ProcessBuffer(
@@ -178,10 +178,11 @@ ProcessBuffer(
     );
 
 VOID
-//FORCEINLINE
+FORCEINLINE
 HandleResponse(
     IN PVOID DeviceExtension,
-    IN PVirtIOSCSICmd cmd
+    IN PVirtIOSCSICmd cmd,
+    IN PVOID InlineFuncName
     );
 
 PVOID
@@ -194,7 +195,7 @@ VOID
 CompleteRequest(
     IN PVOID DeviceExtension,
     IN PSRB_TYPE Srb
- );
+    );
 
 VOID FirmwareRequest(
     IN PVOID DeviceExtension,

--- a/vioscsi/trace.h
+++ b/vioscsi/trace.h
@@ -31,22 +31,37 @@
 #define ___TRACING_H___
 
 /* RUN_UNCHECKED - NO DEBUG OR TRACING
- * This option disables all debug messages and ETW for maximum performance.*/
+ * This option disables all debug messages and ETW for maximum performance.
+ * NOT the default configuration.
+ * Configured in the vioscsi.vcxproj project file, which looks for the 
+ * FORCE_RUN_UNCHECKED environment variable, from which the RUN_UNCHECKED 
+ * macro is configured. */
+#if !defined(RUN_UNCHECKED)
 #define RUN_UNCHECKED 1
-#undef RUN_UNCHECKED // <== switch me here with comment
+#undef RUN_UNCHECKED // <== switch me here with comment (force always defined - use with CAUTION)
+#endif
 
-/* RUN_MIN_CHECKED - MINIMUM DEBUG OR FULL TRACING
+/* RUN_COLD_PATH_ONLY - COLD PATH DEBUG OR TRACING
  * This option includes select conditionally compiled debug messages.
- * However, if ETW is enabled instead of DEBUG, all traces will be included 
- * regardless of any compile-time conditional statements because the WPP will 
- * scan for all events and will ignore compile-time conditional statements. */
-#define RUN_MIN_CHECKED 1
-#undef RUN_MIN_CHECKED // <== switch me here with comment
+ * This is the default option.
+ * Configured in the vioscsi.vcxproj project file, which looks for the 
+ * RUN_WPP_ALL_PATHS environment variable, from which the WPP configuration 
+ * and the RUN_COLD_PATH_ONLY macro are configured. */
+#if !defined(RUN_COLD_PATH_ONLY)
+#define RUN_COLD_PATH_ONLY 1
+#undef RUN_COLD_PATH_ONLY // <== switch me here with comment (force always defined - use with CAUTION)
+#endif
 
 /* EVENT_TRACING - CHOOSE BETWEEN DEBUG OR TRACING
- * if EVENT_TRACING is undefined, DEBUG (DBG) will be enabled below... */
+ * if EVENT_TRACING is undefined, DEBUG (DBG) will be enabled below...
+ * This is the default option.
+ * Configured in the vioscsi.vcxproj project file, which looks for the 
+ * FORCE_RUN_DEBUG environment variable, from which the EVENT_TRACING 
+ * macro is configured. */
+#if !defined(EVENT_TRACING)
 #define EVENT_TRACING 1
-//#undef EVENT_TRACING  // <== switch me here with comment
+#undef EVENT_TRACING  // <== switch me here with comment (force always defined - use with CAUTION)
+#endif
 
 #include <ntddk.h>
 #include <storport.h>
@@ -108,6 +123,39 @@ extern int nVioscsiDebugLevel;
 #define VioScsiDbgBreak()\
     if (KD_DEBUGGER_ENABLED && !KD_DEBUGGER_NOT_PRESENT) DbgBreakPoint();
 
+#if !defined(RUN_COLD_PATH_ONLY)
+// Put all hot path entries from here. We will skip them when RUN_COLD_PATH_ONLY is defined.
+#define RhelDbgPrintHotPath(Level, MSG, ...) \
+    if ((!bDebugPrint) || Level > nVioscsiDebugLevel) {} \
+    else VirtioDebugPrintProc (MSG, __VA_ARGS__)
+#define ENTER_FN_HP() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define EXIT_FN_HP()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
+#define ENTER_INL_FN_HP() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
+#define EXIT_INL_FN_HP()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
+#define EXIT_ERR_HP() RhelDbgPrint(TRACE_LEVEL_ERROR, " <--> %s (%d).\n", __FUNCTION__, __LINE__)
+#define ENTER_FN_SRB_HP() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define EXIT_FN_SRB_HP()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define ENTER_INL_FN_SRB_HP() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define EXIT_INL_FN_SRB_HP()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s Srb = 0x%p.\n",__FUNCTION__, Srb)
+#define LOG_SRB_INFO_HP() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
+#define LOG_SRB_INFO_FROM_INLFN_HP() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
+#else
+#define RhelDbgPrintHotPath(Level, MSG, ...) \
+    if ((!bDebugPrint) || Level > nVioscsiDebugLevel) {} \
+    else VirtioDebugPrintProc (MSG, __VA_ARGS__)
+#define ENTER_FN_HP()
+#define EXIT_FN_HP()
+#define ENTER_INL_FN_HP()
+#define EXIT_INL_FN_HP()
+#define EXIT_ERR_HP()
+#define ENTER_FN_SRB_HP()
+#define EXIT_FN_SRB_HP()
+#define LOG_SRB_INFO_HP()
+#define ENTER_INL_FN_SRB_HP()
+#define EXIT_INL_FN_SRB_HP()
+#define LOG_SRB_INFO_FROM_INLFN_HP()
+#endif
+
 #define ENTER_FN() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
 #define EXIT_FN()  RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <-- %s.\n",__FUNCTION__)
 #define ENTER_INL_FN() RhelDbgPrint(TRACE_LEVEL_VERBOSE, " --> %s.\n",__FUNCTION__)
@@ -120,10 +168,21 @@ extern int nVioscsiDebugLevel;
 #define LOG_SRB_INFO() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
 #define LOG_SRB_INFO_FROM_INLFN() RhelDbgPrint(TRACE_LEVEL_INFORMATION, "%s <--> Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p\n",__FUNCTION__, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb)
 
-#else
-#if defined(RUN_UNCHECKED) && !defined(RUN_MIN_CHECKED)
+#else // DBG above, EVENT_TRACING below.
+#if defined(RUN_UNCHECKED)
+/* When the FORCE_RUN_UNCHECKED environment variable is set, 
+ * the vioscsi.vcxproj project file will DISABLE the WPP, so
+ * we disable ETW here too. We define RUN_COLD_PATH_ONLY to 
+ * dereference hot path entries, as these are subject to the 
+ * compile-time conditional !defined(RUN_COLD_PATH_ONLY).
+ */
 #undef EVENT_TRACING
+#if !defined(RUN_COLD_PATH_ONLY)
+#define RUN_COLD_PATH_ONLY
+#endif
 #else
+/* Enable EVENT_TRACING */
+
 #pragma warning(disable: 28170)
 #pragma warning(disable: 28251)
 #include <stortrce.h>
@@ -156,91 +215,40 @@ extern int nVioscsiDebugLevel;
         WPP_DEFINE_BIT(TRACE_ALL)                      /* bit LAST PLACEHLDR  */ \
         )
 
-// begin_wpp config
-// USEPREFIX (RhelDbgPrint, "%!STDPREFIX! ####\t\t[%!FUNC!] DEBUG:");
-// FUNC RhelDbgPrint(LEVEL, MSG, ...);
-// end_wpp
-#define WPP_Flags_LEVEL_LOGGER(Flags, level) WPP_LEVEL_LOGGER(Flags)
-#define WPP_Flags_LEVEL_ENABLED(Flags, level) \
-    (WPP_LEVEL_ENABLED(Flags) && \
-    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
-
-// begin_wpp config
-// USEPREFIX (ENTER_FN, "%!STDPREFIX! ===>\t\t[%!FUNC!] X---X Working X---X");
-// FUNC ENTER_FN{ENTRYLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_ENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_ENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (EXIT_FN, "%!STDPREFIX! <===\t\t[%!FUNC!] Processing complete.");
-// FUNC EXIT_FN{EXITLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_EXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_EXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (ENTER_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] X---X Working X---X", InlineFuncName);
-// FUNC ENTER_INL_FN{INLENTRYLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_INLENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_INLENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (EXIT_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] Processing complete.", InlineFuncName);
-// FUNC EXIT_INL_FN{INLEXITLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_INLEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_INLEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (EXIT_ERR, "%!STDPREFIX! >>>>\t\t[%!FUNC!] ERROR line %d", __LINE__);
-// FUNC EXIT_ERR{ERRORLEVEL=TRACE_LEVEL_ERROR}(...);
-// end_wpp
-#define WPP_ERRORLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_ERRORLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (ENTER_FN_SRB(PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!] SRB 0x%p", Srb);
-// FUNC ENTER_FN_SRB{SRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_SRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_SRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!] SRB 0x%p", Srb);
-// FUNC EXIT_FN_SRB{SRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_SRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_SRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
-// FUNC LOG_SRB_INFO{SRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
-// end_wpp
-#define WPP_SRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_SRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (ENTER_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] SRB 0x%p", InlineFuncName, Srb);
-// FUNC ENTER_INL_FN_SRB{INLSRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_INLSRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_INLSRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (EXIT_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] SRB 0x%p", InlineFuncName, Srb);
-// FUNC EXIT_INL_FN_SRB{INLSRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
-// end_wpp
-#define WPP_INLSRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_INLSRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
-
-// begin_wpp config
-// USEPREFIX (LOG_SRB_INFO_FROM_INLFN(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!]:[%s] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", InlineFuncName, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
-// FUNC LOG_SRB_INFO_FROM_INLFN{INLSRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
-// end_wpp
-#define WPP_INLSRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
-#define WPP_INLSRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+#if !defined(RUN_COLD_PATH_ONLY)
+/* This is NOT the default.
+ * When RUN_COLD_PATH_ONLY is NOT defined or when the RUN_WPP_ALL_PATHS 
+ * environment variable is set, we load the wpp_all_paths.h header file.
+ * This header file contains both hot and cold path entries.
+ * The vioscsi.vcxproj project file will configure WPP to use this file.
+ */
+#include "wpp_all_paths.h"
+#else
+/* This is the default.
+ * When RUN_COLD_PATH_ONLY is defined or when the RUN_WPP_ALL_PATHS 
+ * environment variable is NOT set, we load the wpp_cold_path.h header file.
+ * This header file contains cold paths entries only.
+ * The vioscsi.vcxproj project file will configure WPP to use this file.
+ */
+#include "wpp_cold_path.h"
+/* To avoid copilation errors, we need dummy macros here for 
+ * when the hot path is not included. Here VirtioDebugPrintProc is set to 
+ * NoDebugPrintFunc in the utils.c file, so nothing will be printed.
+ */
+#define RhelDbgPrintHotPath(Level, MSG, ...) VirtioDebugPrintProc (MSG, __VA_ARGS__)
+#define ENTER_FN_HP()
+#define EXIT_FN_HP()
+#define ENTER_INL_FN_HP()
+#define EXIT_INL_FN_HP()
+#define EXIT_ERR_HP()
+#define ENTER_FN_SRB_HP()
+#define EXIT_FN_SRB_HP()
+#define LOG_SRB_INFO_HP()
+#define ENTER_INL_FN_SRB_HP()
+#define EXIT_INL_FN_SRB_HP()
+#define LOG_SRB_INFO_FROM_INLFN_HP()
+#endif
+/* Common to hot and cold path entries from here. */
 
 //
 // Configure WPP macros for optimum performance
@@ -248,7 +256,7 @@ extern int nVioscsiDebugLevel;
 // as we call it in DriverEntry() anyway.
 //
 #define WPP_CHECK_INIT
-    
+
 #endif
 
 #endif

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -34,7 +34,7 @@
 #include "vioscsidt.h"
 #include "trace.h"
 
-#if defined(EVENT_TRACING)
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
 #include "vioscsi.tmh"
 #endif
 
@@ -66,11 +66,11 @@ HW_ADAPTER_CONTROL   VioScsiAdapterControl;
 HW_UNIT_CONTROL      VioScsiUnitControl;
 HW_INTERRUPT         VioScsiInterrupt;
 HW_DPC_ROUTINE       VioScsiCompleteDpcRoutine;
-HW_PASSIVE_INITIALIZE_ROUTINE         VioScsiPassiveInitializeRoutine;
+HW_PASSIVE_INITIALIZE_ROUTINE         VioScsiPassiveDpcInitializeRoutine;
 HW_MESSAGE_SIGNALED_INTERRUPT_ROUTINE VioScsiMSInterrupt;
 
 
-#ifdef EVENT_TRACING
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
 PVOID TraceContext = NULL;
 VOID WppCleanupRoutine(PVOID arg1) {
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " WppCleanupRoutine\n");
@@ -140,21 +140,24 @@ BOOLEAN
 FORCEINLINE
 PreProcessRequest(
     IN PVOID DeviceExtension,
-    IN PSRB_TYPE Srb
+    IN PSRB_TYPE Srb,
+    IN PVOID InlineFuncName
     );
 
 VOID
 FORCEINLINE
 PostProcessRequest(
     IN PVOID DeviceExtension,
-    IN PSRB_TYPE Srb
+    IN PSRB_TYPE Srb,
+    IN PVOID InlineFuncName
     );
 
 VOID
 FORCEINLINE
 DispatchQueue(
     IN PVOID DeviceExtension,
-    IN ULONG MessageId
+    IN ULONG MessageId,
+    IN PVOID InlineFuncName
     );
 
 BOOLEAN
@@ -313,7 +316,9 @@ BOOLEAN VioScsiReadRegistryParameter(
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     pBuf = StorPortAllocateRegistryBuffer(DeviceExtension, &Len);
     if (pBuf == NULL) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, "StorPortAllocateRegistryBuffer failed to allocate buffer\n");
+        #endif
         return FALSE;
     }
 
@@ -327,7 +332,9 @@ BOOLEAN VioScsiReadRegistryParameter(
                                &Len);
 
     if ((Ret == FALSE) || (Len == 0)) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, "StorPortRegistryRead returned 0x%x, Len = %d\n", Ret, Len);
+        #endif
         StorPortFreeRegistryBuffer(DeviceExtension, pBuf);
         return FALSE;
     }
@@ -351,17 +358,21 @@ DriverEntry(
     HW_INITIALIZATION_DATA hwInitData;
     ULONG                  initResult;
 
-#ifdef EVENT_TRACING
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
     STORAGE_TRACE_INIT_INFO initInfo;
 #endif
 
     InitializeDebugPrints((PDRIVER_OBJECT)DriverObject, (PUNICODE_STRING)RegistryPath);
 
     IsCrashDumpMode = FALSE;
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_FATAL, " Vioscsi driver started...built on %s %s\n", __DATE__, __TIME__);
+    #endif
     if (RegistryPath == NULL) {
         IsCrashDumpMode = TRUE;
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Crash dump mode\n");
+        #endif
     }
 
     RtlZeroMemory(&hwInitData, sizeof(HW_INITIALIZATION_DATA));
@@ -401,7 +412,7 @@ DriverEntry(
                                     &hwInitData,
                                     NULL);
 
-#ifdef EVENT_TRACING
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
     TraceContext = NULL;
 
     memset(&initInfo, 0, sizeof(STORAGE_TRACE_INIT_INFO));
@@ -418,8 +429,10 @@ DriverEntry(
     }
 #endif
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_VERBOSE,
                  " Initialize returned 0x%x\n", initResult);
+    #endif
 
     return initResult;
 
@@ -435,6 +448,10 @@ VioScsiFindAdapter(
     IN PBOOLEAN Again
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION adaptExt;
     PVOID              uncachedExtensionVa;
     USHORT             queueLength = 0;
@@ -450,8 +467,6 @@ VioScsiFindAdapter(
     UNREFERENCED_PARAMETER( BusInformation );
     UNREFERENCED_PARAMETER( ArgumentString );
     UNREFERENCED_PARAMETER( Again );
-
-ENTER_FN();
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     RtlZeroMemory(adaptExt, sizeof(ADAPTER_EXTENSION));
@@ -473,7 +488,9 @@ ENTER_FN();
     VioScsiWmiInitialize(DeviceExtension);
 
     if (!InitHW(DeviceExtension, ConfigInfo)) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot initialize HardWare\n");
+        #endif
         return SP_RETURN_NOT_FOUND;
     }
 
@@ -516,8 +533,10 @@ ENTER_FN();
     ConfigInfo->NumberOfPhysicalBreaks = adaptExt->max_physical_breaks + 1;
     ConfigInfo->MaximumTransferLength  = adaptExt->max_physical_breaks * PAGE_SIZE;
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " NumberOfPhysicalBreaks %d\n", ConfigInfo->NumberOfPhysicalBreaks);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MaximumTransferLength %d\n", ConfigInfo->MaximumTransferLength);
+    #endif
 
     num_cpus = KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
     max_cpus = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);
@@ -541,7 +560,9 @@ ENTER_FN();
     adaptExt->resp_time = 0;
     VioScsiReadRegistryParameter(DeviceExtension, REGISTRY_RESP_TIME_LIMIT, FIELD_OFFSET(ADAPTER_EXTENSION, resp_time));
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Queues %d CPUs %d\n", adaptExt->num_queues, num_cpus);
+    #endif
 
     /* Figure out the maximum number of queues we will ever need to set up. Note that this may
      * be higher than adaptExt->num_queues, because the driver may be reinitialized by calling
@@ -553,7 +574,9 @@ ENTER_FN();
     } else {
         max_queues = min(max_cpus, adaptExt->scsi_config.num_queues);
         if (adaptExt->num_queues > max_queues) {
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_WARNING, " Multiqueue can only use at most one queue per cpu.");
+            #endif
             adaptExt->num_queues = max_queues;
         }
     }
@@ -581,7 +604,9 @@ ENTER_FN();
                 SP_INTERNAL_ADAPTER_ERROR,
                 __LINE__);
 
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_FATAL, " Virtual queue %d config failed.\n", index);
+            #endif
             return SP_RETURN_ERROR;
         }
         adaptExt->pageAllocationSize += ROUND_TO_PAGES(Size);
@@ -607,19 +632,25 @@ ENTER_FN();
     ConfigInfo->InitialLunQueueDepth = ConfigInfo->MaxIOsPerLun;
     ConfigInfo->MaxNumberOfIO = ConfigInfo->MaxIOsPerLun;
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " breaks_number = %x  queue_depth = %x\n",
                 ConfigInfo->NumberOfPhysicalBreaks,
                 adaptExt->queue_depth);
+    #endif
 
     extensionSize = PAGE_SIZE + adaptExt->pageAllocationSize + adaptExt->poolAllocationSize;
     uncachedExtensionVa = StorPortGetUncachedExtension(DeviceExtension, ConfigInfo, extensionSize);
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " StorPortGetUncachedExtension uncachedExtensionVa = %p allocation size = %d\n", uncachedExtensionVa, extensionSize);
+    #endif
     if (!uncachedExtensionVa) {
         LogError(DeviceExtension,
                 SP_INTERNAL_ADAPTER_ERROR,
                 __LINE__);
 
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Can't get uncached extension allocation size = %d\n", extensionSize);
+        #endif
         return SP_RETURN_ERROR;
     }
 
@@ -640,10 +671,12 @@ ENTER_FN();
     if (adaptExt->poolAllocationSize > 0) {
         adaptExt->poolAllocationVa = (PVOID)((ULONG_PTR)adaptExt->pageAllocationVa + adaptExt->pageAllocationSize);
     }
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Page-aligned area at %p, size = %d\n", adaptExt->pageAllocationVa, adaptExt->pageAllocationSize);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Pool area at %p, size = %d\n", adaptExt->poolAllocationVa, adaptExt->poolAllocationSize);
 
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " pmsg_affinity = %p\n",adaptExt->pmsg_affinity);
+    #endif
     if (!adaptExt->dump_mode && (adaptExt->num_queues > 1) && (adaptExt->pmsg_affinity == NULL)) {
         adaptExt->num_affinity = adaptExt->num_queues + 3;
         ULONG Status =
@@ -651,22 +684,29 @@ ENTER_FN();
                              sizeof(GROUP_AFFINITY) * (ULONGLONG)adaptExt->num_affinity,
                              VIOSCSI_POOL_TAG,
                              (PVOID*)&adaptExt->pmsg_affinity);
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " pmsg_affinity = %p Status = %lu\n",adaptExt->pmsg_affinity, Status);
+        #endif
     }
     adaptExt->fw_ver = '0';
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return SP_RETURN_FOUND;
 }
 
 BOOLEAN
-VioScsiPassiveInitializeRoutine(
+VioScsiPassiveDpcInitializeRoutine(
     IN PVOID DeviceExtension
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     ULONG index;
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-ENTER_FN();
 
     for (index = 0; index < adaptExt->num_queues; ++index) {
         StorPortInitializeDpc(DeviceExtension,
@@ -674,7 +714,9 @@ ENTER_FN();
             VioScsiCompleteDpcRoutine);
     }
     adaptExt->dpc_ok = TRUE;
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return TRUE;
 }
 
@@ -687,7 +729,9 @@ static BOOLEAN InitializeVirtualQueues(PADAPTER_EXTENSION adaptExt, ULONG numQue
         numQueues,
         adaptExt->vq);
     if (!NT_SUCCESS(status)) {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " FAILED with status 0x%x\n", status);
+        #endif
         return FALSE;
     }
 
@@ -709,7 +753,9 @@ VioScsiPoolAlloc(
         RtlZeroMemory(ptr, size);
         return ptr;
     }
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_FATAL, " Out of memory %Id \n", size);
+    #endif
     return NULL;
 }
 
@@ -718,6 +764,10 @@ VioScsiHwInitialize(
     IN PVOID DeviceExtension
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     ULONG              i;
     ULONG              index;
@@ -726,55 +776,173 @@ VioScsiHwInitialize(
     ULONG              status = STOR_STATUS_SUCCESS;
     MESSAGE_INTERRUPT_INFORMATION msi_info = { 0 };
     PREQUEST_LIST  element;
-ENTER_FN();
 
     adaptExt->msix_vectors = 0;
     adaptExt->pageOffset = 0;
     adaptExt->poolOffset = 0;
 
+    if ((!adaptExt->dump_mode) && (adaptExt->num_queues > 1) && (adaptExt->perfFlags == 0)) {
+        perfData.Version = STOR_PERF_VERSION;
+        perfData.Size = sizeof(PERF_CONFIGURATION_DATA);
+
+        status = StorPortInitializePerfOpts(DeviceExtension, TRUE, &perfData);
+
+        if (status == STOR_STATUS_SUCCESS) {
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_FATAL,
+                " PERF: GET PerfOpts : Version = 0x%x, Flags = 0x%x, ConcurrentChannels = %d, FirstRedirectionMessageNumber = %d, LastRedirectionMessageNumber = %d, DeviceNode = %d\n",
+                perfData.Version,
+                perfData.Flags,
+                perfData.ConcurrentChannels,
+                perfData.FirstRedirectionMessageNumber,
+                perfData.LastRedirectionMessageNumber,
+                perfData.DeviceNode);
+            #endif
+        } else {
+            //FIXME...
+            //should we not return here with ERROR, or continue with WARNING
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_WARNING, " PERF: StorPortInitializePerfOpts GET failed with status = 0x%x\n", status);
+            //EXIT_FN();
+            #endif
+            //return FALSE;
+        }
+            
+        if ( (status == STOR_STATUS_SUCCESS) &&
+            (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION)) ) {
+            adaptExt->perfFlags = STOR_PERF_DPC_REDIRECTION;
+            if (CHECKFLAG(perfData.Flags, STOR_PERF_CONCURRENT_CHANNELS)) {
+                adaptExt->perfFlags |= STOR_PERF_CONCURRENT_CHANNELS;
+                perfData.ConcurrentChannels = adaptExt->num_queues;
+            }
+            if (CHECKFLAG(perfData.Flags, STOR_PERF_INTERRUPT_MESSAGE_RANGES)) {
+                adaptExt->perfFlags |= STOR_PERF_INTERRUPT_MESSAGE_RANGES;
+                perfData.FirstRedirectionMessageNumber = VIRTIO_SCSI_REQUEST_QUEUE_0 + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET;
+                perfData.LastRedirectionMessageNumber = perfData.FirstRedirectionMessageNumber + perfData.ConcurrentChannels - 1;
+            }
+        
+            ASSERT(perfData.LastRedirectionMessageNumber < adaptExt->num_affinity);
+            if ((adaptExt->pmsg_affinity != NULL) && CHECKFLAG(perfData.Flags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
+                RtlZeroMemory((PCHAR)adaptExt->pmsg_affinity, sizeof(GROUP_AFFINITY) * ((ULONGLONG)adaptExt->num_affinity));
+                adaptExt->perfFlags |= STOR_PERF_ADV_CONFIG_LOCALITY;
+                perfData.MessageTargets = adaptExt->pmsg_affinity;
+            }
+            if (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION_CURRENT_CPU)) {
+//                adaptExt->perfFlags |= STOR_PERF_DPC_REDIRECTION_CURRENT_CPU;
+            }
+            if (CHECKFLAG(perfData.Flags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO)) {
+//                adaptExt->perfFlags |= STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO;
+            }
+            perfData.Flags = adaptExt->perfFlags;
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION,
+                " PERF: SET PerfOpts : Version = 0x%x, Flags = 0x%x, ConcurrentChannels = %d, FirstRedirectionMessageNumber = %d, LastRedirectionMessageNumber = %d, DeviceNode = %d\n",
+                perfData.Version,
+                perfData.Flags,
+                perfData.ConcurrentChannels,
+                perfData.FirstRedirectionMessageNumber,
+                perfData.LastRedirectionMessageNumber,
+                perfData.DeviceNode);
+            #endif
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_DPC_REDIRECTION flag is : %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_CONCURRENT_CHANNELS flag is: %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_CONCURRENT_CHANNELS)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_INTERRUPT_MESSAGE_RANGES flag is : %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_INTERRUPT_MESSAGE_RANGES)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_ADV_CONFIG_LOCALITY flag is: %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_ADV_CONFIG_LOCALITY)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO flag is: %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_DPC_REDIRECTION_CURRENT_CPU flag is : %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION_CURRENT_CPU)) ? "ON" : "OFF");
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " PERF: STOR_PERF_NO_SGL flag is : %s \n", 
+                            (CHECKFLAG(perfData.Flags, STOR_PERF_NO_SGL)) ? "ON" : "OFF");
+            #endif
+            
+            status = StorPortInitializePerfOpts(DeviceExtension, FALSE, &perfData);
+
+            if (status != STOR_STATUS_SUCCESS) {
+                adaptExt->perfFlags = 0;
+                #if !defined(RUN_UNCHECKED)
+                RhelDbgPrint(TRACE_LEVEL_ERROR, " PERF: StorPortInitializePerfOpts SET failed with status = 0x%x\n", status);
+                #endif
+            }
+            for (index = 0; index < adaptExt->num_affinity; ++index) {
+                GROUP_AFFINITY vector_affinity = adaptExt->pmsg_affinity[index];
+                #if !defined(RUN_UNCHECKED)
+                RhelDbgPrint(TRACE_MSIX_CPU_AFFINITY, 
+                        " PERF: MSI-X Vector %lu CPU Affinity : KAFFINITY Mask = %I64d, CPU Group = %lu \n", 
+                        index, vector_affinity.Mask, vector_affinity.Group);
+                #endif
+            }
+        }
+    }
+
     while(StorPortGetMSIInfo(DeviceExtension, adaptExt->msix_vectors, &msi_info) == STOR_STATUS_SUCCESS) {
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MessageId = %x\n", msi_info.MessageId);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MessageData = %x\n", msi_info.MessageData);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " InterruptVector = %x\n", msi_info.InterruptVector);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " InterruptLevel = %x\n", msi_info.InterruptLevel);
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " InterruptMode = %s\n", msi_info.InterruptMode == LevelSensitive ? "LevelSensitive" : "Latched");
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MessageAddress = %I64x\n\n", msi_info.MessageAddress.QuadPart);
+        #if !defined(RUN_UNCHECKED)
+        if (adaptExt->num_queues > 1) {
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, 
+                    " MSI-X Vector [MessageId] = %lu, MessageAddress = 0x%I64x, MessageData = %lu, InterruptVector = %lu, InterruptLevel = %lu, InterruptMode = %s, CPU Affinity : Mask = %I64d, Group = %lu \n", 
+                    msi_info.MessageId, msi_info.MessageAddress.QuadPart, msi_info.MessageData, 
+                    msi_info.InterruptVector, msi_info.InterruptLevel, msi_info.InterruptMode == LevelSensitive ? "LevelSensitive" : "Latched",
+                    adaptExt->pmsg_affinity[msi_info.MessageId].Mask, adaptExt->pmsg_affinity[msi_info.MessageId].Group);
+        } else {
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, 
+                    " MSI-X Vector [MessageId] = %lu, MessageAddress = 0x%I64x, MessageData = %lu, InterruptVector = %lu, InterruptLevel = %lu, InterruptMode = %s \n", 
+                    msi_info.MessageId, msi_info.MessageAddress.QuadPart, msi_info.MessageData, 
+                    msi_info.InterruptVector, msi_info.InterruptLevel, msi_info.InterruptMode == LevelSensitive ? "LevelSensitive" : "Latched");
+        }
+        #endif
         ++adaptExt->msix_vectors;
     }
 
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Queues %d msix_vectors %d\n", adaptExt->num_queues, adaptExt->msix_vectors);
     if (adaptExt->num_queues > 1 &&
-        ((adaptExt->num_queues + 3) > adaptExt->msix_vectors)) {
+        ((adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0 + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET) > adaptExt->msix_vectors)) {
         adaptExt->num_queues = (USHORT)adaptExt->msix_vectors;
     }
 
     if (!adaptExt->dump_mode && adaptExt->msix_vectors > 0) {
-        if (adaptExt->msix_vectors >= adaptExt->num_queues + 3) {
+        if (adaptExt->msix_vectors >= adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0 + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET) {
             /* initialize queues with a MSI vector per queue */
-            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Using a unique MSI vector per queue\n");
             adaptExt->msix_one_vector = FALSE;
         } else {
             /* if we don't have enough vectors, use one for all queues */
-            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Using one MSI vector for all queues\n");
             adaptExt->msix_one_vector = TRUE;
         }
-        if (!InitializeVirtualQueues(adaptExt, adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0)) {
-            return FALSE;
-        }
     }
-    else
-    {
+    else {
         /* initialize queues with no MSI interrupts */
         adaptExt->msix_enabled = FALSE;
-        if (!InitializeVirtualQueues(adaptExt, adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0)) {
-            return FALSE;
-        }
     }
 
+    if (!InitializeVirtualQueues(adaptExt, adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0)) {
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_FATAL, " !!! - Failed to initialize the Virtual Queues - !!!\n");
+        EXIT_FN();
+        #endif
+        return FALSE;
+    }
+
+    #if !defined(RUN_UNCHECKED)
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VirtIO Request Queues : %d, MSI-X Enabled : %s, MSI-X Use ONE Vector : %s, MSI-X Vectors [msix_vectors] : %d \n", 
+            adaptExt->num_queues, 
+            (adaptExt->msix_enabled) ? "YES" : "NO", 
+            (adaptExt->msix_one_vector) ? "YES" : "NO", 
+            adaptExt->msix_vectors);
+    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " MSI-X Vector %lu | StorPort exclusive control \n", (VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET - 1));
+    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " MSI-X Vector %lu | VIRTIO Control Queue \n", (VIRTIO_SCSI_CONTROL_QUEUE + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET));
+    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " MSI-X Vector %lu | VIRTIO Events Queue \n", (VIRTIO_SCSI_EVENTS_QUEUE + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET));
+    #endif
     for (index = 0; index < adaptExt->num_queues; ++index) {
-          element = &adaptExt->processing_srbs[index];
-          InitializeListHead(&element->srb_list);
-          element->srb_cnt = 0;
+        element = &adaptExt->processing_srbs[index];
+        InitializeListHead(&element->srb_list);
+        element->srb_cnt = 0;
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " MSI-X Vector %lu | VIRTIO Request Queue %lu (index %lu) \n", 
+                     (index + VIRTIO_SCSI_REQUEST_QUEUE_0 + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET), (index + 1), index);
+        #endif
     }
 
     if (!adaptExt->dump_mode) {
@@ -786,79 +954,32 @@ ENTER_FN();
             adaptExt->events = (PVirtIOSCSIEventNode)VioScsiPoolAlloc(DeviceExtension, sizeof(VirtIOSCSIEventNode) * 8);
             adaptExt->dpc = (PSTOR_DPC)VioScsiPoolAlloc(DeviceExtension, sizeof(STOR_DPC) * adaptExt->num_queues);
         }
-    }
-
-    if (!adaptExt->dump_mode && CHECKBIT(adaptExt->features, VIRTIO_SCSI_F_HOTPLUG)) {
-        PVirtIOSCSIEventNode events = adaptExt->events;
-        for (i = 0; i < 8; i++) {
-           if (!KickEvent(DeviceExtension, (PVOID)(&events[i]))) {
-                RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot add event %d\n", i);
-           }
-        }
-    }
-    if (!adaptExt->dump_mode)
-    {
-        if ((adaptExt->num_queues > 1) && (adaptExt->perfFlags == 0)) {
-            perfData.Version = STOR_PERF_VERSION;
-            perfData.Size = sizeof(PERF_CONFIGURATION_DATA);
-
-            status = StorPortInitializePerfOpts(DeviceExtension, TRUE, &perfData);
-
-            RhelDbgPrint(TRACE_LEVEL_FATAL, " Current PerfOpts Version = 0x%x, Flags = 0x%x, ConcurrentChannels = %d, FirstRedirectionMessageNumber = %d,LastRedirectionMessageNumber = %d\n",
-                        perfData.Version,
-                        perfData.Flags,
-                        perfData.ConcurrentChannels,
-                        perfData.FirstRedirectionMessageNumber,
-                        perfData.LastRedirectionMessageNumber);
-            if ( (status == STOR_STATUS_SUCCESS) &&
-                 (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION)) ) {
-                    adaptExt->perfFlags = STOR_PERF_DPC_REDIRECTION;
-                if (CHECKFLAG(perfData.Flags, STOR_PERF_INTERRUPT_MESSAGE_RANGES)) {
-                    adaptExt->perfFlags |= STOR_PERF_INTERRUPT_MESSAGE_RANGES;
-                    perfData.FirstRedirectionMessageNumber = 3;
-                    perfData.LastRedirectionMessageNumber = perfData.FirstRedirectionMessageNumber + adaptExt->num_queues - 1;
-                    ASSERT(perfData.LastRedirectionMessageNumber < adaptExt->num_affinity);
-                    if ((adaptExt->pmsg_affinity != NULL) && CHECKFLAG(perfData.Flags, STOR_PERF_ADV_CONFIG_LOCALITY)) {
-                        RtlZeroMemory((PCHAR)adaptExt->pmsg_affinity, sizeof (GROUP_AFFINITY) * ((ULONGLONG)adaptExt->num_queues + 3));
-                        adaptExt->perfFlags |= STOR_PERF_ADV_CONFIG_LOCALITY;
-                        perfData.MessageTargets = adaptExt->pmsg_affinity;
-                        if (CHECKFLAG(perfData.Flags, STOR_PERF_CONCURRENT_CHANNELS)) {
-                            adaptExt->perfFlags |= STOR_PERF_CONCURRENT_CHANNELS;
-                            perfData.ConcurrentChannels = adaptExt->num_queues;
-                        }
-                    }
-                }
-                if (CHECKFLAG(perfData.Flags, STOR_PERF_DPC_REDIRECTION_CURRENT_CPU)) {
-//                    adaptExt->perfFlags |= STOR_PERF_DPC_REDIRECTION_CURRENT_CPU;
-                }
-                if (CHECKFLAG(perfData.Flags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO)) {
-//                    adaptExt->perfFlags |= STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO;
-                }
-                perfData.Flags = adaptExt->perfFlags;
-                RhelDbgPrint(TRACE_LEVEL_INFORMATION, "Applied PerfOpts Version = 0x%x, Flags = 0x%x, ConcurrentChannels = %d, FirstRedirectionMessageNumber = %d,LastRedirectionMessageNumber = %d\n",
-                            perfData.Version,
-                            perfData.Flags,
-                            perfData.ConcurrentChannels,
-                            perfData.FirstRedirectionMessageNumber,
-                            perfData.LastRedirectionMessageNumber);
-                status = StorPortInitializePerfOpts(DeviceExtension, FALSE, &perfData);
-                if (status != STOR_STATUS_SUCCESS) {
-                    adaptExt->perfFlags = 0;
-                    RhelDbgPrint(TRACE_LEVEL_ERROR, " StorPortInitializePerfOpts set failed with status = 0x%x\n", status);
+        
+        if (CHECKBIT(adaptExt->features, VIRTIO_SCSI_F_HOTPLUG)) {
+            PVirtIOSCSIEventNode events = adaptExt->events;
+            for (i = 0; i < 8; i++) {
+                if (!KickEvent(DeviceExtension, (PVOID)(&events[i]))) {
+                    #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
+                    RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot add event %d\n", i);
+                    #endif
                 }
             }
-            else {
-                RhelDbgPrint(TRACE_LEVEL_INFORMATION, " StorPortInitializePerfOpts get failed with status = 0x%x\n", status);
-            }
         }
-        if (!adaptExt->dpc_ok && !StorPortEnablePassiveInitialization(DeviceExtension, VioScsiPassiveInitializeRoutine)) {
+
+        if (!adaptExt->dpc_ok && !StorPortEnablePassiveInitialization(DeviceExtension, VioScsiPassiveDpcInitializeRoutine)) {
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
             RhelDbgPrint(TRACE_LEVEL_FATAL, " StorPortEnablePassiveInitialization FAILED\n");
+            EXIT_FN();
+            #endif
             return FALSE;
         }
     }
 
     virtio_device_ready(&adaptExt->vdev);
-EXIT_FN();
+
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return TRUE;
 }
 
@@ -884,8 +1005,10 @@ VioScsiStartIo(
     IN PSCSI_REQUEST_BLOCK Srb
     )
 {
-ENTER_FN_SRB();
-    if (PreProcessRequest(DeviceExtension, (PSRB_TYPE)Srb))
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_SRB_HP();
+    #endif
+    if (PreProcessRequest(DeviceExtension, (PSRB_TYPE)Srb, "PreProcessRequest"))
     {
         CompleteRequest(DeviceExtension, (PSRB_TYPE)Srb);
     }
@@ -893,17 +1016,26 @@ ENTER_FN_SRB();
     {
         SendSRB(DeviceExtension, (PSRB_TYPE)Srb);
     }
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_FN_SRB_HP();
+    #endif
     return TRUE;
 }
 
 VOID
+FORCEINLINE
 HandleResponse(
     IN PVOID DeviceExtension,
-    IN PVirtIOSCSICmd cmd
+    IN PVirtIOSCSICmd cmd,
+    IN PVOID InlineFuncName
 )
 {
     PSRB_TYPE Srb = (PSRB_TYPE)(cmd->srb);
+
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_INL_FN_SRB_HP();
+    #endif
+
     PSRB_EXTENSION srbExt = SRB_EXTENSION(Srb);
     VirtIOSCSICmdResp *resp = &cmd->resp.cmd;
     UCHAR senseInfoBufferLength = 0;
@@ -911,54 +1043,83 @@ HandleResponse(
     UCHAR srbStatus = SRB_STATUS_SUCCESS;
     ULONG srbDataTransferLen = SRB_DATA_TRANSFER_LENGTH(Srb);
 
-ENTER_FN();
-
-    LOG_SRB_INFO();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    LOG_SRB_INFO_FROM_INLFN_HP();
+    #endif
 
     switch (resp->response) {
     case VIRTIO_SCSI_S_OK:
         SRB_SET_SCSI_STATUS(Srb, resp->status);
         srbStatus = (resp->status == SCSISTAT_GOOD) ? SRB_STATUS_SUCCESS : SRB_STATUS_ERROR;
+        #if !defined(RUN_UNCHECKED)
+        if (srbStatus == SRB_STATUS_SUCCESS) {
+            #if !defined(RUN_COLD_PATH_ONLY)
+            RhelDbgPrintHotPath(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_OK : SRB_STATUS_SUCCESS\n");
+            #endif
+        } else {
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_OK : SRB_STATUS_ERROR\n");
+        }
+        #endif
         break;
     case VIRTIO_SCSI_S_UNDERRUN:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_UNDERRUN\n");
+        #endif
         srbStatus = SRB_STATUS_DATA_OVERRUN;
         break;
     case VIRTIO_SCSI_S_ABORTED:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_ABORTED\n");
+        #endif
         srbStatus = SRB_STATUS_ABORTED;
         break;
     case VIRTIO_SCSI_S_BAD_TARGET:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_BAD_TARGET\n");
+        #endif
         srbStatus = SRB_STATUS_INVALID_TARGET_ID;
         break;
     case VIRTIO_SCSI_S_RESET:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_RESET\n");
+        #endif
         srbStatus = SRB_STATUS_BUS_RESET;
         break;
     case VIRTIO_SCSI_S_BUSY:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_BUSY\n");
+        #endif
         srbStatus = SRB_STATUS_BUSY;
         break;
     case VIRTIO_SCSI_S_TRANSPORT_FAILURE:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_TRANSPORT_FAILURE\n");
+        #endif
         srbStatus = SRB_STATUS_ERROR;
         break;
     case VIRTIO_SCSI_S_TARGET_FAILURE:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_TARGET_FAILURE\n");
+        #endif
         srbStatus = SRB_STATUS_ERROR;
         break;
     case VIRTIO_SCSI_S_NEXUS_FAILURE:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_NEXUS_FAILURE\n");
+        #endif
         srbStatus = SRB_STATUS_ERROR;
         break;
     case VIRTIO_SCSI_S_FAILURE:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_SCSI_S_FAILURE\n");
+        #endif
         srbStatus = SRB_STATUS_ERROR;
         break;
     default:
         srbStatus = SRB_STATUS_ERROR;
+        #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Unknown response %d\n", resp->response);
+        #endif
         break;
     }
     if (srbStatus == SRB_STATUS_SUCCESS &&
@@ -985,10 +1146,13 @@ ENTER_FN();
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, srbExt->Xfer);
         srbStatus = SRB_STATUS_DATA_OVERRUN;
     }
+    
     SRB_SET_SRB_STATUS(Srb, srbStatus);
     CompleteRequest(DeviceExtension, Srb);
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_INL_FN_HP();
+    #endif
 }
 
 BOOLEAN
@@ -1030,7 +1194,9 @@ VioScsiInterrupt(
               case VIRTIO_SCSI_S_FUNCTION_SUCCEEDED:
                  break;
               default:
+                 #if !defined(RUN_UNCHECKED)
                  RhelDbgPrint(TRACE_LEVEL_ERROR, " unknown response %d\n", resp->response);
+                 #endif
                  ASSERT(0);
                  break;
               }
@@ -1050,7 +1216,9 @@ VioScsiInterrupt(
               ParamChange(DeviceExtension, evt);
               break;
            default:
+              #if !defined(RUN_UNCHECKED)
               RhelDbgPrint(TRACE_LEVEL_ERROR, " Unsupport virtio scsi event %x\n", evt->event);
+              #endif
               break;
            }
            SynchronizedKickEventRoutine(DeviceExtension, evtNode);
@@ -1069,7 +1237,9 @@ VioScsiInterrupt(
         }
     }
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, " isInterruptServiced = %d\n", isInterruptServiced);
+    #endif
     return isInterruptServiced;
 }
 
@@ -1088,12 +1258,14 @@ VioScsiMSInterruptWorker(
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    RhelDbgPrint(TRACE_LEVEL_VERBOSE,
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    RhelDbgPrintHotPath(TRACE_LEVEL_VERBOSE,
                  " MessageID 0x%x\n", MessageID);
+    #endif
 
     if (MessageID >= QUEUE_TO_MESSAGE(VIRTIO_SCSI_REQUEST_QUEUE_0))
     {
-        DispatchQueue(DeviceExtension, MessageID);
+        DispatchQueue(DeviceExtension, MessageID, "DispatchQueue");
         return TRUE;
     }
     if (MessageID == 0)
@@ -1115,7 +1287,9 @@ VioScsiMSInterruptWorker(
               case VIRTIO_SCSI_S_FUNCTION_SUCCEEDED:
                  break;
               default:
+                 #if !defined(RUN_UNCHECKED)
                  RhelDbgPrint(TRACE_LEVEL_ERROR, " Unknown response %d\n", resp->response);
+                 #endif
                  ASSERT(0);
                  break;
               }
@@ -1138,7 +1312,9 @@ VioScsiMSInterruptWorker(
               ParamChange(DeviceExtension, evt);
               break;
            default:
+              #if !defined(RUN_UNCHECKED)
               RhelDbgPrint(TRACE_LEVEL_ERROR, " Unsupport virtio scsi event %x\n", evt->event);
+              #endif
               break;
            }
            SynchronizedKickEventRoutine(DeviceExtension, evtNode);
@@ -1195,6 +1371,10 @@ VioScsiAdapterControl(
     IN PVOID Parameters
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PSCSI_SUPPORTED_CONTROL_TYPE_LIST ControlTypeList;
     ULONG                             AdjustedMaxControlType;
     ULONG                             Index;
@@ -1202,7 +1382,6 @@ VioScsiAdapterControl(
     SCSI_ADAPTER_CONTROL_STATUS       status = ScsiAdapterControlUnsuccessful;
     BOOLEAN SupportedControlTypes[17] = { 0 };
 
-ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     SupportedControlTypes[0]  = 1; //ScsiQuerySupportedControlTypes
     SupportedControlTypes[1]  = 1; //ScsiStopAdapter
@@ -1212,7 +1391,9 @@ ENTER_FN();
     switch (ControlType) {
 
     case ScsiQuerySupportedControlTypes: {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_VERBOSE, " ScsiQuerySupportedControlTypes\n");
+        #endif
         ControlTypeList = (PSCSI_SUPPORTED_CONTROL_TYPE_LIST)Parameters;
         AdjustedMaxControlType =
             (ControlTypeList->MaxControlType < 5) ?
@@ -1226,7 +1407,9 @@ ENTER_FN();
         break;
     }
     case ScsiStopAdapter: {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_VERBOSE, " ScsiStopAdapter\n");
+        #endif
         ShutDown(DeviceExtension);
         if (adaptExt->pmsg_affinity != NULL) {
             StorPortFreePool(DeviceExtension,
@@ -1238,28 +1421,38 @@ ENTER_FN();
         break;
     }
     case ScsiRestartAdapter: {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " ScsiRestartAdapter\n");
+        #endif
         ShutDown(DeviceExtension);
         if (!VioScsiHwReinitialize(DeviceExtension))
         {
-           RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot reinitialize HW\n");
-           break;
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_FATAL, " Cannot reinitialize HW\n");
+            #endif
+            break;
         }
         status = ScsiAdapterControlSuccess;
         break;
     }
     case ScsiAdapterSurpriseRemoval: {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " ScsiAdapterSurpriseRemoval\n");
+        #endif
         adaptExt->bRemoved = TRUE;
         status = ScsiAdapterControlSuccess;
         break;
     }
     default:
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_ERROR, " Unsupported ControlType %d\n", ControlType);
+        #endif
         break;
     }
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return status;
 }
 
@@ -1270,6 +1463,10 @@ VioScsiUnitControl(
     IN PVOID Parameters
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PSCSI_SUPPORTED_CONTROL_TYPE_LIST ControlTypeList;
     ULONG                             AdjustedMaxControlType;
     ULONG                             index;
@@ -1277,14 +1474,15 @@ VioScsiUnitControl(
     SCSI_UNIT_CONTROL_STATUS          Status = ScsiUnitControlUnsuccessful;
     BOOLEAN SupportedControlTypes[11] = { 0 };
 
-ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     SupportedControlTypes[0]  = 1; //ScsiQuerySupportedControlTypes
     SupportedControlTypes[2]  = 1; //ScsiUnitStart
     SupportedControlTypes[9]  = 1; //ScsiUnitRemove
     SupportedControlTypes[10] = 1; //ScsiUnitSurpriseRemoval
 
+    #if !defined(RUN_UNCHECKED)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Unit Control Type %d\n", ControlType);
+    #endif
     switch (ControlType) {
         case ScsiQuerySupportedControlTypes:
             ControlTypeList = (PSCSI_SUPPORTED_CONTROL_TYPE_LIST)Parameters;
@@ -1322,11 +1520,13 @@ ENTER_FN();
                             SRB_LUN(currSrb) == stor_addr->Lun) {
                             SRB_SET_SRB_STATUS(currSrb, SRB_STATUS_NO_DEVICE);
                             CompleteRequest(DeviceExtension, (PSRB_TYPE)currSrb);
+                            #if !defined(RUN_UNCHECKED)
                             RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                                 " Complete pending I/Os on Path %d Target %d Lun %d \n",
                                 SRB_PATH_ID(currSrb),
                                 SRB_TARGET_ID(currSrb),
                                 SRB_LUN(currSrb));
+                            #endif
                             element->srb_cnt--;
                         }
                     }
@@ -1336,11 +1536,15 @@ ENTER_FN();
             Status = ScsiUnitControlSuccess;
             break;
         default:
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_ERROR, " Unsupported Unit ControlType %d\n", ControlType);
+            #endif
             break;
     }
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return Status;
 }
 
@@ -1362,7 +1566,10 @@ VioScsiBuildIo(
     UCHAR                 TargetId;
     UCHAR                 Lun;
 
-ENTER_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_SRB_HP();
+    #endif
+
     cdb      = SRB_CDB(Srb);
     srbExt   = SRB_EXTENSION(Srb);
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
@@ -1380,7 +1587,9 @@ ENTER_FN_SRB();
         return FALSE;
     }
 
-    LOG_SRB_INFO();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    LOG_SRB_INFO_HP();
+    #endif
 
     RtlZeroMemory(srbExt, sizeof(*srbExt));
     srbExt->Srb = Srb;
@@ -1449,11 +1658,15 @@ ENTER_FN_SRB();
         }
         else
         {
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_ERROR, "SRB 0x%p StorPortQueryPerformanceCounter failed with status  0x%lx\n", Srb, status);
+            #endif
         }
     }
 
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_FN_SRB_HP();
+    #endif
     return TRUE;
 }
 
@@ -1462,11 +1675,15 @@ VOID
 FORCEINLINE
 DispatchQueue(
     IN PVOID DeviceExtension,
-    IN ULONG MessageId
+    IN ULONG MessageId,
+    IN PVOID InlineFuncName
 )
 {
     PADAPTER_EXTENSION  adaptExt;
-ENTER_FN();
+
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_INL_FN_HP();
+    #endif
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
@@ -1476,11 +1693,15 @@ ENTER_FN();
             &adaptExt->dpc[MessageId - QUEUE_TO_MESSAGE(VIRTIO_SCSI_REQUEST_QUEUE_0)],
             ULongToPtr(MessageId),
             ULongToPtr(MessageId));
-EXIT_FN();
+        #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+        EXIT_INL_FN_HP();
+        #endif
         return;
     }
     ProcessBuffer(DeviceExtension, MessageId, InterruptLock);
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_INL_FN_HP();
+    #endif
 }
 
 VOID
@@ -1502,10 +1723,14 @@ ProcessBuffer(
     ULONG               vq_req_idx;
     PVOID               LockContext = NULL; //sanity check for LockMode = InterruptLock or StartIoLock
 
-ENTER_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_HP();
+    #endif
 
     if (QueueNumber >= (adaptExt->num_queues + VIRTIO_SCSI_REQUEST_QUEUE_0)) {
-        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Modulo assignment required for QueueNumber as it exceeds the number of virtqueues available.\n");
+        #if !defined(RUN_UNCHECKED)
+        RhelDbgPrint(TRACE_VQ, " Modulo assignment required for QueueNumber as it exceeds the number of virtqueues available.\n");
+        #endif
         QueueNumber %= adaptExt->num_queues;
     }
     vq_req_idx = QueueNumber - VIRTIO_SCSI_REQUEST_QUEUE_0;
@@ -1543,14 +1768,16 @@ ENTER_FN();
                 }
             }
             if (bFound) {
-                HandleResponse(DeviceExtension, cmd);
+                HandleResponse(DeviceExtension, cmd, "HandleResponse");
             }
         }
     } while (!virtqueue_enable_cb(vq));
 
     StorPortReleaseSpinLock(DeviceExtension, &LockHandle);
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_FN_HP();
+    #endif
 }
 
 VOID
@@ -1563,10 +1790,14 @@ VioScsiCompleteDpcRoutine(
 {
     ULONG MessageId;
 
-ENTER_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_HP();
+    #endif
     MessageId = PtrToUlong(SystemArgument1);
     ProcessBuffer(Context, MessageId, DpcLock);
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_FN_HP();
+    #endif
 }
 
 VOID
@@ -1591,7 +1822,9 @@ CompletePendingRequestsOnReset(
 
         for (vq_req_idx = 0; vq_req_idx < adaptExt->num_queues; vq_req_idx++) {
             element = &adaptExt->processing_srbs[vq_req_idx];
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_FATAL, " queue %d cnt %d\n", vq_req_idx, element->srb_cnt);
+            #endif
             LockContext = &adaptExt->dpc[vq_req_idx];
             StorPortAcquireSpinLock(DeviceExtension, DpcLock, LockContext, &LockHandle);
             while (!IsListEmpty(&element->srb_list)) {
@@ -1614,7 +1847,9 @@ CompletePendingRequestsOnReset(
         StorPortResume(DeviceExtension);
     }
     else {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Reset is already in progress, doing nothing.\n");
+        #endif
     }
     adaptExt->reset_in_progress = FALSE;
 }
@@ -1625,22 +1860,27 @@ VioScsiProcessPnP(
     IN PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION      adaptExt;
     PSCSI_PNP_REQUEST_BLOCK pnpBlock;
     ULONG                   SrbPnPFlags;
     ULONG                   PnPAction;
     UCHAR                   SrbStatus;
 
-ENTER_FN();
     adaptExt  = (PADAPTER_EXTENSION)DeviceExtension;
     pnpBlock  = (PSCSI_PNP_REQUEST_BLOCK)Srb;
     SrbStatus = SRB_STATUS_SUCCESS;
     SRB_GET_PNP_INFO(Srb, SrbPnPFlags, PnPAction);
     switch (PnPAction) {
         case StorQueryCapabilities:
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                 " StorQueryCapabilities on %d::%d::%d\n",
                 SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb));
+            #endif
             if (((SrbPnPFlags & SRB_PNP_FLAGS_ADAPTER_REQUEST) == 0) ||
                 (SRB_DATA_TRANSFER_LENGTH(Srb) >= sizeof(STOR_DEVICE_CAPABILITIES))) {
                 PSTOR_DEVICE_CAPABILITIES devCap =
@@ -1652,19 +1892,25 @@ ENTER_FN();
             break;
         case StorRemoveDevice:
         case StorSurpriseRemoval:
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_FATAL,
                 " Adapter Removal happens on %d::%d::%d\n",
                 SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb));
+            #endif
             adaptExt->bRemoved = TRUE;
             break;
         default:
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_FATAL,
                 " Unsupported PnPAction SrbPnPFlags = %d, PnPAction = %d\n",
                 SrbPnPFlags, PnPAction);
+            #endif
             SrbStatus = SRB_STATUS_INVALID_REQUEST;
             break;
     }
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return SrbStatus;
 }
 
@@ -1672,12 +1918,16 @@ BOOLEAN
 FORCEINLINE
 PreProcessRequest(
     IN PVOID DeviceExtension,
-    IN PSRB_TYPE Srb
+    IN PSRB_TYPE Srb,
+    IN PVOID InlineFuncName
     )
 {
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_INL_FN_SRB_HP();
+    #endif
+
     PADAPTER_EXTENSION adaptExt;
 
-ENTER_FN_SRB();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
     switch (SRB_FUNCTION(Srb)) {
@@ -1692,20 +1942,34 @@ ENTER_FN_SRB();
         case SRB_FUNCTION_RESET_BUS:
         case SRB_FUNCTION_RESET_DEVICE:
         case SRB_FUNCTION_RESET_LOGICAL_UNIT:
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> SRB_FUNCTION_RESET_LOGICAL_UNIT Target (%d::%d::%d), SRB 0x%p\n", SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+            #endif
             switch (adaptExt->action_on_reset) {
                 case VioscsiResetCompleteRequests:
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Completing all pending SRBs\n");
+                    #endif
+                    //CompletePendingRequestsOnReset(DeviceExtension, DpcLock);
                     CompletePendingRequestsOnReset(DeviceExtension);
                     SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
+                    #if !defined(RUN_UNCHECKED)
+                    EXIT_INL_FN_SRB();
+                    #endif
                     return TRUE;
                 case VioscsiResetDoNothing:
-                    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Doing nothing with all pending SRBs\n");
                     SRB_SET_SRB_STATUS(Srb, SRB_STATUS_SUCCESS);
+                    #if !defined(RUN_UNCHECKED)
+                    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Doing nothing with all pending SRBs\n");
+                    EXIT_INL_FN_SRB();
+                    #endif
                     return TRUE;
                 case VioscsiResetBugCheck:
-                    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Let's bugcheck due to this reset event\n");
                     KeBugCheckEx(0xDEADDEAD, (ULONG_PTR)Srb, SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb));
+                    #if !defined(RUN_UNCHECKED)
+                    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Let's bugcheck due to this reset event\n");
+                    EXIT_INL_FN_SRB();
+                    #endif
                     return TRUE;
             }
         case SRB_FUNCTION_WMI:
@@ -1715,26 +1979,43 @@ ENTER_FN_SRB();
             VioScsiIoControl(DeviceExtension, Srb);
             return TRUE;
     }
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_INL_FN_SRB_HP();
+    #endif
     return FALSE;
 }
 
 VOID
+FORCEINLINE
 PostProcessRequest(
     IN PVOID DeviceExtension,
-    IN PSRB_TYPE Srb
+    IN PSRB_TYPE Srb,
+    IN PVOID InlineFuncName
     )
 {
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_INL_FN_SRB_HP();
+    #endif
+
     PCDB                  cdb = NULL;
     PADAPTER_EXTENSION    adaptExt = NULL;
     PSRB_EXTENSION        srbExt = NULL;
-ENTER_FN_SRB();
+
     if (SRB_FUNCTION(Srb) != SRB_FUNCTION_EXECUTE_SCSI) {
+        #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+        RhelDbgPrintHotPath(TRACE_LEVEL_VERBOSE, " Post-Processor detected this is NOT a SRB_FUNCTION_EXECUTE_SCSI.\n");
+        EXIT_INL_FN_SRB_HP();
+        #endif
         return;
     }
-    cdb      = SRB_CDB(Srb);
-    if (!cdb)
+    cdb = SRB_CDB(Srb);
+    if (!cdb) {
+        #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+        RhelDbgPrintHotPath(TRACE_LEVEL_VERBOSE, " Post-Processor detected this is NOT a Command Descriptor Block (CDB).\n");
+        EXIT_INL_FN_SRB_HP();
+        #endif
         return;
+    }
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
@@ -1744,21 +2025,27 @@ ENTER_FN_SRB();
         case SCSIOP_READ_CAPACITY16:
            break;
         case SCSIOP_INQUIRY:
-           VioScsiSaveInquiryData(DeviceExtension, Srb);
-           VioScsiPatchInquiryData(DeviceExtension, Srb);
-           if (!StorPortSetDeviceQueueDepth( DeviceExtension, SRB_PATH_ID(Srb),
-                                     SRB_TARGET_ID(Srb), SRB_LUN(Srb),
-                                     adaptExt->queue_depth)) {
-              RhelDbgPrint(TRACE_LEVEL_ERROR, " StorPortSetDeviceQueueDepth(%p, %x) failed.\n",
-                          DeviceExtension,
-                          adaptExt->queue_depth);
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Post-Processor detected SCSIOP_INQUIRY. Saving and Patching Inquiry Data...\n");
+            #endif
+            VioScsiSaveInquiryData(DeviceExtension, Srb);
+            VioScsiPatchInquiryData(DeviceExtension, Srb);
+            if (!StorPortSetDeviceQueueDepth( DeviceExtension, SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), adaptExt->queue_depth)) {
+                #if !defined(RUN_UNCHECKED)
+                RhelDbgPrint(TRACE_LEVEL_ERROR, " StorPortSetDeviceQueueDepth(%p, %x) failed.\n", DeviceExtension, adaptExt->queue_depth);
+                EXIT_INL_FN_SRB();
+                #endif
            }
-           break;
+            break;
         default:
-           break;
-
+            #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+            RhelDbgPrintHotPath(TRACE_LEVEL_VERBOSE, " Post-Processor did NOT detect any CDB6GENERIC Operation Codes in the Command Descriptor Block (CDB).\n");
+            #endif
+            break;
     }
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    EXIT_INL_FN_SRB_HP();
+    #endif
 }
 
 VOID
@@ -1767,13 +2054,17 @@ CompleteRequest(
     IN PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    ENTER_FN_SRB_HP();
+    #endif
+
     PADAPTER_EXTENSION    adaptExt = NULL;
     PSRB_EXTENSION        srbExt = NULL;
 
- ENTER_FN_SRB();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    PostProcessRequest(DeviceExtension, Srb);
+    PostProcessRequest(DeviceExtension, Srb, "PostProcessRequest");
 
+    #if !defined(RUN_UNCHECKED)
     if (adaptExt->resp_time)
     {
         srbExt = SRB_EXTENSION(Srb);
@@ -1808,10 +2099,15 @@ CompleteRequest(
             }
         }
     }
+    #endif
     StorPortNotification(RequestComplete,
                          DeviceExtension,
                          Srb);
-EXIT_FN_SRB();
+
+    #if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)
+    RhelDbgPrintHotPath(TRACE_LEVEL_VERBOSE, " StorPort was notified the request is complete.\n");
+    EXIT_FN_SRB_HP();
+    #endif
 }
 
 VOID
@@ -1840,22 +2136,29 @@ TransportReset(
     IN PVirtIOSCSIEvent evt
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     UCHAR TargetId = evt->lun[1];
     UCHAR Lun = (evt->lun[2] << 8) | evt->lun[3];
-ENTER_FN();
 
-    switch (evt->reason)
-    {
+    switch (evt->reason) {
         case VIRTIO_SCSI_EVT_RESET_RESCAN:
-           StorPortNotification( BusChangeDetected, DeviceExtension, 0);
-           break;
+            StorPortNotification(BusChangeDetected, DeviceExtension, 0);
+            break;
         case VIRTIO_SCSI_EVT_RESET_REMOVED:
-           StorPortNotification( BusChangeDetected, DeviceExtension, 0);
-           break;
+            StorPortNotification(BusChangeDetected, DeviceExtension, 0);
+            break;
         default:
-           RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <--> Unsupport virtio scsi event reason 0x%x\n", evt->reason);
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " <--> Unsupport virtio scsi event reason 0x%x\n", evt->reason);
+            #endif
+            break;
     }
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
 
 VOID
@@ -1864,11 +2167,14 @@ ParamChange(
     IN PVirtIOSCSIEvent evt
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     UCHAR TargetId = evt->lun[1];
     UCHAR Lun = (evt->lun[2] << 8) | evt->lun[3];
     UCHAR AdditionalSenseCode = (UCHAR)(evt->reason & 255);
     UCHAR AdditionalSenseCodeQualifier = (UCHAR)(evt->reason >> 8);
-ENTER_FN();
 
     if (AdditionalSenseCode == SCSI_ADSENSE_PARAMETERS_CHANGED &&
        (AdditionalSenseCodeQualifier == SPC3_SCSI_SENSEQ_PARAMETERS_CHANGED ||
@@ -1877,7 +2183,9 @@ ENTER_FN();
     {
         StorPortNotification( BusChangeDetected, DeviceExtension, 0);
     }
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
 
 VOID
@@ -1885,9 +2193,12 @@ VioScsiWmiInitialize(
     IN PVOID DeviceExtension
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION    adaptExt;
     PSCSI_WMILIB_CONTEXT WmiLibContext;
-ENTER_FN();
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     WmiLibContext = (PSCSI_WMILIB_CONTEXT)(&(adaptExt->WmiLibContext));
@@ -1900,7 +2211,10 @@ ENTER_FN();
     WmiLibContext->SetWmiDataBlock = NULL;
     WmiLibContext->ExecuteWmiMethod = VioScsiExecuteWmiMethod;
     WmiLibContext->WmiFunctionControl = NULL;
-EXIT_FN();
+
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }
 
 VOID
@@ -1909,13 +2223,16 @@ VioScsiWmiSrb(
     IN OUT PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN_SRB();
+    #endif
+
     UCHAR status;
     SCSIWMI_REQUEST_CONTEXT requestContext = {0};
     ULONG retSize;
     PADAPTER_EXTENSION    adaptExt;
     PSRB_WMI_DATA pSrbWmi = SRB_WMI_DATA(Srb);
 
-ENTER_FN_SRB();
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
     ASSERT(SRB_FUNCTION(Srb) == SRB_FUNCTION_WMI);
@@ -1924,6 +2241,9 @@ ENTER_FN_SRB();
     ASSERT(SRB_DATA_BUFFER(Srb));
 
     if (!pSrbWmi)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
     if (!(pSrbWmi->WMIFlags & SRB_WMI_FLAGS_ADAPTER_REQUEST))
     {
@@ -1947,8 +2267,9 @@ ENTER_FN_SRB();
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, retSize);
         SRB_SET_SRB_STATUS(Srb, status);
     }
-
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN_SRB();
+    #endif
 }
 
 VOID
@@ -1957,11 +2278,13 @@ VioScsiIoControl(
     IN OUT PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN_SRB();
+    #endif
+
     PSRB_IO_CONTROL srbControl;
     PVOID           srbDataBuffer = SRB_DATA_BUFFER(Srb);
     PADAPTER_EXTENSION    adaptExt;
-
-ENTER_FN_SRB();
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     srbControl = (PSRB_IO_CONTROL)srbDataBuffer;
@@ -1969,21 +2292,29 @@ ENTER_FN_SRB();
     switch (srbControl->ControlCode) {
         case IOCTL_SCSI_MINIPORT_NOT_QUORUM_CAPABLE:
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_ERROR);
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> Signature = %02x %02x %02x %02x %02x %02x %02x %02x\n",
                 srbControl->Signature[0], srbControl->Signature[1], srbControl->Signature[2], srbControl->Signature[3],
                 srbControl->Signature[4], srbControl->Signature[5], srbControl->Signature[6], srbControl->Signature[7]);
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> IOCTL_SCSI_MINIPORT_NOT_QUORUM_CAPABLE\n");
+            #endif
             break;
         case IOCTL_SCSI_MINIPORT_FIRMWARE:
             FirmwareRequest(DeviceExtension, Srb);
+            #if !defined(RUN_UNCHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> IOCTL_SCSI_MINIPORT_FIRMWARE\n");
+            #endif
             break;
         default:
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_INVALID_REQUEST);
-            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> Unsupport control code 0x%x\n", srbControl->ControlCode);
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> Unsupported control code 0x%x\n", srbControl->ControlCode);
+            #endif
             break;
     }
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN_SRB();
+    #endif
 }
 
 UCHAR
@@ -1993,11 +2324,14 @@ ParseIdentificationDescr(
     IN UCHAR PageLength
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION    adaptExt;
     UCHAR CodeSet = 0;
     UCHAR IdentifierType = 0;
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    ENTER_FN();
     if (IdentificationDescr) {
         CodeSet = IdentificationDescr->CodeSet;//(UCHAR)(((PCHAR)IdentificationDescr)[0]);
         IdentifierType = IdentificationDescr->IdentifierType;//(UCHAR)(((PCHAR)IdentificationDescr)[1]);
@@ -2014,7 +2348,9 @@ ParseIdentificationDescr(
                     if (NT_SUCCESS(Status)) {
                         StorPortMoveMemory(adaptExt->ser_num, IdentificationDescr->Identifier, ln);
                         adaptExt->ser_num[ln] = '\0';
+                        #if !defined(RUN_UNCHECKED)
                         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " serial number %s\n", adaptExt->ser_num);
+                        #endif
                     }
                 }
             }
@@ -2023,31 +2359,44 @@ ParseIdentificationDescr(
         case VioscsiVpdIdentifierTypeFCPHName: {
             if ((CodeSet == VioscsiVpdCodeSetBinary) && (IdentificationDescr->IdentifierLength == sizeof(ULONGLONG))) {
                 REVERSE_BYTES_QUAD(&adaptExt->wwn, IdentificationDescr->Identifier);
+                #if !defined(RUN_UNCHECKED)
                 RhelDbgPrint(TRACE_LEVEL_INFORMATION, " wwn %llu\n", (ULONGLONG)adaptExt->wwn);
+                #endif
             }
         }
         break;
         case VioscsiVpdIdentifierTypeFCTargetPortPHName: {
             if ((CodeSet == VioscsiVpdCodeSetSASBinary) && (IdentificationDescr->IdentifierLength == sizeof(ULONGLONG))) {
                 REVERSE_BYTES_QUAD(&adaptExt->port_wwn, IdentificationDescr->Identifier);
+                #if !defined(RUN_UNCHECKED)
                 RhelDbgPrint(TRACE_LEVEL_INFORMATION, " port wwn %llu\n", (ULONGLONG)adaptExt->port_wwn);
+                #endif
             }
         }
         break;
         case VioscsiVpdIdentifierTypeFCTargetPortRelativeTargetPort: {
             if ((CodeSet == VioscsiVpdCodeSetSASBinary) && (IdentificationDescr->IdentifierLength == sizeof(ULONG))) {
                 REVERSE_BYTES(&adaptExt->port_idx, IdentificationDescr->Identifier);
+                #if !defined(RUN_UNCHECKED)
                 RhelDbgPrint(TRACE_LEVEL_INFORMATION, " port index %lu\n", (ULONG)adaptExt->port_idx);
+                #endif
             }
         }
         break;
         default:
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
             RhelDbgPrint(TRACE_LEVEL_ERROR, " Unsupported IdentifierType = %x!\n", IdentifierType);
+            #endif
             break;
         }
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN();
+        #endif
         return IdentificationDescr->IdentifierLength;
     }
+    #if !defined(RUN_UNCHECKED)
     EXIT_FN();
+    #endif
     return 0;
 }
 
@@ -2057,23 +2406,35 @@ VioScsiSaveInquiryData(
     IN OUT PSRB_TYPE Srb
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN_SRB();
+    #endif
+
     PVOID           dataBuffer;
     PADAPTER_EXTENSION    adaptExt;
     PCDB cdb;
     ULONG dataLen;
     UCHAR SrbStatus = SRB_STATUS_SUCCESS;
-ENTER_FN_SRB();
 
     if (!Srb)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     cdb  = SRB_CDB(Srb);
 
     if (!cdb)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     SRB_GET_SCSI_STATUS(Srb, SrbStatus);
     if (SrbStatus == SRB_STATUS_ERROR)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
@@ -2085,7 +2446,9 @@ ENTER_FN_SRB();
             case VPD_SERIAL_NUMBER: {
                 PVPD_SERIAL_NUMBER_PAGE SerialPage;
                 SerialPage = (PVPD_SERIAL_NUMBER_PAGE)dataBuffer;
+                #if !defined(RUN_UNCHECKED)
                 RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VPD_SERIAL_NUMBER PageLength = %d\n", SerialPage->PageLength);
+                #endif
                 if (SerialPage->PageLength > 0 && adaptExt->ser_num == NULL) {
                     int ln = min(64, SerialPage->PageLength);
                     ULONG Status =
@@ -2096,7 +2459,9 @@ ENTER_FN_SRB();
                     if (NT_SUCCESS(Status)) {
                         StorPortMoveMemory(adaptExt->ser_num, SerialPage->SerialNumber, ln);
                         adaptExt->ser_num[ln] = '\0';
+                        #if !defined(RUN_UNCHECKED)
                         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " serial number %s\n", adaptExt->ser_num);
+                        #endif
                     }
                 }
             }
@@ -2130,7 +2495,9 @@ ENTER_FN_SRB();
             CopyBufferToAnsiString(adaptExt->rev_id, InquiryData->ProductRevisionLevel, ' ',sizeof(InquiryData->ProductRevisionLevel));
         }
     }
-EXIT_FN_SRB();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN_SRB();
+    #endif
 }
 
 VOID
@@ -2139,23 +2506,35 @@ VioScsiPatchInquiryData(
     IN OUT PSRB_TYPE Srb
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN_SRB();
+    #endif
+
     PVOID           dataBuffer;
     PADAPTER_EXTENSION    adaptExt;
     PCDB cdb;
     ULONG dataLen;
     UCHAR SrbStatus = SRB_STATUS_SUCCESS;
-    ENTER_FN_SRB();
 
     if (!Srb)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     cdb = SRB_CDB(Srb);
 
     if (!cdb)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     SRB_GET_SCSI_STATUS(Srb, SrbStatus);
     if (SrbStatus == SRB_STATUS_ERROR)
+        #if !defined(RUN_UNCHECKED)
+        EXIT_FN_SRB();
+        #endif
         return;
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
@@ -2196,7 +2575,9 @@ VioScsiPatchInquiryData(
             break;
         }
     }
+    #if !defined(RUN_UNCHECKED)
     EXIT_FN_SRB();
+    #endif
 }
 
 BOOLEAN
@@ -2211,11 +2592,14 @@ VioScsiQueryWmiDataBlock(
     OUT PUCHAR Buffer
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     ULONG size = 0;
     UCHAR status = SRB_STATUS_SUCCESS;
     PADAPTER_EXTENSION    adaptExt;
 
-ENTER_FN();
     adaptExt = (PADAPTER_EXTENSION)Context;
 
     UNREFERENCED_PARAMETER(InstanceIndex);
@@ -2240,7 +2624,9 @@ ENTER_FN();
         case VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX:
         {
             PMS_SM_AdapterInformationQuery pOutBfr = (PMS_SM_AdapterInformationQuery)Buffer;
-            RhelDbgPrint(TRACE_LEVEL_FATAL, " --> VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX\n");
+            #if !defined(RUN_UNCHECKED)
+            RhelDbgPrint(TRACE_LEVEL_WARNING, " --> VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX\n");
+            #endif
             size = sizeof(MS_SM_AdapterInformationQuery);
             if (OutBufferSize < size)
             {
@@ -2284,7 +2670,9 @@ ENTER_FN();
             if (OutBufferSize < size)
             {
                 status = SRB_STATUS_DATA_OVERRUN;
+                #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
                 RhelDbgPrint(TRACE_LEVEL_WARNING, " --> VIOSCSI_MS_PORT_INFORM_GUID_INDEX out buffer too small %d %d\n", OutBufferSize, size);
+                #endif
                 break;
             }
             *InstanceLengthArray = size;
@@ -2301,7 +2689,9 @@ ENTER_FN();
                            status,
                            size);
 
-EXIT_FN();
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return TRUE;
 }
 
@@ -2317,24 +2707,31 @@ VioScsiExecuteWmiMethod(
     IN OUT PUCHAR Buffer
     )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     PADAPTER_EXTENSION      adaptExt = (PADAPTER_EXTENSION)Context;
     ULONG                   size = 0;
     UCHAR                   status = SRB_STATUS_SUCCESS;
     UNREFERENCED_PARAMETER(InstanceIndex);
 
-    ENTER_FN();
     switch (GuidIndex)
     {
         case VIOSCSI_SETUP_GUID_INDEX:
         {
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> VIOSCSI_SETUP_GUID_INDEX ERROR\n");
+            #endif
         }
         break;
         case VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX:
         {
             PMS_SM_AdapterInformationQuery pOutBfr = (PMS_SM_AdapterInformationQuery)Buffer;
             pOutBfr;
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> VIOSCSI_MS_ADAPTER_INFORM_GUID_INDEX ERROR\n");
+            #endif
         }
         break;
         case VIOSCSI_MS_PORT_INFORM_GUID_INDEX:
@@ -2345,7 +2742,9 @@ VioScsiExecuteWmiMethod(
                 {
                     PSM_GetPortType_IN  pInBfr = (PSM_GetPortType_IN)Buffer;
                     PSM_GetPortType_OUT pOutBfr = (PSM_GetPortType_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetPortType\n");
+                    #endif
                     size = SM_GetPortType_OUT_SIZE;
                     if (OutBufferSize < size)
                     {
@@ -2366,7 +2765,9 @@ VioScsiExecuteWmiMethod(
                     PSM_GetAdapterPortAttributes_IN  pInBfr = (PSM_GetAdapterPortAttributes_IN)Buffer;
                     PSM_GetAdapterPortAttributes_OUT pOutBfr = (PSM_GetAdapterPortAttributes_OUT)Buffer;
                     PMS_SMHBA_FC_Port pPortSpecificAttributes = NULL;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetAdapterPortAttributes\n");
+                    #endif
                     size = FIELD_OFFSET(SM_GetAdapterPortAttributes_OUT, PortAttributes) + FIELD_OFFSET(MS_SMHBA_PORTATTRIBUTES, PortSpecificAttributes) + sizeof(MS_SMHBA_FC_Port);
                     if (OutBufferSize < size)
                     {
@@ -2399,7 +2800,9 @@ VioScsiExecuteWmiMethod(
                 {
                     PSM_GetDiscoveredPortAttributes_IN  pInBfr = (PSM_GetDiscoveredPortAttributes_IN)Buffer;
                     PSM_GetDiscoveredPortAttributes_OUT pOutBfr = (PSM_GetDiscoveredPortAttributes_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetDiscoveredPortAttributes\n");
+                    #endif
                     size = SM_GetDiscoveredPortAttributes_OUT_SIZE;
                     if (OutBufferSize < size)
                     {
@@ -2421,7 +2824,9 @@ VioScsiExecuteWmiMethod(
                 {
                     PSM_GetPortAttributesByWWN_IN  pInBfr = (PSM_GetPortAttributesByWWN_IN)Buffer;
                     PSM_GetPortAttributesByWWN_OUT pOutBfr = (PSM_GetPortAttributesByWWN_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetPortAttributesByWWN\n");
+                    #endif
                     size = SM_GetPortAttributesByWWN_OUT_SIZE;
                     if (OutBufferSize < size)
                     {
@@ -2437,14 +2842,18 @@ VioScsiExecuteWmiMethod(
                     CopyUnicodeString(pOutBfr->PortAttributes.OSDeviceName, MODEL, sizeof(pOutBfr->PortAttributes.OSDeviceName));
                     pOutBfr->PortAttributes.PortState = HBA_PORTSTATE_ONLINE;
                     pOutBfr->PortAttributes.PortType = HBA_PORTTYPE_SASDEVICE;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetPortAttributesByWWN Not Implemented Yet\n");
+                    #endif
                 }
                 break;
                 case SM_GetProtocolStatistics:
                 {
                     PSM_GetProtocolStatistics_IN  pInBfr = (PSM_GetProtocolStatistics_IN)Buffer;
                     PSM_GetProtocolStatistics_OUT pOutBfr = (PSM_GetProtocolStatistics_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetProtocolStatistics\n");
+                    #endif
                     size = SM_GetProtocolStatistics_OUT_SIZE;
                     if (OutBufferSize < size)
                     {
@@ -2462,7 +2871,9 @@ VioScsiExecuteWmiMethod(
                 {
                     PSM_GetPhyStatistics_IN  pInBfr = (PSM_GetPhyStatistics_IN)Buffer;
                     PSM_GetPhyStatistics_OUT pOutBfr = (PSM_GetPhyStatistics_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetPhyStatistics\n");
+                    #endif
                     size = FIELD_OFFSET(SM_GetPhyStatistics_OUT, PhyCounter) + sizeof(LONGLONG);
                     if (OutBufferSize < size)
                     {
@@ -2481,7 +2892,9 @@ VioScsiExecuteWmiMethod(
                     PSM_GetFCPhyAttributes_IN  pInBfr = (PSM_GetFCPhyAttributes_IN)Buffer;
                     PSM_GetFCPhyAttributes_OUT pOutBfr = (PSM_GetFCPhyAttributes_OUT)Buffer;
 
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetFCPhyAttributes\n");
+                    #endif
                     size = SM_GetFCPhyAttributes_OUT_SIZE;
 
                     if (OutBufferSize < size)
@@ -2501,7 +2914,9 @@ VioScsiExecuteWmiMethod(
                 {
                     PSM_GetSASPhyAttributes_IN  pInBfr = (PSM_GetSASPhyAttributes_IN)Buffer;
                     PSM_GetSASPhyAttributes_OUT pOutBfr = (PSM_GetSASPhyAttributes_OUT)Buffer;
+                    #if !defined(RUN_UNCHECKED)
                     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " --> SM_GetSASPhyAttributes\n");
+                    #endif
                     size = SM_GetSASPhyAttributes_OUT_SIZE;
                     if (OutBufferSize < size)
                     {
@@ -2521,21 +2936,27 @@ VioScsiExecuteWmiMethod(
                 break;
                 default:
                     status = SRB_STATUS_INVALID_REQUEST;
+                    #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
                     RhelDbgPrint(TRACE_LEVEL_ERROR, " --> ERROR Unknown MethodId = %lu\n", MethodId);
+                    #endif
                     break;
             }
         }
         break;
         default:
             status = SRB_STATUS_INVALID_REQUEST;
+            #if !defined(RUN_UNCHECKED) || defined(RUN_MIN_CHECKED)
             RhelDbgPrint(TRACE_LEVEL_ERROR, " --> VioScsiExecuteWmiMethod Unsupported GuidIndex = %lu\n", GuidIndex);
+            #endif
         break;
     }
     ScsiPortWmiPostProcess(RequestContext,
         status,
         size);
 
+    #if !defined(RUN_UNCHECKED)
     EXIT_FN();
+    #endif
     return SRB_STATUS_SUCCESS;
 
 }
@@ -2547,11 +2968,18 @@ VioScsiQueryWmiRegInfo(
     OUT PWCHAR *MofResourceName
     )
 {
-ENTER_FN();
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     UNREFERENCED_PARAMETER(Context);
     UNREFERENCED_PARAMETER(RequestContext);
 
     *MofResourceName = VioScsiWmi_MofResourceName;
+
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
     return SRB_STATUS_SUCCESS;
 }
 
@@ -2561,11 +2989,13 @@ IN PVOID Context,
 OUT PUCHAR Buffer
 )
 {
+    #if !defined(RUN_UNCHECKED)
+    ENTER_FN();
+    #endif
+
     UCHAR numberOfBytes = sizeof(VioScsiExtendedInfo) - 1;
     PADAPTER_EXTENSION    adaptExt;
     PVioScsiExtendedInfo  extInfo;
-
-ENTER_FN();
 
     adaptExt = (PADAPTER_EXTENSION)Context;
     extInfo = (PVioScsiExtendedInfo)Buffer;
@@ -2583,5 +3013,8 @@ ENTER_FN();
     extInfo->CompletionDuringStartIo = CHECKFLAG(adaptExt->perfFlags, STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO);
     extInfo->PhysicalBreaks = adaptExt->max_physical_breaks;
     extInfo->ResponseTime = adaptExt->resp_time;
-EXIT_FN();
+
+    #if !defined(RUN_UNCHECKED)
+    EXIT_FN();
+    #endif
 }

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -121,8 +121,9 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_SCSI_QUEUE_LAST                 VIRTIO_SCSI_REQUEST_QUEUE_0 + MAX_CPU
 
 /* MSI messages and virtqueue indices are offset by 1, MSI 0 is not used */
-#define QUEUE_TO_MESSAGE(QueueId)              ((QueueId) + 1)
-#define MESSAGE_TO_QUEUE(MessageId)            ((MessageId) - 1)
+#define VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET       1
+#define QUEUE_TO_MESSAGE(QueueId)              ((QueueId) + VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET)
+#define MESSAGE_TO_QUEUE(MessageId)            ((MessageId) - VIRTIO_SCSI_MSI_CONTROL_Q_OFFSET)
 
 /* SCSI command request, followed by data-out */
 #pragma pack(1)
@@ -271,7 +272,7 @@ typedef struct virtio_bar {
     PHYSICAL_ADDRESS  BasePA;
     ULONG             uLength;
     PVOID             pBase;
-    BOOLEAN           bPortSpace;
+    BOOLEAN           bMemorySpace;
 } VIRTIO_BAR, *PVIRTIO_BAR;
 
 typedef enum ACTION_ON_RESET {
@@ -365,6 +366,58 @@ typedef struct {
   PCIX_TABLE_POINTER      MessageTable;
   PCIX_TABLE_POINTER      PBATable;
 } PCI_MSIX_CAPABILITY, *PPCI_MSIX_CAPABILITY;
+#endif
+
+struct virtio_pci_cfg_cap {
+    struct virtio_pci_cap cap;
+    u8 pci_cfg_data[4]; /* Data for BAR access. */
+};
+
+struct virtio_pci_isr_cap {
+    struct virtio_pci_cap cap;
+    u8 isr;
+};
+
+struct virtio_pci_device_cap {
+    struct virtio_pci_cap cap;
+    // Be careful not to touch anything hot here...
+};
+
+struct virtio_pci_common_cfg_cap{
+    struct virtio_pci_cap cap;
+    struct virtio_pci_common_cfg;
+};
+
+typedef struct virtio_pci_notify_cap VIRTIO_PCI_NOTIFY_CAP;
+typedef VIRTIO_PCI_NOTIFY_CAP* PVIRTIO_PCI_NOTIFY_CAP;
+typedef struct virtio_pci_cfg_cap VIRTIO_PCI_CFG_CAP;
+typedef VIRTIO_PCI_CFG_CAP* PVIRTIO_PCI_CFG_CAP;
+typedef struct virtio_pci_isr_cap VIRTIO_PCI_ISR_CAP;
+typedef VIRTIO_PCI_ISR_CAP* PVIRTIO_PCI_ISR_CAP;
+typedef struct virtio_pci_device_cap VIRTIO_PCI_DEVICE_CAP;
+typedef VIRTIO_PCI_DEVICE_CAP* PVIRTIO_PCI_DEVICE_CAP;
+typedef struct virtio_pci_common_cfg_cap VIRTIO_PCI_COMMON_CFG_CAP;
+typedef VIRTIO_PCI_COMMON_CFG_CAP* PVIRTIO_PCI_COMMON_CFG_CAP;
+
+
+#define PCI_CAP_REDHAT_TYPE_OFFSET  3
+//#define REDHAT_CAP_RESOURCE_RESERVE 1 // <-- This clashes with VIRTIO_PCI_CAP_COMMON_CFG=1 per virtio_pci.h
+#define REDHAT_CAP_RESOURCE_RESERVE 6
+#define REDHAT_CAP_RESOURCE_RESERVE_SIZE 32
+
+#ifndef PCI_RHEL_QEMU_CAPABILITY
+typedef struct {
+  PCI_CAPABILITIES_HEADER Header;
+  struct {
+    u8  len;
+    u8  type;
+    u32 bus_res;
+    u64 io;
+    u32 mem;
+    u32 prefetchable_32;
+    u64 prefetchable_64;
+  } Reservation;
+} PCI_RHEL_QEMU_CAPABILITY, *PPCI_RHEL_QEMU_CAPABILITY;
 #endif
 
 #define SPC3_SCSI_SENSEQ_PARAMETERS_CHANGED                 0x0

--- a/vioscsi/vioscsi.vcxproj
+++ b/vioscsi/vioscsi.vcxproj
@@ -33,6 +33,9 @@
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <Configuration>Win10 Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <DisableTracing Condition="'$(FORCE_RUN_UNCHECKED)' != ''">true</DisableTracing>
+    <LimitPathsWPP Condition="'$(RUN_WPP_ALL_PATHS)' == ''">WPPColdPathOnly</LimitPathsWPP>
+    <UseDebugTracing Condition="'$(FORCE_RUN_DEBUG)' != ''">true</UseDebugTracing>
     <SignMode>Off</SignMode>
   </PropertyGroup>
   <PropertyGroup Label="Globals">
@@ -127,6 +130,22 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Win10 Release'">
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(DisableTracing)'=='true'">%(PreprocessorDefinitions);RUN_UNCHECKED=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(LimitPathsWPP)'=='WPPColdPathOnly'">%(PreprocessorDefinitions);RUN_COLD_PATH_ONLY=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseDebugTracing)'!='true'">%(PreprocessorDefinitions);EVENT_TRACING=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NTDDI_VERSION=NTDDI_WINTHRESHOLD</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Win11 Release'">
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(DisableTracing)'=='true'">%(PreprocessorDefinitions);RUN_UNCHECKED=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(LimitPathsWPP)'=='WPPColdPathOnly'">%(PreprocessorDefinitions);RUN_COLD_PATH_ONLY=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseDebugTracing)'!='true'">%(PreprocessorDefinitions);EVENT_TRACING=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);NTDDI_VERSION=NTDDI_WIN10_CO</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
       <Command>
@@ -139,28 +158,34 @@
       <Outputs>$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\vioscsi.DVL.XML;$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\vioscsi.DVL-win10.XML</Outputs>
     </CustomBuildStep>
     <ClCompile>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">true</WppEnabled>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">trace.h</WppScanConfigurationData>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|Win32' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
     </ClCompile>
     <ClCompile>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">true</WppEnabled>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">trace.h</WppScanConfigurationData>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|x64' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
     </ClCompile>
     <ClCompile>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">true</WppEnabled>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64' And '$(DisableTracing)'!='true' And '$(UseDebugTracing)'!='true'">true</WppEnabled>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
       <WppGenerateUsingTemplateFile Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">{km-StorDefault.tpl}*.tmh</WppGenerateUsingTemplateFile>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64'">trace.h</WppScanConfigurationData>
-      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64'">trace.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win10 Release|ARM64' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64' And '$(LimitPathsWPP)'=='WPPColdPathOnly'">wpp_cold_path.h</WppScanConfigurationData>
+      <WppScanConfigurationData Condition="'$(Configuration)|$(Platform)'=='Win11 Release|ARM64' And '$(LimitPathsWPP)'!='WPPColdPathOnly'">wpp_all_paths.h</WppScanConfigurationData>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vioscsi/virtio_pci.c
+++ b/vioscsi/virtio_pci.c
@@ -38,7 +38,7 @@
 #include "helper.h"
 #include "trace.h"
 
-#if defined(EVENT_TRACING)
+#if defined(EVENT_TRACING) && !defined(RUN_UNCHECKED)
 #include "virtio_pci.tmh"
 #endif
 
@@ -113,7 +113,9 @@ static void *mem_alloc_contiguous_pages(void *context, size_t size)
         RtlZeroMemory(ptr, size);
         return ptr;
     } else {
+        #if !defined(RUN_UNCHECKED)
         RhelDbgPrint(TRACE_LEVEL_FATAL, " Ran out of memory in alloc_pages_exact(%Id)\n", size);
+        #endif
         return NULL;
     }
 }
@@ -189,7 +191,7 @@ static void *pci_map_address_range(void *context, int bar, size_t offset, size_t
                 adaptExt->system_io_bus_number,
                 pBar->BasePA,
                 pBar->uLength,
-                !!pBar->bPortSpace);
+                !pBar->bMemorySpace);
         }
         if (pBar->pBase != NULL && offset < pBar->uLength) {
             return (PUCHAR)pBar->pBase + offset;

--- a/vioscsi/wpp_all_paths.h
+++ b/vioscsi/wpp_all_paths.h
@@ -1,0 +1,208 @@
+/*
+* This file contains debug print support routines and globals.
+*
+* Copyright (c) 2012-2024 Red Hat, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met :
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and / or other materials provided with the distribution.
+* 3. Neither the names of the copyright holders nor the names of their contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+
+#ifndef ___WPPALLPATHS_H___
+#define ___WPPALLPATHS_H___
+
+/* Custom RhelDbgPrint Entries */
+
+// begin_wpp config
+// USEPREFIX (RhelDbgPrint, "%!STDPREFIX! ####\t\t[%!FUNC!] DEBUG:");
+// FUNC RhelDbgPrint(LEVEL, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (RhelDbgPrintHotPath, "%!STDPREFIX! ####\t\t[%!FUNC!] DEBUG:");
+// FUNC RhelDbgPrintHotPath(LEVEL, MSG, ...);
+// end_wpp
+
+#define WPP_Flags_LEVEL_LOGGER(Flags, level) WPP_LEVEL_LOGGER(Flags)
+#define WPP_Flags_LEVEL_ENABLED(Flags, level) \
+    (WPP_LEVEL_ENABLED(Flags) && \
+    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
+
+/* Cold Path Entries */
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN, "%!STDPREFIX! ===>\t\t[%!FUNC!] X---X Working X---X");
+// FUNC ENTER_FN{ENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_ENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN, "%!STDPREFIX! <===\t\t[%!FUNC!] Processing complete.");
+// FUNC EXIT_FN{EXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_EXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_EXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] X---X Working X---X", InlineFuncName);
+// FUNC ENTER_INL_FN{INLENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] Processing complete.", InlineFuncName);
+// FUNC EXIT_INL_FN{INLEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_ERR, "%!STDPREFIX! >>>>\t\t[%!FUNC!] ERROR line %d", __LINE__);
+// FUNC EXIT_ERR{ERRORLEVEL=TRACE_LEVEL_ERROR}(...);
+// end_wpp
+#define WPP_ERRORLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ERRORLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN_SRB(PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC ENTER_FN_SRB{SRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC EXIT_FN_SRB{SRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO{SRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_SRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC ENTER_INL_FN_SRB{INLSRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC EXIT_INL_FN_SRB{INLSRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO_FROM_INLFN(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!]:[%s] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", InlineFuncName, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO_FROM_INLFN{INLSRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_INLSRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+/* Hot Path Entries */
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN_HP, "%!STDPREFIX! ===>\t\t[%!FUNC!] X---X Working X---X");
+// FUNC ENTER_FN_HP{ENTRYLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_ENTRYLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ENTRYLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN_HP, "%!STDPREFIX! <===\t\t[%!FUNC!] Processing complete.");
+// FUNC EXIT_FN_HP{EXITLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_EXITLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_EXITLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN_HP(PVOID InlineFuncName), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] X---X Working X---X", InlineFuncName);
+// FUNC ENTER_INL_FN_HP{INLENTRYLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLENTRYLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLENTRYLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN_HP(PVOID InlineFuncName), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] Processing complete.", InlineFuncName);
+// FUNC EXIT_INL_FN_HP{INLEXITLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLEXITLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLEXITLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_ERR_HP, "%!STDPREFIX! >>>>\t\t[%!FUNC!] ERROR line %d", __LINE__);
+// FUNC EXIT_ERR_HP{ERRORLEVELHP=TRACE_LEVEL_ERROR}(...);
+// end_wpp
+#define WPP_ERRORLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ERRORLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN_SRB_HP(PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC ENTER_FN_SRB_HP{SRBENTRYLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBENTRYLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBENTRYLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN_SRB_HP(PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC EXIT_FN_SRB_HP{SRBEXITLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBEXITLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBEXITLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO_HP(PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO_HP{SRBINFOLEVELHP=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_SRBINFOLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL) 
+#define WPP_SRBINFOLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN_SRB_HP(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC ENTER_INL_FN_SRB_HP{INLSRBENTRYLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBENTRYLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBENTRYLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN_SRB_HP(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC EXIT_INL_FN_SRB_HP{INLSRBEXITLEVELHP=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBEXITLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBEXITLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO_FROM_INLFN_HP(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!]:[%s] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", InlineFuncName, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO_FROM_INLFN_HP{INLSRBINFOLEVELHP=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_INLSRBINFOLEVELHP_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBINFOLEVELHP_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+#endif //__WPPALLPATHS_H___

--- a/vioscsi/wpp_cold_path.h
+++ b/vioscsi/wpp_cold_path.h
@@ -1,0 +1,123 @@
+/*
+* This file contains debug print support routines and globals.
+*
+* Copyright (c) 2012-2024 Red Hat, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met :
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and / or other materials provided with the distribution.
+* 3. Neither the names of the copyright holders nor the names of their contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+
+#ifndef ___WPPCOLDPATH_H___
+#define ___WPPCOLDPATH_H___
+
+/* Custom RhelDbgPrint Entries */
+
+// begin_wpp config
+// USEPREFIX (RhelDbgPrint, "%!STDPREFIX! ####\t\t[%!FUNC!] DEBUG:");
+// FUNC RhelDbgPrint(LEVEL, MSG, ...);
+// end_wpp
+#define WPP_Flags_LEVEL_LOGGER(Flags, level) WPP_LEVEL_LOGGER(Flags)
+#define WPP_Flags_LEVEL_ENABLED(Flags, level) \
+    (WPP_LEVEL_ENABLED(Flags) && \
+    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
+
+/* Cold Path Entries */
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN, "%!STDPREFIX! ===>\t\t[%!FUNC!] X---X Working X---X");
+// FUNC ENTER_FN{ENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_ENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN, "%!STDPREFIX! <===\t\t[%!FUNC!] Processing complete.");
+// FUNC EXIT_FN{EXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_EXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_EXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] X---X Working X---X", InlineFuncName);
+// FUNC ENTER_INL_FN{INLENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN(PVOID InlineFuncName), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] Processing complete.", InlineFuncName);
+// FUNC EXIT_INL_FN{INLEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_ERR, "%!STDPREFIX! >>>>\t\t[%!FUNC!] ERROR line %d", __LINE__);
+// FUNC EXIT_ERR{ERRORLEVEL=TRACE_LEVEL_ERROR}(...);
+// end_wpp
+#define WPP_ERRORLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_ERRORLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_FN_SRB(PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC ENTER_FN_SRB{SRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_FN_SRB(PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!] SRB 0x%p", Srb);
+// FUNC EXIT_FN_SRB{SRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_SRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO(PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO{SRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_SRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_SRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (ENTER_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ===>\t\t[%!FUNC!]>>>[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC ENTER_INL_FN_SRB{INLSRBENTRYLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBENTRYLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBENTRYLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (EXIT_INL_FN_SRB(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! <===\t\t[%!FUNC!]<<<[%s] SRB 0x%p", InlineFuncName, Srb);
+// FUNC EXIT_INL_FN_SRB{INLSRBEXITLEVEL=TRACE_ENTER_EXIT}(...);
+// end_wpp
+#define WPP_INLSRBEXITLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBEXITLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+// begin_wpp config
+// USEPREFIX (LOG_SRB_INFO_FROM_INLFN(PVOID InlineFuncName, PVOID Srb), "%!STDPREFIX! ####\t\t[%!FUNC!]:[%s] Operation %s (0x%X), Target (%d::%d::%d), SRB 0x%p", InlineFuncName, DbgGetScsiOpStr(DbgGetScsiOp(Srb)), DbgGetScsiOp(Srb), SRB_PATH_ID(Srb), SRB_TARGET_ID(Srb), SRB_LUN(Srb), Srb);
+// FUNC LOG_SRB_INFO_FROM_INLFN{INLSRBINFOLEVEL=TRACE_LEVEL_INFORMATION}(...);
+// end_wpp
+#define WPP_INLSRBINFOLEVEL_ENABLED(LEVEL) WPP_LEVEL_ENABLED(LEVEL)
+#define WPP_INLSRBINFOLEVEL_LOGGER(LEVEL) WPP_LEVEL_LOGGER(LEVEL)
+
+#endif //__WPPCOLDPATH_H___


### PR DESCRIPTION
1. Introduced three (3) compile-time environment variables:
   a) `RUN_WPP_ALL_PATHS`
   Compile WPP for the hot path too.
   Is the inverse of `RUN_COLD_PATH_ONLY`, which is the default behaviour.
   b) `FORCE_RUN_UNCHECKED`
   Run without `EVENT_TRACING` or `DBG`. Defines `RUN_UNCHECKED`.
   c) `FORCE_RUN_DEBUG`
   Run with `DBG` rather than `EVENT_TRACING`. Undefines `EVENT_TRACING`.

2. WPP scans for WPP config on a per file basis. Sections of the config file cannot be excluded and conditional macros will be ignored. To solve this, we establish two new files with WPP configuration data. One holds exclusively cold path data (`wpp_cold_path.h`) and the other holds data for all paths (`wpp_all_paths.h`). Which file to use is set conditionally per the `vioscsi.vcxproj` project file configuration.

3. The hot path DBG and WPP macro variants are a clone of the cold path macros, but with a "_HP" suffix. The exception to this is `RhelDbgPrint()` which we extend as `RhelDbgPrintHotPath()`.

4. Encapsulated exisitng cold and and hot trace messages in compile-time conditional macros and in same manner drops `*.tmh` includes when necessary. The general format for the cold path is `#if !defined(RUN_UNCHECKED)` and for the hot path `#if !defined(RUN_UNCHECKED) || !defined(RUN_COLD_PATH_ONLY)`.

5. Minor refactoring of: 
    a) `helper.c` - `GetScsiConfig()`
    b) `helper.c` - `SetGuestFeatures()`

6. Major refactoring of:
    a) `trace.h`
    b) `vioscsi.c` - `VioScsiHwInitialize()` - corrects order of init for benefit of clean trace.

7. Major new instrumentation of:
    a) `helper.c` - `InitVirtIODevice()`

8. Reconfigured the following for INLINE function tracing:
   a) `vioscsi.c` - `HandleResponse()`
   b) `vioscsi.c` - `PreProcessRequest()`
   c) `vioscsi.c` - `PostProcessRequest()`
   d) `vioscsi.c` - `DispatchQueue()`

9. Mnemonic rename of `VioScsiPassiveInitializeRoutine()` to `VioScsiPassiveDpcInitializeRoutine()`.

10. Correct struct `virtio_bar` for `bMemorySpace` rather than `bPortSpace` (`vioscsi.h` and `virtio_pci.c`).

11. Add missing structs for PCI Capabilities (`vioscsi.h`).

12. Included `stddef.h` for `offsetof` function.

Hard to split this one up further methinks.
I do have a fair bit of additional instrumentation to merge after this one.