### PR TITLE
RHEL-70446: [viostor] Fix returning SUCCESS when really -ENOSPC (regression)

### DIFF
--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -144,6 +144,10 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
+        result = TRUE;
+#ifdef DBG
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
     }
     else
     {
@@ -154,10 +158,6 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     {
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
     }
-#ifdef DBG
-    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
-    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
@@ -231,6 +231,10 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
+        result = TRUE;
+#ifdef DBG
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
     }
     else
     {
@@ -238,10 +242,6 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
-#ifdef DBG
-    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
-    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
@@ -388,6 +388,10 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
+        result = TRUE;
+#ifdef DBG
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
     }
     else
     {
@@ -395,10 +399,6 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
-#ifdef DBG
-    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
-    result = TRUE;
     if (notify)
     {
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " %s virtqueue_notify %d.\n", __FUNCTION__, QueueNumber);
@@ -486,6 +486,10 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
+        result = TRUE;
+#ifdef DBG
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
     }
     else
     {
@@ -493,10 +497,6 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
-#ifdef DBG
-    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
-    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);


### PR DESCRIPTION
1. Refactored to only return `TRUE` when `add_buffer_req_status == VQ_ADD_BUFFER_SUCCESS`.

2. Pro-actively refactors calls to `InterlockedIncrement()` back to the
    `add_buffer_req_status == VQ_ADD_BUFFER_SUCCESS` path.

Impacts: `RhelDoFlush()`, `RhelDoReadWrite()`, `RhelDoUnMap()` and `RhelGetSerialNumber()`.

Regression introduced with PR #1174 (379f291).
Will likely resolve issue #1204 (RHEL-70446)
Unlikely to resolve issue #907.

My bad... 8^d