### PR TITLE
vioscsi: Address possible memory management issues when receiving i…

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -123,7 +123,7 @@ VOID SendSRB(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
                                               srbExt->psgl,
                                               srbExt->out,
                                               srbExt->in,
-                                              &srbExt->cmd,
+                                              (void *)srbExt->id,
                                               va,
                                               pa);
 

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -260,6 +260,7 @@ typedef struct _SRB_EXTENSION
     VIO_SG vio_sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS desc_alias[VIRTIO_MAX_SG];
     ULONGLONG time;
+    ULONG_PTR id;
 } SRB_EXTENSION, *PSRB_EXTENSION;
 #pragma pack()
 
@@ -352,6 +353,7 @@ typedef struct _ADAPTER_EXTENSION
     ULONGLONG fw_ver;
     ULONG resp_time;
     BOOLEAN bRemoved;
+    ULONG_PTR last_srb_id;
 } ADAPTER_EXTENSION, *PADAPTER_EXTENSION;
 
 #ifndef PCIX_TABLE_POINTER


### PR DESCRIPTION
…nterrupts for already completed requests

When vioscsi receives a bus reset request, it may complete all pending requests. This may be a problem when the host signals finishing of its work on a request that is already completed. At best, this means access to memory not currently owned by the vioscsi driver. At worst, incorrect SRB may be completed (since it occupies the same memory as that SRB completed on bus reset).

This commit addresses this issue by using autoincrementing unique IDs to match interrupts/DPCs to correct SRBs instead of addresses of VirtIOSCSICmd structures within SRB extensions. Unlike addresses, these IDs repeat every 2^32 request on 32-bit platforms and every 2^64 request on 64-bit ones which should be more than enough to avoid the problems described above.