### PR TITLE
[CI-NO-BUILD] [vioscsi] Increase PHYS_SEGMENTS_LIMIT value

### DIFF
--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -50,7 +50,7 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #endif
 
 #define PHYS_SEGMENTS                        32
-#define MAX_PHYS_SEGMENTS                    512
+#define PHYS_SEGMENTS_LIMIT                  1022
 #define VIOSCSI_POOL_TAG                     'SoiV'
 #define VIRTIO_MAX_SG                        (1 + 1 + MAX_PHYS_SEGMENTS + 1) // cmd + resp + (MAX_PHYS_SEGMENTS + extra_page)
 


### PR DESCRIPTION
Changes the `PHYS_SEGMENTS_LIMIT` to 1,022 equal to QEMU's `VIRTQUEUE_MAX_SIZE` less 2 (for the `CONTROL` and `EVENT` queues).

This results in:
1. `adaptExt->max_segments` = 1022
2. `ConfigInfo->NumberOfPhysicalBreaks` = 1023
3. `ConfigInfo->MaximumTransferLength` = 4,088KiB (1,022 * PAGE_SIZE = 4,088KiB)