### PR TITLE
[RHEL-82494]netkvm: ensure poll handler scheduling on RSS queue change

### DIFF
--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -666,7 +666,12 @@ VOID CParaNdisRX::ProcessRxRing(CCHAR nCurrCpuReceiveQueue)
             {
                 if (m_Context->bPollModeEnabled)
                 {
+                    // ensure the NDIS just schedules the other poll and does not do anything
+                    // otherwise if both polls are configured to the same CPU
+                    // this may cause a deadlock in return nbl path
+                    KIRQL prev = KeRaiseIrqlToSynchLevel();
                     ParaNdisPollNotify(m_Context, nTargetReceiveQueueNum, "RSS");
+                    KeLowerIrql(prev);
                 }
                 else
                 {


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHEL-82494 Raise IRQL when triggering other poll handler due to RSS queue miss, this effectively prevents synchronous call to second poll handler and prevents deadlock if both poll handlers have the same affinity.