### PR TITLE
[NetKVM] Refactored legacy DVL creation

### DIFF
--- a/NetKVM/NetKVM-VS2015.vcxproj
+++ b/NetKVM/NetKVM-VS2015.vcxproj
@@ -179,13 +179,39 @@
   <ItemDefinitionGroup>
     <CustomBuildStep>
       <Command>
-        copy /Y $(ProjectDir)NetKVM.DVL.XML $(ProjectDir)Install\$(TargetOS)\$(TargetArch)
+        echo Copying $(TargetName).DVL.XML to Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL.XML
+        copy /Y $(ProjectDir)$(TargetName).DVL.XML^
+         $(ProjectDir)Install\$(TargetOS)\$(TargetArch)
+        echo Copying $(IntDir)vc.nativecodeanalysis.all.xml to $(ProjectDir)
         copy /Y $(IntDir)vc.nativecodeanalysis.all.xml $(ProjectDir)
-        call "..\build\dvl1903.bat" "$(ProjectDir)\$(IntDir)" "$(TargetName)" "$(Configuration)" "$(Platform)"
-        copy /Y $(ProjectDir)NetKVM.DVL.XML $(ProjectDir)Install\$(TargetOS)\$(TargetArch)\NetKVM.DVL-win10.XML
+        if "$(TargetOS)"=="Win10" (
+          echo Copying $(TargetName).DVL.XML to $(ProjectDir)$(TargetName).DVL-win10-latest.XML
+          copy /Y $(ProjectDir)$(TargetName).DVL.XML^
+           $(ProjectDir)$(TargetName).DVL-win10-latest.XML
+        )
+        if "$(TargetOS)"=="Win11" (
+          echo Copying $(TargetName).DVL.XML to $(ProjectDir)$(TargetName).DVL-win11-latest.XML
+          copy /Y $(ProjectDir)$(TargetName).DVL.XML^
+           $(ProjectDir)$(TargetName).DVL-win11-latest.XML
+        )
+        call "..\build\makeLegacyDVLs.bat" "$(ProjectDir)" "$(IntDir)" "$(TargetName)" "$(Configuration)" "$(Platform)"
+        if exist "$(ProjectDir)$(TargetName).DVL-win10-1903.XML" (
+          echo Copying $(TargetName).DVL-win10-1903.XML to Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL-win10.XML
+          copy /Y $(ProjectDir)$(TargetName).DVL-win10-1903.XML^
+           $(ProjectDir)Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL-win10.XML
+        ) else (
+          echo Unable to copy Win10 DVL $(ProjectDir)$(TargetName).DVL-win10-1903.XML - it does not exist.
+        )
+        if exist "$(ProjectDir)$(TargetName).DVL-win10-1607.XML" (
+          echo Copying $(TargetName).DVL-win10-1607.XML to Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL-compat.XML
+          copy /Y $(ProjectDir)$(TargetName).DVL-win10-1607.XML^
+           $(ProjectDir)Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL-compat.XML
+        ) else (
+          echo Unable to copy COMPAT DVL $(ProjectDir)$(TargetName).DVL-win10-1607.XML - it does not exist.
+        )
       </Command>
-      <Inputs>$(IntDir)vc.nativecodeanalysis.all.xml;$(ProjectDir)NetKVM.DVL.XML</Inputs>
-      <Outputs>$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\NetKVM.DVL.XML;$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\NetKVM.DVL-win10.XML</Outputs>
+      <Inputs>$(IntDir)vc.nativecodeanalysis.all.xml;$(ProjectDir)$(TargetName).DVL.XML</Inputs>
+      <Outputs>$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL.XML;$(ProjectDir)Install\$(TargetOS)\$(TargetArch)\$(TargetName).DVL-win10.XML</Outputs>
     </CustomBuildStep>
     <ClCompile />
     <ClCompile />

--- a/NetKVM/buildAll.bat
+++ b/NetKVM/buildAll.bat
@@ -3,4 +3,4 @@ if "%VIRTIO_WIN_NO_ARM%"=="" call ..\build\build.bat netkvm-vs2015.sln "Win10 Wi
 if errorlevel 1 goto :eof
 call ..\build\build.bat netkvm-vs2015.sln "Win10 Win11" %*
 if errorlevel 1 goto :eof
-call ..\build\build.bat NetKVM-VS2015.vcxproj "Win11_SDV" %*
+call ..\build\build.bat NetKVM-VS2015.vcxproj "Win10_SDV" "Win11_SDV" %*


### PR DESCRIPTION
1. Refactors the _CustomBuildStep Command_ to manage DVL file creation. We now create DVL files in the _Project_ (driver) folder with version numbers in the file name for DVL files created with legacy EWDKs, and with the _"latest"_ label for current EWDKs. These files are then copied to the relevant `.\Install` folders and renamed for extant WHCP submission operations. Makes use of the new `build\makeLegacyDVLs.bat` script (from PR [#1210](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1210)), which now creates all legacy DVL files. Logging is also enabled to provide feedback when read at the tail of `root\buildAll.bat`. Please see PR [#1212](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1212) for details on those changes.

2. Enables `Win10_SDV` for local (`NetKVM`) `buildAll.bat` script.