### PR TITLE
viogpu: Allocate more buffers than the queue capacity

### DIFF
--- a/viogpu/common/viogpu_queue.cpp
+++ b/viogpu/common/viogpu_queue.cpp
@@ -703,7 +703,7 @@ PGPU_VBUFFER VioGpuBuf::GetBuf(_In_ int size, _In_ int resp_size, _In_opt_ void 
         pbuf = CONTAINING_RECORD(pListItem, GPU_VBUFFER, list_entry);
     }
 
-    ASSERT(pvbuf);
+    ASSERT(pbuf);
     memset(pbuf, 0, VBUFFER_SIZE);
     ASSERT(size > MAX_INLINE_CMD_SIZE);
 
@@ -720,7 +720,7 @@ PGPU_VBUFFER VioGpuBuf::GetBuf(_In_ int size, _In_ int resp_size, _In_opt_ void 
     {
         pbuf->resp_buf = (char *)resp_buf;
     }
-    ASSERT(vbuf->resp_buf);
+    ASSERT(pbuf->resp_buf);
     InsertTailList(&m_InUseBufs, &pbuf->list_entry);
 
     if (SavedIrql < DISPATCH_LEVEL)

--- a/viogpu/common/viogpu_queue.h
+++ b/viogpu/common/viogpu_queue.h
@@ -81,6 +81,7 @@ class VioGpuBuf
     LIST_ENTRY m_InUseBufs;
     KSPIN_LOCK m_SpinLock;
     UINT m_uCount;
+    UINT m_uCountMin = 0;
 };
 
 class VioGpuMemSegment

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -2027,7 +2027,6 @@ NTSTATUS VioGpuDod::ReadRegistryDWORD(_In_ HANDLE DevInstRegKeyHandle,
         if (((PKEY_VALUE_PARTIAL_INFORMATION)Buf)->Type == REG_DWORD &&
             (((PKEY_VALUE_PARTIAL_INFORMATION)Buf)->DataLength == sizeof(DWORD)))
         {
-            ASSERT(Buf.Info.DataLength == sizeof(DWORD));
             *pdwValue = *((PDWORD) & (((PKEY_VALUE_PARTIAL_INFORMATION)Buf)->Data));
         }
         else


### PR DESCRIPTION
I occasionally saw viogpu crashes the whole system because of AllocCmd()
returning NULL. viogpu allocates buffers according to the queue size and
while it works fine in most cases, the specification says:
> Once the ring is full of driver descriptors, the driver stops sending
> new requests and waits for the device to start processing descriptors
> and to write out some used descriptors before making new driver
> descriptors available.

While waiting for the device in such a scenario, the driver will need to
hold buffers more than the queue size.

Allocate a buffer if we need more than the queue size, but free it once
it becomes unnecessary so that we will not keep unbound amount of memory
indefinitely.