### PR TITLE
[CI-NO-BUILD] [viostor] Increase MAX_PHYS_SEGMENTS limit

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -88,7 +88,7 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 
 #define BLOCK_SERIAL_STRLEN                20
 
-#define MAX_PHYS_SEGMENTS                  512
+#define MAX_PHYS_SEGMENTS                  1024
 #define VIRTIO_MAX_SG                      (3 + MAX_PHYS_SEGMENTS)
 
 #define VIOBLK_POOL_TAG                    'BoiV'


### PR DESCRIPTION
Changes the `MAX_PHYS_SEGMENTS` limit to 1,024 equal to QEMU's `VIRTQUEUE_MAX_SIZE`.

This results in:
1. `adaptExt->max_segments` = 1024
2. `ConfigInfo->NumberOfPhysicalBreaks` = 1025
3. `ConfigInfo->MaximumTransferLength` = 4MiB (1,024 * PAGE_SIZE = 4,096KiB)