### PR TITLE
[build] Use Germanium EWDK to sign Win11 drivers

### DIFF
--- a/build/signAll.bat
+++ b/build/signAll.bat
@@ -9,7 +9,7 @@ endlocal
 
 setlocal
 echo Loading Windows 11 build env
-call "%~dp0\SetVsEnv.bat" Win10
+call "%~dp0\SetVsEnv.bat" Win11
 for /r "%~dp0\..\" %%i in (*.sys) do call :sign_if_win11 "%%i"
 for /r "%~dp0\..\" %%i in (*.cat) do call :sign_if_win11 "%%i"
 endlocal


### PR DESCRIPTION
1. Use the Germanium EWDK Build Lab environment to sign Win11 drivers.
    We currently use the Cobalt EWDK to sign both Win10 and Win11 drivers.

Split from PR #1212.