### PR TITLE
viogpu fixes processing edid

### DIFF
--- a/viogpu/common/edid.cpp
+++ b/viogpu/common/edid.cpp
@@ -191,7 +191,7 @@ bool GetStandardTimingResolution(PSTANDARD_TIMING_DESCRIPTOR desc, PVIOGPU_DISP_
     if (desc && mode && (desc->HorizontalActivePixels > 0))
     {
         mode->XResolution = (desc->HorizontalActivePixels + 31) * 8;
-        switch (desc->RefreshRate)
+        switch (desc->ImageAspectRatio)
         {
             case AR_16_10:
                 mode->YResolution = ((mode->XResolution) / 16 * 10);

--- a/viogpu/common/edid.h
+++ b/viogpu/common/edid.h
@@ -147,11 +147,9 @@ typedef struct _EDID_DETAILED_DESCRIPTOR
 
 typedef struct _EDID_DISPLAY_DESCRIPTOR
 {
-    USHORT Indicator;
-    UCHAR Reserved0;
-    UCHAR Tag;
-    UCHAR Reserved1;
-    UCHAR Data[13];
+    UCHAR Tag[5];
+    UCHAR Revision;
+    UCHAR Data[12];
 } EDID_DISPLAY_DESCRIPTOR, *PEDID_DISPLAY_DESCRIPTOR;
 
 typedef struct _EDID_DATA_V1

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3067,6 +3067,7 @@ BOOLEAN VioGpuAdapter::UpdateModes(USHORT xres, USHORT yres, int &cnt)
 {
     int idx = 0;
 
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" x_res: %d, y_res: %d\n", xres, yres));
     if ((xres < MIN_WIDTH_SIZE) || (yres < MIN_HEIGHT_SIZE))
     {
         return FALSE;
@@ -3093,9 +3094,11 @@ int VioGpuAdapter::AddEdidModes(void)
     MANUFACTURER_TIMINGS manufact_timing = edid_data->ManufacturerTimings;
     int modecount = 0;
 
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" Default resolutions\n"));
     UpdateModes(MIN_WIDTH_SIZE, MIN_HEIGHT_SIZE, modecount);
     UpdateModes(NOM_WIDTH_SIZE, NOM_HEIGHT_SIZE, modecount);
 
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing EDID's Established timings I and II\n"));
     if (est_timing_1_2.Timing_800x600_60 || est_timing_1_2.Timing_800x600_56 || est_timing_1_2.Timing_800x600_75 ||
         est_timing_1_2.Timing_800x600_72)
     {
@@ -3123,6 +3126,7 @@ int VioGpuAdapter::AddEdidModes(void)
     }
 
     PSTANDARD_TIMING_DESCRIPTOR standard_timing = edid_data->StandardTimings;
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing EDID's Standard timings\n"));
     for (int i = 0; i < 8; i++, standard_timing++)
     {
         VIOGPU_DISP_MODE mode{0};
@@ -3132,6 +3136,7 @@ int VioGpuAdapter::AddEdidModes(void)
         }
     }
 
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing EDID's detailed timings (4 18-byte blocks)\n"));
     if (edid_data->Revision[0] == 4)
     {
         PEDID_DETAILED_DESCRIPTOR detailed_desc = edid_data->EDIDDetailedTimings;
@@ -3254,6 +3259,7 @@ int VioGpuAdapter::AddEdidModes(void)
         }
     }
 
