### PR TITLE
RHEL-40693:netkvm: Stop lazy alloc thread on reboot

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -1578,6 +1578,9 @@ Parameters:
 VOID ParaNdis_OnShutdown(PARANDIS_ADAPTER *pContext)
 {
     DEBUG_ENTRY(0); // this is only for kdbg :)
+
+    pContext->systemThread.Stop();
+
     ParaNdis_ResetVirtIONetDevice(pContext);
 
     pContext->m_StateMachine.NotifyShutdown();


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHEL-75532 Lazy allocation thread must be stopped before resetting virtio device.