### PR TITLE
[vioscsi]: fix warning as error ScsiQuerySupportedControlTypes

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1238,7 +1238,7 @@ VioScsiUnitControl(IN PVOID DeviceExtension, IN SCSI_UNIT_CONTROL_TYPE ControlTy
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Unit Control Type %d\n", ControlType);
     switch (ControlType)
     {
-        case ScsiQuerySupportedControlTypes:
+        case ScsiQuerySupportedUnitControlTypes:
             ControlTypeList = (PSCSI_SUPPORTED_CONTROL_TYPE_LIST)Parameters;
             AdjustedMaxControlType = (ControlTypeList->MaxControlType < 11) ? ControlTypeList->MaxControlType : 11;
             for (index = 0; index < AdjustedMaxControlType; index++)


### PR DESCRIPTION
ScsiQuerySupportedControlTypes should be ScsiQuerySupportedUnitControlTypes