### PR TITLE
RHEL-99518: Add generic HWID (PCI\VEN_1AF4&DEV_1050) to viogpudo INF

### DIFF
--- a/viogpu/viogpudo/viogpudo.inx
+++ b/viogpu/viogpudo/viogpudo.inx
@@ -34,7 +34,7 @@ viogpudo.sys = 1,,
 %VENDOR%=VioGpu,NT$ARCH$
 
 [VioGpu.NT$ARCH$]
-%VioGpuDod.DeviceDesc% = VioGpuDod_Inst, PCI\VEN_1AF4&DEV_1050&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01
+%VioGpuDod.DeviceDesc% = VioGpuDod_Inst, PCI\VEN_1AF4&DEV_1050&SUBSYS_1100_INX_SUBSYS_VENDOR_ID&REV_01, PCI\VEN_1AF4&DEV_1050
 
 [VioGpuDod_Files_Driver]
 viogpudo.sys,,,2


### PR DESCRIPTION
Resolve: https://github.com/virtio-win/kvm-guest-drivers-windows/issues/1335