### PR TITLE
RHEL-107465: [pciserial driver] Update INF files

### DIFF
--- a/pciserial/qemupciserial.inf
+++ b/pciserial/qemupciserial.inf
@@ -24,8 +24,9 @@ Signature="$Windows NT$"
 Class=MultiFunction
 ClassGUID={4d36e971-e325-11ce-bfc1-08002be10318}
 Provider=%QEMU%
-DriverVer=12/29/2013,1.3.0
+DriverVer=05/21/2022,100.90.104.22100
 CatalogFile=qemupciserial.cat
+PnpLockdown=1
 
 [ControlFlags]
 ExcludeFromSelect=*

--- a/pciserial/rhel/qemupciserial.inf
+++ b/pciserial/rhel/qemupciserial.inf
@@ -24,7 +24,8 @@ Class=Ports
 ClassGuid={4D36E978-E325-11CE-BFC1-08002BE10318}
 CatalogFile=qemupciserial.cat
 Provider=%QEMU%
-DriverVer=05/09/2017,1.4.0
+DriverVer=05/21/2022,100.90.104.22100
+PnpLockdown=1
 
 [SourceDisksNames]
 3426=windows cd


### PR DESCRIPTION
Set defaults to the same values as in drivers released by Red Hat for upstream.