### PR TITLE
[viostor] Fix performance issue (regression)

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -492,6 +492,10 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
                  ConfigInfo->NumberOfPhysicalBreaks,
                  adaptExt->queue_depth);
 
+    ConfigInfo->MaxIOsPerLun = adaptExt->queue_depth * adaptExt->num_queues;
+    ConfigInfo->InitialLunQueueDepth = ConfigInfo->MaxIOsPerLun;
+    ConfigInfo->MaxNumberOfIO = ConfigInfo->MaxIOsPerLun;
+
     extensionSize = PAGE_SIZE + adaptExt->pageAllocationSize + adaptExt->poolAllocationSize;
     uncachedExtensionVa = StorPortGetUncachedExtension(DeviceExtension, ConfigInfo, extensionSize);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION,


### PR DESCRIPTION
1. Added missing juice in PR [#487](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/487) (f8c904c), recommended for SMP with CPU affinity plus increase in `MAX_PHYS_SEGMENTS` (8x) and MaxXfer size.

Other performance enhancements are available, but this commit should resolve issue #992.