### PR TITLE
viostor: Address possible memory management issues when receiving i…

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -256,6 +256,7 @@ typedef struct _ADAPTER_EXTENSION
     REQUEST_LIST processing_srbs[MAX_CPU];
     BOOLEAN reset_in_progress;
     ULONGLONG fw_ver;
+    ULONG_PTR last_srb_id;
 #ifdef DBG
     LONG srb_cnt;
     LONG inqueue_cnt;
@@ -277,6 +278,7 @@ typedef struct _SRB_EXTENSION
     ULONG in;
     ULONG MessageID;
     BOOLEAN fua;
+    ULONG_PTR id;
     VIO_SG sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS desc[VIRTIO_MAX_SG];
 } SRB_EXTENSION, *PSRB_EXTENSION;

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -134,7 +134,7 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
                                               &srbExt->sg[0],
                                               srbExt->out,
                                               srbExt->in,
-                                              &srbExt->vbr,
+                                              (void *)srbExt->id,
                                               va,
                                               pa);
 
@@ -221,7 +221,7 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
                                               &srbExt->sg[0],
                                               srbExt->out,
                                               srbExt->in,
-                                              &srbExt->vbr,
+                                              (void *)srbExt->id,
                                               va,
                                               pa);
 
@@ -378,7 +378,7 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
                                               &srbExt->sg[0],
                                               srbExt->out,
                                               srbExt->in,
-                                              &srbExt->vbr,
+                                              (void *)srbExt->id,
                                               va,
                                               pa);
 
@@ -476,7 +476,7 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
                                               &srbExt->sg[0],
                                               srbExt->out,
                                               srbExt->in,
-                                              &srbExt->vbr,
+                                              (void *)srbExt->id,
                                               va,
                                               pa);
 


### PR DESCRIPTION
…nterrupts for already completed requests

When viostor receives a bus reset request, it completes all pending requests. This may be a problem when the host signals finishing of its work on a request that is already completed. At least, this means access to memory not currently owned by the viostor driver. At worst, incorrect SRB may be completed (since it occupies the same memory as that SRB completed on bus reset).

This commit addresses this issue by using autoincrementing unique IDs to match interrupts/DPCs to correct SRBs instead of addresses of blk_req structures within SRB extensions. Unlike addresses, these IDs repeat every 2^32 request on 32-bit platforms and every 2^64 request on 64-bit ones which should be more than enough to avoid the problems described above.