### PR TITLE
 RHEL-104117: Add infrastructure for cab file creation SKIP-HCK-CI

### DIFF
--- a/.hck-ci/triggers.yml
+++ b/.hck-ci/triggers.yml
@@ -138,3 +138,10 @@ viomem:
     - README.md
     - contributing.md
     - status.txt
+    - win10_arm64.ddf
+    - win10_x64.ddf
+    - win10_x86.ddf
+    - win11_arm64.ddf
+    - win11_x64.ddf
+
+

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -47,6 +47,9 @@ for %%D in (pciserial fwcfg Q35) do @(
  call :bld_inf_drvr %%D
 )
 echo.
+call build_cab.bat
+if errorlevel 1 goto :fail
+echo.
 echo Processing DVL files to create Windows 10 COMPAT ^(WIN10_RS1 ^/ 1607^) version...
 for /R %%f in (*.dvl.xml) do @(
   call :process_xml %%f

--- a/build_cab.bat
+++ b/build_cab.bat
@@ -1,0 +1,29 @@
+@echo off
+
+rem ================================================================================
+rem Build script for all project cabinet (.cab) files
+rem
+rem This script iterates through a predefined list of .ddf files and uses
+rem makecab.exe to generate the corresponding .cab archives.
+rem
+rem The script will stop if any of the makecab operations fail.
+rem ================================================================================
+
+rem A list of all .ddf files to be built
+set DDF_FILES=win10_arm64.ddf win10_x64.ddf win10_x86.ddf win11_arm64.ddf win11_x64.ddf
+
+echo.
+echo Starting cabinet file build process...
+echo.
+
+for %%F in (%DDF_FILES%) do (
+    echo Generating cabinet from %%F
+    makecab /f "%%F"
+    if errorlevel 1 (
+        echo ERROR: Build failed for %%F. Stopping.
+        exit /b 1
+    )
+)
+
+echo.
+echo All cabinet files built successfully.

--- a/win10_arm64.ddf
+++ b/win10_arm64.ddf
@@ -1,0 +1,110 @@
+;*** win10_arm64.ddf
+;
+.OPTION EXPLICIT     ; Generate errors
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+;Specify file name for new cab file
+.Set CabinetNameTemplate=win10arm64.cab
+.Set DiskDirectoryTemplate=
+;Specify files to be included in cab file
+; Balloon Driver
+.Set DestinationDir=Balloon
+.\Balloon\Install\Win10\ARM64\balloon.cat
+.\Balloon\Install\Win10\ARM64\balloon.inf
+.\Balloon\Install\Win10\ARM64\balloon.pdb
+.\Balloon\Install\Win10\ARM64\balloon.sys
+; NetKvm driver
+.Set DestinationDir=NetKvm
+.\NetKvm\Install\Win10\ARM64\netkvm.cat
+.\NetKvm\Install\Win10\ARM64\netkvm.inf
+.\NetKvm\Install\Win10\ARM64\netkvm.pdb
+.\NetKvm\Install\Win10\ARM64\netkvm.sys
+.\NetKvm\Install\Win10\ARM64\netkvmp.exe
+.\NetKvm\Install\Win10\ARM64\netkvmp.pdb
+;pvpanic driver
+.Set DestinationDir=pvpanic
+.\pvpanic\Install\Win10\ARM64\pvpanic.cat
+.\pvpanic\Install\Win10\ARM64\pvpanic.inf
+.\pvpanic\Install\Win10\ARM64\pvpanic.pdb
+.\pvpanic\Install\Win10\ARM64\pvpanic.sys
+.\pvpanic\Install\Win10\ARM64\pvpanic-pci.cat
+.\pvpanic\Install\Win10\ARM64\pvpanic-pci.inf
+; vioinput driver
+.Set DestinationDir=vioinput
+.\vioinput\Install\Win10\ARM64\viohidkmdf.pdb
+.\vioinput\Install\Win10\ARM64\viohidkmdf.sys
+.\vioinput\Install\Win10\ARM64\vioinput.cat
+.\vioinput\Install\Win10\ARM64\vioinput.inf
+.\vioinput\Install\Win10\ARM64\vioinput.pdb
+.\vioinput\Install\Win10\ARM64\vioinput.sys
+; viorng driver
+.Set DestinationDir=viorng
+.\viorng\Install\Win10\ARM64\viorng.cat
+.\viorng\Install\Win10\ARM64\viorng.inf
+.\viorng\Install\Win10\ARM64\viorng.pdb
+.\viorng\Install\Win10\ARM64\viorng.sys
+.\viorng\Install\Win10\ARM64\viorngum.dll
+.\viorng\Install\Win10\ARM64\viorngum.pdb
+; vioscsi driver
+.Set DestinationDir=vioscsi
+.\vioscsi\Install\Win10\ARM64\vioscsi.cat
+.\vioscsi\Install\Win10\ARM64\vioscsi.inf
+.\vioscsi\Install\Win10\ARM64\vioscsi.pdb
+.\vioscsi\Install\Win10\ARM64\vioscsi.sys
+; vioserial driver
+.Set DestinationDir=vioserial
+.\vioserial\Install\Win10\ARM64\vioser.cat
+.\vioserial\Install\Win10\ARM64\vioser.inf
+.\vioserial\Install\Win10\ARM64\vioser.pdb
+.\vioserial\Install\Win10\ARM64\vioser.sys
+; viostor driver
+.Set DestinationDir=viostor
+.\viostor\Install\Win10\ARM64\viostor.cat
+.\viostor\Install\Win10\ARM64\viostor.inf
+.\viostor\Install\Win10\ARM64\viostor.pdb
+.\viostor\Install\Win10\ARM64\viostor.sys
+; viogpudo driver
+.Set DestinationDir=viogpudo
+.\viogpu\Install\Win10\ARM64\viogpudo.cat
+.\viogpu\Install\Win10\ARM64\viogpudo.inf
+.\viogpu\Install\Win10\ARM64\viogpudo.pdb
+.\viogpu\Install\Win10\ARM64\viogpudo.sys
+.\viogpu\Install\Win10\ARM64\vgpusrv.pdb
+.\viogpu\Install\Win10\ARM64\vgpusrv.exe
+.\viogpu\Install\Win10\ARM64\viogpuap.pdb
+.\viogpu\Install\Win10\ARM64\viogpuap.exe
+; fwcfg driver
+;.Set DestinationDir=fwcfg
+;.\fwcfg64\Install\Win10\ARM64\fwcfg.cat
+;.\fwcfg64\Install\Win10\ARM64\fwcfg.inf
+;.\fwcfg64\Install\Win10\ARM64\fwcfg.pdb
+;.\fwcfg64\Install\Win10\ARM64\fwcfg.sys
+; viomem driver
+.Set DestinationDir=viomem
+.\viomem\Install\Win10\ARM64\viomem.cat
+.\viomem\Install\Win10\ARM64\viomem.inf
+.\viomem\Install\Win10\ARM64\viomem.pdb
+.\viomem\Install\Win10\ARM64\viomem.sys
+; viosock driver
+.Set DestinationDir=viosock
+.\viosock\Install\Win10\ARM64\viosock-test.exe
+.\viosock\Install\Win10\ARM64\viosock-test.pdb
+.\viosock\Install\Win10\ARM64\viosock.cat
+.\viosock\Install\Win10\ARM64\viosock.inf
+.\viosock\Install\Win10\ARM64\viosock.pdb
+.\viosock\Install\Win10\ARM64\viosock.sys
+.\viosock\Install\Win10\ARM64\viosocklib-test.exe
+.\viosock\Install\Win10\ARM64\viosocklib-test.pdb
+.\viosock\Install\Win10\ARM64\viosocklib.dll
+.\viosock\Install\Win10\ARM64\viosocklib.pdb
+.\viosock\Install\Win10\ARM64\viosockwspsvc.exe
+.\viosock\Install\Win10\ARM64\viosockwspsvc.pdb
+.\viosock\Install\Win10\ARM64\vstbridge.exe
+.\viosock\Install\Win10\ARM64\vstbridge.pdb

--- a/win10_x64.ddf
+++ b/win10_x64.ddf
@@ -1,0 +1,132 @@
+;*** win10_x64.ddf
+;
+.OPTION EXPLICIT     ; Generate errors
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+;Specify file name for new cab file
+.Set CabinetNameTemplate=win10x64.cab
+.Set DiskDirectoryTemplate=
+;Specify files to be included in cab file
+; Balloon Driver
+.Set DestinationDir=Balloon
+.\Balloon\Install\Win10\amd64\balloon.cat
+.\Balloon\Install\Win10\amd64\balloon.inf
+.\Balloon\Install\Win10\amd64\balloon.pdb
+.\Balloon\Install\Win10\amd64\balloon.sys
+; NetKvm driver
+.Set DestinationDir=NetKvm
+.\NetKvm\Install\Win10\amd64\netkvm.cat
+.\NetKvm\Install\Win10\amd64\netkvm.inf
+.\NetKvm\Install\Win10\amd64\netkvm.pdb
+.\NetKvm\Install\Win10\amd64\netkvm.sys
+.\NetKvm\Install\Win10\amd64\netkvmp.exe
+.\NetKvm\Install\Win10\amd64\netkvmp.pdb
+; NotifyObject driver
+.Set DestinationDir=NotifyObj
+.\NetKvm\Install\Win10\amd64\vioprot.cat
+.\NetKvm\Install\Win10\amd64\vioprot.inf
+;pvpanic driver
+.Set DestinationDir=pvpanic
+.\pvpanic\Install\Win10\amd64\pvpanic.cat
+.\pvpanic\Install\Win10\amd64\pvpanic.inf
+.\pvpanic\Install\Win10\amd64\pvpanic.pdb
+.\pvpanic\Install\Win10\amd64\pvpanic.sys
+.\pvpanic\Install\Win10\amd64\pvpanic-pci.cat
+.\pvpanic\Install\Win10\amd64\pvpanic-pci.inf
+; viofs driver
+.Set DestinationDir=viofs
+.\viofs\Install\Win10\amd64\viofs.cat
+.\viofs\Install\Win10\amd64\viofs.inf
+.\viofs\Install\Win10\amd64\viofs.pdb
+.\viofs\Install\Win10\amd64\viofs.sys
+.\viofs\Install\Win10\amd64\virtiofs.exe
+.\viofs\Install\Win10\amd64\virtiofs.pdb
+; vioinput driver
+.Set DestinationDir=vioinput
+.\vioinput\Install\Win10\amd64\viohidkmdf.pdb
+.\vioinput\Install\Win10\amd64\viohidkmdf.sys
+.\vioinput\Install\Win10\amd64\vioinput.cat
+.\vioinput\Install\Win10\amd64\vioinput.inf
+.\vioinput\Install\Win10\amd64\vioinput.pdb
+.\vioinput\Install\Win10\amd64\vioinput.sys
+; viorng driver
+.Set DestinationDir=viorng
+.\viorng\Install\Win10\amd64\viorng.cat
+.\viorng\Install\Win10\amd64\viorng.inf
+.\viorng\Install\Win10\amd64\viorng.pdb
+.\viorng\Install\Win10\amd64\viorng.sys
+.\viorng\Install\Win10\amd64\viorngum.dll
+.\viorng\Install\Win10\amd64\viorngum.pdb
+; vioscsi driver
+.Set DestinationDir=vioscsi
+.\vioscsi\Install\Win10\amd64\vioscsi.cat
+.\vioscsi\Install\Win10\amd64\vioscsi.inf
+.\vioscsi\Install\Win10\amd64\vioscsi.pdb
+.\vioscsi\Install\Win10\amd64\vioscsi.sys
+; vioserial driver
+.Set DestinationDir=vioserial
+.\vioserial\Install\Win10\amd64\vioser.cat
+.\vioserial\Install\Win10\amd64\vioser.inf
+.\vioserial\Install\Win10\amd64\vioser.pdb
+.\vioserial\Install\Win10\amd64\vioser.sys
+; viostor driver
+.Set DestinationDir=viostor
+.\viostor\Install\Win10\amd64\viostor.cat
+.\viostor\Install\Win10\amd64\viostor.inf
+.\viostor\Install\Win10\amd64\viostor.pdb
+.\viostor\Install\Win10\amd64\viostor.sys
+; viogpudo driver
+.Set DestinationDir=viogpudo
+.\viogpu\Install\Win10\amd64\viogpudo.cat
+.\viogpu\Install\Win10\amd64\viogpudo.inf
+.\viogpu\Install\Win10\amd64\viogpudo.pdb
+.\viogpu\Install\Win10\amd64\viogpudo.sys
+.\viogpu\Install\Win10\amd64\vgpusrv.pdb
+.\viogpu\Install\Win10\amd64\vgpusrv.exe
+.\viogpu\Install\Win10\amd64\viogpuap.pdb
+.\viogpu\Install\Win10\amd64\viogpuap.exe
+; pciserial driver
+.Set DestinationDir=pciserial
+.\pciserial\Install\qemupciserial.cat
+.\pciserial\Install\qemupciserial.inf
+; fwcfg driver
+.Set DestinationDir=fwcfg
+.\fwcfg\Install\qemufwcfg.cat
+.\fwcfg\Install\qemufwcfg.inf
+; fwcfg64 driver
+.Set DestinationDir=fwcfg64
+.\fwcfg64\Install\Win10\amd64\fwcfg.cat
+.\fwcfg64\Install\Win10\amd64\fwcfg.inf
+.\fwcfg64\Install\Win10\amd64\fwcfg.pdb
+.\fwcfg64\Install\Win10\amd64\fwcfg.sys
+; viomem driver
+.Set DestinationDir=viomem
+.\viomem\Install\Win10\amd64\viomem.cat
+.\viomem\Install\Win10\amd64\viomem.inf
+.\viomem\Install\Win10\amd64\viomem.pdb
+.\viomem\Install\Win10\amd64\viomem.sys
+; viosock driver
+.Set DestinationDir=viosock
+.\viosock\Install\Win10\amd64\viosock-test.exe
+.\viosock\Install\Win10\amd64\viosock-test.pdb
+.\viosock\Install\Win10\amd64\viosock.cat
+.\viosock\Install\Win10\amd64\viosock.inf
+.\viosock\Install\Win10\amd64\viosock.pdb
+.\viosock\Install\Win10\amd64\viosock.sys
+.\viosock\Install\Win10\amd64\viosocklib-test.exe
+.\viosock\Install\Win10\amd64\viosocklib-test.pdb
+.\viosock\Install\Win10\amd64\viosocklib_x64.dll
+.\viosock\Install\Win10\amd64\viosocklib_x64.pdb
+.\viosock\Install\Win10\amd64\viosocklib_x86.dll
+.\viosock\Install\Win10\amd64\viosocklib_x86.pdb
+.\viosock\Install\Win10\amd64\viosockwspsvc.exe
+.\viosock\Install\Win10\amd64\viosockwspsvc.pdb
+.\viosock\Install\Win10\amd64\vstbridge.exe
+.\viosock\Install\Win10\amd64\vstbridge.pdb

--- a/win10_x86.ddf
+++ b/win10_x86.ddf
@@ -1,0 +1,130 @@
+;*** win10_x86.ddf
+;
+.OPTION EXPLICIT     ; Generate errors
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+;Specify file name for new cab file
+.Set CabinetNameTemplate=win10x86.cab
+.Set DiskDirectoryTemplate=
+;Specify files to be included in cab file
+; Balloon Driver
+.Set DestinationDir=Balloon
+.\Balloon\Install\Win10\x86\balloon.cat
+.\Balloon\Install\Win10\x86\balloon.inf
+.\Balloon\Install\Win10\x86\balloon.pdb
+.\Balloon\Install\Win10\x86\balloon.sys
+; NetKvm driver
+.Set DestinationDir=NetKvm
+.\NetKvm\Install\Win10\x86\netkvm.cat
+.\NetKvm\Install\Win10\x86\netkvm.inf
+.\NetKvm\Install\Win10\x86\netkvm.pdb
+.\NetKvm\Install\Win10\x86\netkvm.sys
+.\NetKvm\Install\Win10\x86\netkvmp.exe
+.\NetKvm\Install\Win10\x86\netkvmp.pdb
+; NotifyObject driver
+.Set DestinationDir=NotifyObj
+.\NetKvm\Install\Win10\x86\vioprot.cat
+.\NetKvm\Install\Win10\x86\vioprot.inf
+;pvpanic driver
+.Set DestinationDir=pvpanic
+.\pvpanic\Install\Win10\x86\pvpanic.cat
+.\pvpanic\Install\Win10\x86\pvpanic.inf
+.\pvpanic\Install\Win10\x86\pvpanic.pdb
+.\pvpanic\Install\Win10\x86\pvpanic.sys
+.\pvpanic\Install\Win10\x86\pvpanic-pci.cat
+.\pvpanic\Install\Win10\x86\pvpanic-pci.inf
+; viofs driver
+.Set DestinationDir=viofs
+.\viofs\Install\Win10\x86\viofs.cat
+.\viofs\Install\Win10\x86\viofs.inf
+.\viofs\Install\Win10\x86\viofs.pdb
+.\viofs\Install\Win10\x86\viofs.sys
+.\viofs\Install\Win10\x86\virtiofs.exe
+.\viofs\Install\Win10\x86\virtiofs.pdb
+; vioinput driver
+.Set DestinationDir=vioinput
+.\vioinput\Install\Win10\x86\viohidkmdf.pdb
+.\vioinput\Install\Win10\x86\viohidkmdf.sys
+.\vioinput\Install\Win10\x86\vioinput.cat
+.\vioinput\Install\Win10\x86\vioinput.inf
+.\vioinput\Install\Win10\x86\vioinput.pdb
+.\vioinput\Install\Win10\x86\vioinput.sys
+; viorng driver
+.Set DestinationDir=viorng
+.\viorng\Install\Win10\x86\viorng.cat
+.\viorng\Install\Win10\x86\viorng.inf
+.\viorng\Install\Win10\x86\viorng.pdb
+.\viorng\Install\Win10\x86\viorng.sys
+.\viorng\Install\Win10\x86\viorngum.dll
+.\viorng\Install\Win10\x86\viorngum.pdb
+; vioscsi driver
+.Set DestinationDir=vioscsi
+.\vioscsi\Install\Win10\x86\vioscsi.cat
+.\vioscsi\Install\Win10\x86\vioscsi.inf
+.\vioscsi\Install\Win10\x86\vioscsi.pdb
+.\vioscsi\Install\Win10\x86\vioscsi.sys
+; vioserial driver
+.Set DestinationDir=vioserial
+.\vioserial\Install\Win10\x86\vioser.cat
+.\vioserial\Install\Win10\x86\vioser.inf
+.\vioserial\Install\Win10\x86\vioser.pdb
+.\vioserial\Install\Win10\x86\vioser.sys
+; viostor driver
+.Set DestinationDir=viostor
+.\viostor\Install\Win10\x86\viostor.cat
+.\viostor\Install\Win10\x86\viostor.inf
+.\viostor\Install\Win10\x86\viostor.pdb
+.\viostor\Install\Win10\x86\viostor.sys
+; viogpudo driver
+.Set DestinationDir=viogpudo
+.\viogpu\Install\Win10\x86\viogpudo.cat
+.\viogpu\Install\Win10\x86\viogpudo.inf
+.\viogpu\Install\Win10\x86\viogpudo.pdb
+.\viogpu\Install\Win10\x86\viogpudo.sys
+.\viogpu\Install\Win10\x86\vgpusrv.pdb
+.\viogpu\Install\Win10\x86\vgpusrv.exe
+.\viogpu\Install\Win10\x86\viogpuap.pdb
+.\viogpu\Install\Win10\x86\viogpuap.exe
+; pciserial driver
+.Set DestinationDir=pciserial
+.\pciserial\Install\qemupciserial.cat
+.\pciserial\Install\qemupciserial.inf
+; fwcfg driver
+.Set DestinationDir=fwcfg
+.\fwcfg\Install\qemufwcfg.cat
+.\fwcfg\Install\qemufwcfg.inf
+; fwcfg64 driver
+.Set DestinationDir=fwcfg64
+.\fwcfg64\Install\Win10\x86\fwcfg.cat
+.\fwcfg64\Install\Win10\x86\fwcfg.inf
+.\fwcfg64\Install\Win10\x86\fwcfg.pdb
+.\fwcfg64\Install\Win10\x86\fwcfg.sys
+; viomem driver
+.Set DestinationDir=viomem
+.\viomem\Install\Win10\x86\viomem.cat
+.\viomem\Install\Win10\x86\viomem.inf
+.\viomem\Install\Win10\x86\viomem.pdb
+.\viomem\Install\Win10\x86\viomem.sys
+; viosock driver
+.Set DestinationDir=viosock
+.\viosock\Install\Win10\x86\viosock-test.exe
+.\viosock\Install\Win10\x86\viosock-test.pdb
+.\viosock\Install\Win10\x86\viosock.cat
+.\viosock\Install\Win10\x86\viosock.inf
+.\viosock\Install\Win10\x86\viosock.pdb
+.\viosock\Install\Win10\x86\viosock.sys
+.\viosock\Install\Win10\x86\viosocklib-test.exe
+.\viosock\Install\Win10\x86\viosocklib-test.pdb
+.\viosock\Install\Win10\x86\viosocklib.dll
+.\viosock\Install\Win10\x86\viosocklib.pdb
+.\viosock\Install\Win10\x86\viosockwspsvc.exe
+.\viosock\Install\Win10\x86\viosockwspsvc.pdb
+.\viosock\Install\Win10\x86\vstbridge.exe
+.\viosock\Install\Win10\x86\vstbridge.pdb

--- a/win11_arm64.ddf
+++ b/win11_arm64.ddf
@@ -1,0 +1,110 @@
+;*** win11_arm64.ddf
+;
+.OPTION EXPLICIT     ; Generate errors
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+;Specify file name for new cab file
+.Set CabinetNameTemplate=win11arm64.cab
+.Set DiskDirectoryTemplate=
+;Specify files to be included in cab file
+; Balloon Driver
+.Set DestinationDir=Balloon
+.\Balloon\Install\Win11\ARM64\balloon.cat
+.\Balloon\Install\Win11\ARM64\balloon.inf
+.\Balloon\Install\Win11\ARM64\balloon.pdb
+.\Balloon\Install\Win11\ARM64\balloon.sys
+; NetKvm driver
+.Set DestinationDir=NetKvm
+.\NetKvm\Install\Win11\ARM64\netkvm.cat
+.\NetKvm\Install\Win11\ARM64\netkvm.inf
+.\NetKvm\Install\Win11\ARM64\netkvm.pdb
+.\NetKvm\Install\Win11\ARM64\netkvm.sys
+.\NetKvm\Install\Win11\ARM64\netkvmp.exe
+.\NetKvm\Install\Win11\ARM64\netkvmp.pdb
+;pvpanic driver
+.Set DestinationDir=pvpanic
+.\pvpanic\Install\Win11\ARM64\pvpanic.cat
+.\pvpanic\Install\Win11\ARM64\pvpanic.inf
+.\pvpanic\Install\Win11\ARM64\pvpanic.pdb
+.\pvpanic\Install\Win11\ARM64\pvpanic.sys
+.\pvpanic\Install\Win11\ARM64\pvpanic-pci.cat
+.\pvpanic\Install\Win11\ARM64\pvpanic-pci.inf
+; vioinput driver
+.Set DestinationDir=vioinput
+.\vioinput\Install\Win11\ARM64\viohidkmdf.pdb
+.\vioinput\Install\Win11\ARM64\viohidkmdf.sys
+.\vioinput\Install\Win11\ARM64\vioinput.cat
+.\vioinput\Install\Win11\ARM64\vioinput.inf
+.\vioinput\Install\Win11\ARM64\vioinput.pdb
+.\vioinput\Install\Win11\ARM64\vioinput.sys
+; viorng driver
+.Set DestinationDir=viorng
+.\viorng\Install\Win11\ARM64\viorng.cat
+.\viorng\Install\Win11\ARM64\viorng.inf
+.\viorng\Install\Win11\ARM64\viorng.pdb
+.\viorng\Install\Win11\ARM64\viorng.sys
+.\viorng\Install\Win11\ARM64\viorngum.dll
+.\viorng\Install\Win11\ARM64\viorngum.pdb
+; vioscsi driver
+.Set DestinationDir=vioscsi
+.\vioscsi\Install\Win11\ARM64\vioscsi.cat
+.\vioscsi\Install\Win11\ARM64\vioscsi.inf
+.\vioscsi\Install\Win11\ARM64\vioscsi.pdb
+.\vioscsi\Install\Win11\ARM64\vioscsi.sys
+; vioserial driver
+.Set DestinationDir=vioserial
+.\vioserial\Install\Win11\ARM64\vioser.cat
+.\vioserial\Install\Win11\ARM64\vioser.inf
+.\vioserial\Install\Win11\ARM64\vioser.pdb
+.\vioserial\Install\Win11\ARM64\vioser.sys
+; viostor driver
+.Set DestinationDir=viostor
+.\viostor\Install\Win11\ARM64\viostor.cat
+.\viostor\Install\Win11\ARM64\viostor.inf
+.\viostor\Install\Win11\ARM64\viostor.pdb
+.\viostor\Install\Win11\ARM64\viostor.sys
+; viogpudo driver
+.Set DestinationDir=viogpudo
+.\viogpu\Install\Win11\ARM64\viogpudo.cat
+.\viogpu\Install\Win11\ARM64\viogpudo.inf
+.\viogpu\Install\Win11\ARM64\viogpudo.pdb
+.\viogpu\Install\Win11\ARM64\viogpudo.sys
+.\viogpu\Install\Win11\ARM64\vgpusrv.pdb
+.\viogpu\Install\Win11\ARM64\vgpusrv.exe
+.\viogpu\Install\Win11\ARM64\viogpuap.pdb
+.\viogpu\Install\Win11\ARM64\viogpuap.exe
+; fwcfg driver
+;.Set DestinationDir=fwcfg
+;.\fwcfg64\Install\Win11\ARM64\fwcfg.cat
+;.\fwcfg64\Install\Win11\ARM64\fwcfg.inf
+;.\fwcfg64\Install\Win11\ARM64\fwcfg.pdb
+;.\fwcfg64\Install\Win11\ARM64\fwcfg.sys
+; viomem driver
+.Set DestinationDir=viomem
+.\viomem\Install\Win11\ARM64\viomem.cat
+.\viomem\Install\Win11\ARM64\viomem.inf
+.\viomem\Install\Win11\ARM64\viomem.pdb
+.\viomem\Install\Win11\ARM64\viomem.sys
+; viosock driver
+.Set DestinationDir=viosock
+.\viosock\Install\Win11\ARM64\viosock-test.exe
+.\viosock\Install\Win11\ARM64\viosock-test.pdb
+.\viosock\Install\Win11\ARM64\viosock.cat
+.\viosock\Install\Win11\ARM64\viosock.inf
+.\viosock\Install\Win11\ARM64\viosock.pdb
+.\viosock\Install\Win11\ARM64\viosock.sys
+.\viosock\Install\Win11\ARM64\viosocklib-test.exe
+.\viosock\Install\Win11\ARM64\viosocklib-test.pdb
+.\viosock\Install\Win11\ARM64\viosocklib.dll
+.\viosock\Install\Win11\ARM64\viosocklib.pdb
+.\viosock\Install\Win11\ARM64\viosockwspsvc.exe
+.\viosock\Install\Win11\ARM64\viosockwspsvc.pdb
+.\viosock\Install\Win11\ARM64\vstbridge.exe
+.\viosock\Install\Win11\ARM64\vstbridge.pdb

--- a/win11_x64.ddf
+++ b/win11_x64.ddf
@@ -1,0 +1,132 @@
+;*** win11_x64.ddf
+;
+.OPTION EXPLICIT     ; Generate errors
+.Set CabinetFileCountThreshold=0
+.Set FolderFileCountThreshold=0
+.Set FolderSizeThreshold=0
+.Set MaxCabinetSize=0
+.Set MaxDiskFileCount=0
+.Set MaxDiskSize=0
+.Set CompressionType=MSZIP
+.Set Cabinet=on
+.Set Compress=on
+;Specify file name for new cab file
+.Set CabinetNameTemplate=win11x64.cab
+.Set DiskDirectoryTemplate=
+;Specify files to be included in cab file
+; Balloon Driver
+.Set DestinationDir=Balloon
+.\Balloon\Install\Win11\amd64\balloon.cat
+.\Balloon\Install\Win11\amd64\balloon.inf
+.\Balloon\Install\Win11\amd64\balloon.pdb
+.\Balloon\Install\Win11\amd64\balloon.sys
+; NetKvm driver
+.Set DestinationDir=NetKvm
+.\NetKvm\Install\Win11\amd64\netkvm.cat
+.\NetKvm\Install\Win11\amd64\netkvm.inf
+.\NetKvm\Install\Win11\amd64\netkvm.pdb
+.\NetKvm\Install\Win11\amd64\netkvm.sys
+.\NetKvm\Install\Win11\amd64\netkvmp.exe
+.\NetKvm\Install\Win11\amd64\netkvmp.pdb
+; NotifyObject driver
+.Set DestinationDir=NotifyObj
+.\NetKvm\Install\Win11\amd64\vioprot.cat
+.\NetKvm\Install\Win11\amd64\vioprot.inf
+;pvpanic driver
+.Set DestinationDir=pvpanic
+.\pvpanic\Install\Win11\amd64\pvpanic.cat
+.\pvpanic\Install\Win11\amd64\pvpanic.inf
+.\pvpanic\Install\Win11\amd64\pvpanic.pdb
+.\pvpanic\Install\Win11\amd64\pvpanic.sys
+.\pvpanic\Install\Win11\amd64\pvpanic-pci.cat
+.\pvpanic\Install\Win11\amd64\pvpanic-pci.inf
+; viofs driver
+.Set DestinationDir=viofs
+.\viofs\Install\Win11\amd64\viofs.cat
+.\viofs\Install\Win11\amd64\viofs.inf
+.\viofs\Install\Win11\amd64\viofs.pdb
+.\viofs\Install\Win11\amd64\viofs.sys
+.\viofs\Install\Win11\amd64\virtiofs.exe
+.\viofs\Install\Win11\amd64\virtiofs.pdb
+; vioinput driver
+.Set DestinationDir=vioinput
+.\vioinput\Install\Win11\amd64\viohidkmdf.pdb
+.\vioinput\Install\Win11\amd64\viohidkmdf.sys
+.\vioinput\Install\Win11\amd64\vioinput.cat
+.\vioinput\Install\Win11\amd64\vioinput.inf
+.\vioinput\Install\Win11\amd64\vioinput.pdb
+.\vioinput\Install\Win11\amd64\vioinput.sys
+; viorng driver
+.Set DestinationDir=viorng
+.\viorng\Install\Win11\amd64\viorng.cat
+.\viorng\Install\Win11\amd64\viorng.inf
+.\viorng\Install\Win11\amd64\viorng.pdb
+.\viorng\Install\Win11\amd64\viorng.sys
+.\viorng\Install\Win11\amd64\viorngum.dll
+.\viorng\Install\Win11\amd64\viorngum.pdb
+; vioscsi driver
+.Set DestinationDir=vioscsi
+.\vioscsi\Install\Win11\amd64\vioscsi.cat
+.\vioscsi\Install\Win11\amd64\vioscsi.inf
+.\vioscsi\Install\Win11\amd64\vioscsi.pdb
+.\vioscsi\Install\Win11\amd64\vioscsi.sys
+; vioserial driver
+.Set DestinationDir=vioserial
+.\vioserial\Install\Win11\amd64\vioser.cat
+.\vioserial\Install\Win11\amd64\vioser.inf
+.\vioserial\Install\Win11\amd64\vioser.pdb
+.\vioserial\Install\Win11\amd64\vioser.sys
+; viostor driver
+.Set DestinationDir=viostor
+.\viostor\Install\Win11\amd64\viostor.cat
+.\viostor\Install\Win11\amd64\viostor.inf
+.\viostor\Install\Win11\amd64\viostor.pdb
+.\viostor\Install\Win11\amd64\viostor.sys
+; viogpudo driver
+.Set DestinationDir=viogpudo
+.\viogpu\Install\Win11\amd64\viogpudo.cat
+.\viogpu\Install\Win11\amd64\viogpudo.inf
+.\viogpu\Install\Win11\amd64\viogpudo.pdb
+.\viogpu\Install\Win11\amd64\viogpudo.sys
+.\viogpu\Install\Win11\amd64\vgpusrv.pdb
+.\viogpu\Install\Win11\amd64\vgpusrv.exe
+.\viogpu\Install\Win11\amd64\viogpuap.pdb
+.\viogpu\Install\Win11\amd64\viogpuap.exe
+; pciserial driver
+.Set DestinationDir=pciserial
+.\pciserial\Install\qemupciserial.cat
+.\pciserial\Install\qemupciserial.inf
+; fwcfg driver
+.Set DestinationDir=fwcfg
+.\fwcfg\Install\qemufwcfg.cat
+.\fwcfg\Install\qemufwcfg.inf
+; fwcfg64 driver
+.Set DestinationDir=fwcfg64
+.\fwcfg64\Install\Win11\amd64\fwcfg.cat
+.\fwcfg64\Install\Win11\amd64\fwcfg.inf
+.\fwcfg64\Install\Win11\amd64\fwcfg.pdb
+.\fwcfg64\Install\Win11\amd64\fwcfg.sys
+; viomem driver
+.Set DestinationDir=viomem
+.\viomem\Install\Win11\amd64\viomem.cat
+.\viomem\Install\Win11\amd64\viomem.inf
+.\viomem\Install\Win11\amd64\viomem.pdb
+.\viomem\Install\Win11\amd64\viomem.sys
+; viosock driver
+.Set DestinationDir=viosock
+.\viosock\Install\Win11\amd64\viosock-test.exe
+.\viosock\Install\Win11\amd64\viosock-test.pdb
+.\viosock\Install\Win11\amd64\viosock.cat
+.\viosock\Install\Win11\amd64\viosock.inf
+.\viosock\Install\Win11\amd64\viosock.pdb
+.\viosock\Install\Win11\amd64\viosock.sys
+.\viosock\Install\Win11\amd64\viosocklib-test.exe
+.\viosock\Install\Win11\amd64\viosocklib-test.pdb
+.\viosock\Install\Win11\amd64\viosocklib_x64.dll
+.\viosock\Install\Win11\amd64\viosocklib_x64.pdb
+.\viosock\Install\Win11\amd64\viosocklib_x86.dll
+.\viosock\Install\Win11\amd64\viosocklib_x86.pdb
+.\viosock\Install\Win11\amd64\viosockwspsvc.exe
+.\viosock\Install\Win11\amd64\viosockwspsvc.pdb
+.\viosock\Install\Win11\amd64\vstbridge.exe
+.\viosock\Install\Win11\amd64\vstbridge.pdb


### PR DESCRIPTION
This commit adds the build_cab.bat script and its corresponding .ddf files, integrates it into the main buildAll.bat script, and updates the hck-ci triggers to ignore the new ddf files.