### PR TITLE
[RHEL-84655]virtiolib-wdf: add check for active IOMMU

### DIFF
--- a/VirtIO/WDF/VirtIOWdf.c
+++ b/VirtIO/WDF/VirtIOWdf.c
@@ -47,6 +47,7 @@ NTSTATUS VirtIOWdfInitialize(PVIRTIO_WDF_DRIVER pWdfDriver, WDFDEVICE Device,
 
     RtlZeroMemory(pWdfDriver, sizeof(*pWdfDriver));
     pWdfDriver->MemoryTag = MemoryTag;
+    pWdfDriver->IommuActive = WdfUseDefault;
 
     /* get the PCI bus interface */
     status = WdfFdoQueryForInterface(Device, &GUID_BUS_INTERFACE_STANDARD,
@@ -92,6 +93,11 @@ NTSTATUS VirtIOWdfInitialize(PVIRTIO_WDF_DRIVER pWdfDriver, WDFDEVICE Device,
     /* initialize the underlying VirtIODevice */
     status = virtio_device_initialize(&pWdfDriver->VIODevice, &VirtIOWdfSystemOps, pWdfDriver,
                                       pWdfDriver->nMSIInterrupts > 0);
+
+    if (NT_SUCCESS(status)) {
+        status = VirtIOWdfDeviceCheckIOMMUActive(&pWdfDriver->VIODevice);
+    }
+
     if (!NT_SUCCESS(status)) {
         PCIFreeBars(pWdfDriver);
     }

--- a/VirtIO/WDF/VirtIOWdf.h
+++ b/VirtIO/WDF/VirtIOWdf.h
@@ -47,6 +47,7 @@ typedef struct virtio_wdf_driver {
     VirtIODevice VIODevice;
 
     ULONG MemoryTag;
+    WDF_TRI_STATE IommuActive;
     ULONGLONG uFeatures;
 
     BUS_INTERFACE_STANDARD PCIBus;
@@ -204,3 +205,4 @@ typedef struct virtio_dma_memory_sliced {
 
 PVIRTIO_DMA_MEMORY_SLICED VirtIOWdfDeviceAllocDmaMemorySliced(VirtIODevice *vdev, size_t blockSize,
                                                               ULONG sliceSize);
+NTSTATUS VirtIOWdfDeviceCheckIOMMUActive(VirtIODevice *vdev);


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHEL-84655

Check whether physical addresses received from simple memory mapping and from DMA mapping are different. If they differ and there is no VIRTIO_F_ACCESS_PLATFORM suggested by the device - fail WDF DMA initialization. The driver will appear with yellow bang and with status 'The device is configured incorrectly...'