+    DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing CTA861 data\n"));
     PEDID_CTA_861 cta_data = (PEDID_CTA_861)GetCTA861Data();
     if (cta_data && cta_data->DTDBegin[0] > 4)
     {

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3099,9 +3099,7 @@ int VioGpuAdapter::AddEdidModes(void)
     UpdateModes(NOM_WIDTH_SIZE, NOM_HEIGHT_SIZE, modecount);
 
     DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing EDID's Established timings I and II\n"));
-    if (est_timing_1_2.Timing_640x480_75 ||
-        est_timing_1_2.Timing_640x480_72 ||
-        est_timing_1_2.Timing_640x480_67 ||
+    if (est_timing_1_2.Timing_640x480_75 || est_timing_1_2.Timing_640x480_72 || est_timing_1_2.Timing_640x480_67 ||
         est_timing_1_2.Timing_640x480_60)
     {
         UpdateModes(640, 480, modecount);
@@ -3123,9 +3121,7 @@ int VioGpuAdapter::AddEdidModes(void)
         UpdateModes(832, 624, modecount);
     }
 
-    if (est_timing_1_2.Timing_1024x768_75 ||
-        est_timing_1_2.Timing_1024x768_70 ||
-        est_timing_1_2.Timing_1024x768_60 ||
+    if (est_timing_1_2.Timing_1024x768_75 || est_timing_1_2.Timing_1024x768_70 || est_timing_1_2.Timing_1024x768_60 ||
         est_timing_1_2.Timing_1024x768_87)
     {
         UpdateModes(1024, 768, modecount);

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3128,7 +3128,7 @@ int VioGpuAdapter::AddEdidModes(void)
         est_timing_1_2.Timing_1024x768_60 ||
         est_timing_1_2.Timing_1024x768_87)
     {
-        UpdateModes(1280, 768, modecount);
+        UpdateModes(1024, 768, modecount);
     }
 
     if (est_timing_1_2.Timing_1280x1024_75)

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3145,7 +3145,7 @@ int VioGpuAdapter::AddEdidModes(void)
             if (detailed_desc->PixelClock == 0)
             {
                 PEDID_DISPLAY_DESCRIPTOR disp = (PEDID_DISPLAY_DESCRIPTOR)detailed_desc;
-                if (disp->Tag == 0xF7 && disp->Reserved1 == 0)
+                if (disp->Tag[3] == 0xF7 && disp->Revision == 0xA)
                 {
                     PESTABLISHED_TIMINGS_3 est_timing_3 = (PESTABLISHED_TIMINGS_3)disp->Data;
                     if (est_timing_3->Timing_640x350_85)

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3099,6 +3099,14 @@ int VioGpuAdapter::AddEdidModes(void)
     UpdateModes(NOM_WIDTH_SIZE, NOM_HEIGHT_SIZE, modecount);
 
     DbgPrint(TRACE_LEVEL_INFORMATION, (" Processing EDID's Established timings I and II\n"));
+    if (est_timing_1_2.Timing_640x480_75 ||
+        est_timing_1_2.Timing_640x480_72 ||
+        est_timing_1_2.Timing_640x480_67 ||
+        est_timing_1_2.Timing_640x480_60)
+    {
+        UpdateModes(640, 480, modecount);
+    }
+
     if (est_timing_1_2.Timing_800x600_60 || est_timing_1_2.Timing_800x600_56 || est_timing_1_2.Timing_800x600_75 ||
         est_timing_1_2.Timing_800x600_72)
     {
@@ -3113,6 +3121,14 @@ int VioGpuAdapter::AddEdidModes(void)
     if (est_timing_1_2.Timing_832x624_75)
     {
         UpdateModes(832, 624, modecount);
+    }
+
+    if (est_timing_1_2.Timing_1024x768_75 ||
+        est_timing_1_2.Timing_1024x768_70 ||
+        est_timing_1_2.Timing_1024x768_60 ||
+        est_timing_1_2.Timing_1024x768_87)
+    {
+        UpdateModes(1280, 768, modecount);
     }
 
     if (est_timing_1_2.Timing_1280x1024_75)


### PR DESCRIPTION
These three commits are supposed to fix some flaws in processing EDID Established timings I, II, and III. 

1. Added some extra logging to have better understanding what we get from EDID
2. Established timings I, II: the code was simply missing all checks to report all the resolutions
3. Established timings III: the structure was incorrectly defined as the result the code started processing resolutions from the 5th byte while 5th byte represents revision. 
4. Standard timings: the resolutions incorrectly reported by the adapter as the code uses RefreshRate instead of ImageAspectRatio. 

More details on item 3:
With some extra logging we can see that we get resolutions that are actually not expected:
```00000045	viogpudo.sys	4	800	1	45	08\21\2025-15:12:51:811	 VioGpuAdapter::AddEdidModes VioGpuAdapter::AddEdidModes: Established timers III
00000046	viogpudo.sys	4	800	1	46	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 848, yres: 480
00000047	viogpudo.sys	4	800	1	47	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1024, yres: 768
00000048	viogpudo.sys	4	800	1	48	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1400, yres: 1050
00000049	viogpudo.sys	4	800	1	49	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1440, yres: 900
00000050	viogpudo.sys	4	800	1	50	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1600, yres: 1200
00000051	viogpudo.sys	4	800	1	51	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1920, yres: 1440
```

Raw EDID's block: 
```0: kd> db 0xffff9c019a2ecb6c+0x48
ffff9c01`9a2ecbb4  00 00 00 f7 00 0a 00 40-82 00 28 20 00 00 00 00  .......@..( ....
ffff9c01`9a2ecbc4  00 00 00 00 00 fd 00 32-7d 1e a0 ff 01 0a 20 20  .......2}.....  
ffff9c01`9a2ecbd4  20 20 20 20 00 00 00 fc-00 51 45 4d 55 20 4d 6f      .....QEMU Mo
ffff9c01`9a2ecbe4  6e 69 74 6f 72 0a 01 3a-02 03 0b 00 46 7d 65 60  nitor..:....F}e`
ffff9c01`9a2ecbf4  59 1f 61 00 00 00 10 00-00 00 00 00 00 00 00 00  Y.a.............
ffff9c01`9a2ecc04  00 00 00 00 00 00 00 00-10 00 00 00 00 00 00 00  ................
ffff9c01`9a2ecc14  00 00 00 00 00 00 00 00-00 00 10 00 00 00 00 00  ................
ffff9c01`9a2ecc24  00 00 00 00 00 00 00 00-00 00 00 00 10 00 00 00  ................
```

As we can see that the first two resolutions reported are 848x480 and 1024x768, these two map to binary representation of 0x0A, which is 0y00001010

Item 4:
```
00000036	viogpudo.sys	4	800	1	36	08\21\2025-15:12:51:811	 VioGpuAdapter::AddEdidModes VioGpuAdapter::AddEdidModes: Standard timing
00000037	viogpudo.sys	4	800	1	37	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 2048, yres: 1280
00000038	viogpudo.sys	4	800	1	38	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1920, yres: 1200
00000039	viogpudo.sys	4	800	1	39	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1920, yres: 1200
00000040	viogpudo.sys	4	800	1	40	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1600, yres: 1000
00000041	viogpudo.sys	4	800	1	41	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1680, yres: 1050
00000042	viogpudo.sys	4	800	1	42	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1440, yres: 900
00000043	viogpudo.sys	4	800	1	43	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1280, yres: 800 <<<
00000044	viogpudo.sys	4	800	1	44	08\21\2025-15:12:51:811	 VioGpuAdapter::UpdateModes VioGpuAdapter::UpdateModes: xres: 1280, yres: 800 <<<
```