### PR TITLE
[build] Delete obsolete dvl1903.bat script

### DIFF
--- a/build/dvl1903.bat
+++ b/build/dvl1903.bat
@@ -1,7 +1,0 @@
-set "IntDir_DVL=%~1"
-set "TargetName_DVL=%~2"
-set "CONFIGURATION_DVL=%~3"
-set "PLATFORM_DVL=%~4"
-
-if "%DVL1903%"=="" set DVL1903=C:\DVL1903
-%DVL1903%\dvl.exe


### PR DESCRIPTION
1. Deletes `build\dvl1903.bat` script obsoleted by PRs [#1210](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1210), [#1240](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1240) and [#1241](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1241).