### PR TITLE
RHEL-101554: [viosock/tcp-bridge] Exit threads when recv read 0 bytes

### DIFF
--- a/viosock/tcp-bridge/bridge.cpp
+++ b/viosock/tcp-bridge/bridge.cpp
@@ -99,6 +99,14 @@ DWORD WINAPI CBridge::ThreadV2T(LPVOID lpParam)
     while ((recvLen = recv(pBridge->m_VsockClientSocket->GetSocket(), Buffer, BufferLen, 0)) != SOCKET_ERROR)
     {
         TraceEvents(TRACE_LEVEL_VERBOSE, DBG_THREAD_VT_TRANSFER, "V -> T: recv %d bytes\n", recvLen);
+        if (recvLen == 0)
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION,
+                        DBG_THREAD_VT,
+                        "Thread V -> T: V socket has been gracefully closed, exiting\n");
+            break;
+        }
+
         sendLen = send(pBridge->m_TcpSocket->GetSocket(), Buffer, recvLen, 0);
         if (sendLen == SOCKET_ERROR)
         {
@@ -123,6 +131,14 @@ DWORD WINAPI CBridge::ThreadT2V(LPVOID lpParam)
 
     while ((recvLen = recv(pBridge->m_TcpSocket->GetSocket(), Buffer, BufferLen, 0)) != SOCKET_ERROR)
     {
+        if (recvLen == 0)
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION,
+                        DBG_THREAD_VT,
+                        "Thread T -> V: T socket has been gracefully closed, exiting\n");
+            break;
+        }
+
         TraceEvents(TRACE_LEVEL_VERBOSE, DBG_THREAD_VT_TRANSFER, "T -> V: recv %d bytes\n", recvLen);
         sendLen = send(pBridge->m_VsockClientSocket->GetSocket(), Buffer, recvLen, 0);
         if (sendLen == SOCKET_ERROR)


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-recv If the connection has been gracefully closed, the return value is zero. This means that connection is closed and service can stop bridging actions.