### PR TITLE
[NetKVM] netkvm: fix an array out-of-bounds error

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -2132,7 +2132,7 @@ VOID ParaNdis_OnPnPEvent(PARANDIS_ADAPTER *pContext, NDIS_DEVICE_PNP_EVENT pEven
         ParaNdis_ResetVirtIONetDevice(pContext);
     }
     pContext->PnpEvents[pContext->nPnpEventIndex++] = pEvent;
-    if (pContext->nPnpEventIndex > sizeof(pContext->PnpEvents) / sizeof(pContext->PnpEvents[0]))
+    if (pContext->nPnpEventIndex >= sizeof(pContext->PnpEvents) / sizeof(pContext->PnpEvents[0]))
     {
         pContext->nPnpEventIndex = 0;
     }


### PR DESCRIPTION
Fix an array out-of-bounds in function ParaNdis_OnPnPEvent().