### PR TITLE
[RHEL-22354] potential fix for stuck packet

### DIFF
--- a/NetKVM/Common/ParaNdis-Util.h
+++ b/NetKVM/Common/ParaNdis-Util.h
@@ -276,7 +276,8 @@ class CNdisRefCounter
     }
     operator LONG()
     {
-        return m_Counter;
+        // for example when need it, note the Tx.m_DpcWaiting
+        return InterlockedCompareExchange(&m_Counter, 0, 0);
     }
 
   private:


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHEL-22354

In the investigation with CNBL history we can see that the decision based on read of m_DpcWaiting was not correct. The value reads as 1 but the m_AuditState.LastTxProcess show the timestamp in past (using perf counter timestamps), 30 micros ago. Making read of ref counter interlocked.