### PR TITLE
RHEL-108856: [viomem] Remove code related to unsupported Windows versions

### DIFF
--- a/viomem/sys/trace.h
+++ b/viomem/sys/trace.h
@@ -28,9 +28,7 @@
  */
 #include "kdebugprint.h"
 
-#if ((OSVERSION_MASK & NTDDI_VERSION) > NTDDI_VISTA)
 //#define EVENT_TRACING
-#endif
 
 #if !defined(EVENT_TRACING)
 


### PR DESCRIPTION
Remove code in viomem related to unsupported Windows versions.