### PR TITLE
[build] Extend SetVsEnv.bat

### DIFF
--- a/build/SetVsEnv.bat
+++ b/build/SetVsEnv.bat
@@ -7,11 +7,13 @@ if not "%EnterpriseWDK%"=="" goto ready
 if "%1"=="Win11" (
     if "%EWDK11_24H2_DIR%"=="" set EWDK11_24H2_DIR=c:\ewdk11_24h2
     call %EWDK11_24H2_DIR%\BuildEnv\SetupBuildEnv.cmd
+    @echo off
     goto :eof
 ) else (
     if "%EWDK11_DIR%"=="" set EWDK11_DIR=c:\ewdk11
     :: call :add_path "%EWDK11_DIR%\Program Files\Microsoft Visual Studio\2019\BuildTools\VC\Redist\MSVC\14.28.29910\onecore\x86\Microsoft.VC142.OPENMP\vcomp140.dll"
     call %EWDK11_DIR%\BuildEnv\SetupBuildEnv.cmd
+    @echo off
     goto :eof
 )
 
@@ -23,5 +25,10 @@ set path=%path%;%~dp1
 goto :eof
 
 :ready
-echo We are already in EWDK version: %Version_Number%
+for /f "tokens=4 usebackq delims=\'" %%i in (`echo %%VSINSTALLDIR%%`) do @set vs_year=%%i
+echo **********************************************************************
+echo ** We are already in an Enterprise WDK build environment
+echo ** Version %BuildLab% ^| %Version_Number%
+echo ** Visual Studio %vs_year% Developer Command Prompt v%VSCMD_VER%
+echo **********************************************************************
 goto :eof


### PR DESCRIPTION
1. Enforce echo off after calling `SetupBuildEnv.cmd`, which will otherwise spill noise into the build log.
    If data amongst this noise is required, best to report it specifically.

3. Provide some extra EWDK details when `EnterpriseWDK=True`.
    Here we include the `BuildLab`, VS year and dev CLI version as well as the `Version_Number` (EWDK Build Number).

Split from PR #1212.