### PR TITLE
[build] Pre-build x86 viosock libraries as needed

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -179,6 +179,13 @@ echo.
 pushd %BUILD_DIR%
 call "%~dp0SetVsEnv.bat" %TARGET_PROJ_CONFIG%
 
+rem Check for any prerequisite x86 libraries and build them if needed...
+call "%~dp0prebuild_x86_libs.bat" %BUILD_FILE% %BUILD_ARCH% "%BUILD_DIR%" %TARGET% %BUILD_FLAVOUR%
+IF ERRORLEVEL 1 (
+  set BUILD_FAILED=1
+  goto :build_arch_done
+)
+
 rem Split builds between Code Analysis and No-Analyis...
 if /I "!TAG!"=="SDV" (
   echo.

--- a/build/prebuild_x86_libs.bat
+++ b/build/prebuild_x86_libs.bat
@@ -1,0 +1,60 @@
+@echo off
+setlocal
+rem Check for x86 viosock libraries and build them if needed...
+call :do_viosock %*
+if ERRORLEVEL 1 (
+  endlocal
+  exit /B 1
+)
+endlocal
+goto :eof
+
+:do_viosock
+rem Lay up some variables
+set BUILD_FILE=%~1
+set BUILD_ARCH=%~2
+set BUILD_DIR=%~3
+set TARGET=%~4
+set BUILD_FLAVOUR=%~5
+set VIOSOCK_PREBUILD_X86_LIBS=
+set BUILD_FAILED=
+
+rem Which solutions need this?
+if "%BUILD_FILE%"=="virtio-win.sln" (
+  set VIOSOCK_PREBUILD_X86_LIBS=1
+)
+if "%BUILD_FILE%"=="viosock.sln" (
+  set VIOSOCK_PREBUILD_X86_LIBS=1
+)
+
+if "%VIOSOCK_PREBUILD_X86_LIBS%" EQU "1" (
+  rem Only proceed if we are building for x64
+  if %BUILD_ARCH%==x64 (
+    rem Check for x86 viosock libraries and build them if needed...
+    if not exist "%BUILD_DIR%viosock\lib\x86\%TARGET%%BUILD_FLAVOR%\viosocklib.dll" (
+      echo.
+      echo ATTENTION ^: Need to build x86 viosock libraries before building for amd64...
+      setlocal
+      set VIRTIO_WIN_NO_ARM=1
+      if "%BUILD_FILE%"=="virtio-win.sln" (
+        pushd "%BUILD_DIR%viosock\lib"
+      )
+      if "%BUILD_FILE%"=="viosock.sln" (
+        pushd "%BUILD_DIR%lib"
+      )
+      call ..\..\build\build.bat viosocklib.vcxproj %TARGET% x86
+      if ERRORLEVEL 1 (
+        set BUILD_FAILED=1
+      )
+      popd
+      if "%BUILD_FAILED%" EQU "1" (
+        exit /B 1
+      )
+      echo Successfully built the x86 viosock libraries.
+      echo.
+      echo Continuing with amd64 build...
+      endlocal
+    )
+  )
+)
+goto :eof


### PR DESCRIPTION
1. Pre-builds `x86` `viosock` libraries when building `virtio-win.sln` or `viosock.sln` for `amd64` in the circumstances the required `x86` libraries do not already exist.

Split from PR #1212.