### PR TITLE
sync with the latest downstream viostor and vioscsi related changes 

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -540,11 +540,10 @@ KickEvent(IN PVOID DeviceExtension, IN PVirtIOSCSIEventNode EventNode)
     EXIT_FN();
 }
 
-VOID
-VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr)
+VOID VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr)
 {
-    PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    ULONG               QueueNumber = MESSAGE_TO_QUEUE(MessageID);
+    PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    ULONG QueueNumber = MESSAGE_TO_QUEUE(MessageID);
     ENTER_FN();
 
     if (!isr)
@@ -557,7 +556,10 @@ VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HA
             {
                 QueueNumber %= adaptExt->num_queues;
             }
-            StorPortAcquireSpinLock(DeviceExtension, DpcLock, &adaptExt->dpc[QueueNumber - VIRTIO_SCSI_REQUEST_QUEUE_0], LockHandle);
+            StorPortAcquireSpinLock(DeviceExtension,
+                                    DpcLock,
+                                    &adaptExt->dpc[QueueNumber - VIRTIO_SCSI_REQUEST_QUEUE_0],
+                                    LockHandle);
         }
         else
         {
@@ -567,8 +569,7 @@ VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HA
     EXIT_FN();
 }
 
-VOID
-VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr)
+VOID VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr)
 {
     ENTER_FN();
     if (!isr)
@@ -578,8 +579,7 @@ VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HAND
     EXIT_FN();
 }
 
-VOID
-FirmwareRequest(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
+VOID FirmwareRequest(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
 {
     PADAPTER_EXTENSION adaptExt;
     PSRB_EXTENSION srbExt = NULL;

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -132,20 +132,13 @@ VOID VioScsiCompleteDpcRoutine(IN PSTOR_DPC Dpc, IN PVOID Context, IN PVOID Syst
 
 VOID ProcessBuffer(IN PVOID DeviceExtension, IN ULONG MessageId, IN STOR_SPINLOCK LockMode);
 
-VOID
-VioScsiCompleteDpcRoutine(IN PSTOR_DPC Dpc, IN PVOID Context, IN PVOID SystemArgument1, IN PVOID SystemArgument2);
+VOID ProcessQueue(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN isr);
 
-VOID
-ProcessQueue(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN isr);
+VOID VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
 
-VOID
-VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
+VOID VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
 
-VOID
-VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
-
-VOID
-HandleResponse(IN PVOID DeviceExtension, IN PVirtIOSCSICmd cmd);
+VOID HandleResponse(IN PVOID DeviceExtension, IN PVirtIOSCSICmd cmd);
 
 PVOID
 VioScsiPoolAlloc(IN PVOID DeviceExtension, IN SIZE_T size);

--- a/vioscsi/helper.h
+++ b/vioscsi/helper.h
@@ -133,7 +133,18 @@ VOID VioScsiCompleteDpcRoutine(IN PSTOR_DPC Dpc, IN PVOID Context, IN PVOID Syst
 VOID ProcessBuffer(IN PVOID DeviceExtension, IN ULONG MessageId, IN STOR_SPINLOCK LockMode);
 
 VOID
-// FORCEINLINE
+VioScsiCompleteDpcRoutine(IN PSTOR_DPC Dpc, IN PVOID Context, IN PVOID SystemArgument1, IN PVOID SystemArgument2);
+
+VOID
+ProcessQueue(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN isr);
+
+VOID
+VioScsiVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
+
+VOID
+VioScsiVQUnlock(IN PVOID DeviceExtension, IN ULONG MessageID, IN PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr);
+
+VOID
 HandleResponse(IN PVOID DeviceExtension, IN PVirtIOSCSICmd cmd);
 
 PVOID

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1256,8 +1256,8 @@ VioScsiUnitControl(IN PVOID DeviceExtension, IN SCSI_UNIT_CONTROL_TYPE ControlTy
         case ScsiUnitSurpriseRemoval:
             ULONG QueuNum;
             ULONG MsgId;
-            STOR_LOCK_HANDLE LockHandle = { 0 };
-            PSTOR_ADDR_BTL8  stor_addr = (PSTOR_ADDR_BTL8)Parameters;
+            STOR_LOCK_HANDLE LockHandle = {0};
+            PSTOR_ADDR_BTL8 stor_addr = (PSTOR_ADDR_BTL8)Parameters;
 
             for (index = 0; index < adaptExt->num_queues; index++)
             {
@@ -1428,9 +1428,9 @@ VOID FORCEINLINE DispatchQueue(IN PVOID DeviceExtension, IN ULONG MessageId)
     {
         NT_ASSERT(MessageId >= QUEUE_TO_MESSAGE(VIRTIO_SCSI_REQUEST_QUEUE_0));
         StorPortIssueDpc(DeviceExtension,
-            &adaptExt->dpc[MessageId - QUEUE_TO_MESSAGE(VIRTIO_SCSI_REQUEST_QUEUE_0)],
-            ULongToPtr(MessageId),
-            ULongToPtr(MessageId));
+                         &adaptExt->dpc[MessageId - QUEUE_TO_MESSAGE(VIRTIO_SCSI_REQUEST_QUEUE_0)],
+                         ULongToPtr(MessageId),
+                         ULongToPtr(MessageId));
         EXIT_FN();
         return;
     }
@@ -1438,14 +1438,13 @@ VOID FORCEINLINE DispatchQueue(IN PVOID DeviceExtension, IN ULONG MessageId)
     EXIT_FN();
 }
 
-VOID
-ProcessQueue(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN isr)
+VOID ProcessQueue(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN isr)
 {
     ULONG_PTR srbId;
     unsigned int len;
-    PADAPTER_EXTENSION  adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     ULONG index = MESSAGE_TO_QUEUE(MessageID);
-    STOR_LOCK_HANDLE queueLock = { 0 };
+    STOR_LOCK_HANDLE queueLock = {0};
     struct virtqueue *vq;
     PSRB_EXTENSION srbExt = NULL;
 
@@ -1508,8 +1507,7 @@ VOID VioScsiCompleteDpcRoutine(IN PSTOR_DPC Dpc, IN PVOID Context, IN PVOID Syst
     EXIT_FN();
 }
 
-VOID
-CompletePendingRequestsOnReset(IN PVOID DeviceExtension)
+VOID CompletePendingRequestsOnReset(IN PVOID DeviceExtension)
 {
     PADAPTER_EXTENSION adaptExt;
     ULONG QueueNum;
@@ -1526,7 +1524,7 @@ CompletePendingRequestsOnReset(IN PVOID DeviceExtension)
         for (ULONG index = 0; index < adaptExt->num_queues; index++)
         {
             PREQUEST_LIST element = &adaptExt->processing_srbs[index];
-            STOR_LOCK_HANDLE    LockHandle = { 0 };
+            STOR_LOCK_HANDLE LockHandle = {0};
             RhelDbgPrint(TRACE_LEVEL_FATAL, " queue %d cnt %d\n", index, element->srb_cnt);
             QueueNum = index + VIRTIO_SCSI_REQUEST_QUEUE_0;
             MsgId = QUEUE_TO_MESSAGE(QueueNum);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1276,6 +1276,7 @@ VioScsiUnitControl(IN PVOID DeviceExtension, IN SCSI_UNIT_CONTROL_TYPE ControlTy
                             SRB_LUN(currSrb) == stor_addr->Lun)
                         {
                             SRB_SET_SRB_STATUS(currSrb, SRB_STATUS_NO_DEVICE);
+                            SRB_SET_DATA_TRANSFER_LENGTH(currSrb, 0);
                             CompleteRequest(DeviceExtension, (PSRB_TYPE)currSrb);
                             RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                                          " Complete pending I/Os on Path %d Target %d Lun %d \n",
@@ -1326,6 +1327,7 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
         (Lun >= adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
     {
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         StorPortNotification(RequestComplete, DeviceExtension, Srb);
         return FALSE;
     }
@@ -1539,6 +1541,7 @@ CompletePendingRequestsOnReset(IN PVOID DeviceExtension)
                     if (currSrb)
                     {
                         SRB_SET_SRB_STATUS(currSrb, SRB_STATUS_BUS_RESET);
+                        SRB_SET_DATA_TRANSFER_LENGTH(currSrb, 0);
                         CompleteRequest(DeviceExtension, (PSRB_TYPE)currSrb);
                         element->srb_cnt--;
                     }
@@ -1926,6 +1929,7 @@ VOID VioScsiIoControl(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
             break;
         default:
             SRB_SET_SRB_STATUS(Srb, SRB_STATUS_INVALID_REQUEST);
+            SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
             RhelDbgPrint(TRACE_LEVEL_INFORMATION, " <--> Unsupport control code 0x%x\n", srbControl->ControlCode);
             break;
     }

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -869,6 +869,7 @@ VOID CompletePendingRequests(IN PVOID DeviceExtension)
                     PSRB_EXTENSION currSrbExt = SRB_EXTENSION(currSrb);
                     if (currSrb)
                     {
+                        SRB_SET_DATA_TRANSFER_LENGTH(currSrb, 0);
                         CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)currSrb, SRB_STATUS_BUS_RESET);
                         element->srb_cnt--;
                     }
@@ -1012,6 +1013,7 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
 
         default:
             {
+                SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
                 CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_INVALID_REQUEST);
                 return TRUE;
             }
@@ -1149,7 +1151,7 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
                  Srb,
                  SRB_FUNCTION(Srb),
                  cdb->CDB6GENERIC.OperationCode);
-
+    SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
     CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_INVALID_REQUEST);
     return TRUE;
 }
@@ -1335,6 +1337,7 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
 #endif
     if (SRB_PATH_ID(Srb) || SRB_TARGET_ID(Srb) || SRB_LUN(Srb) || ((adaptExt->removed == TRUE)))
     {
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_NO_DEVICE);
         return FALSE;
     }

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -107,6 +107,7 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
 
     if (adaptExt->reset_in_progress)
     {
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
         return TRUE;
     }
@@ -208,6 +209,7 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
 
     if (adaptExt->reset_in_progress)
     {
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
         return TRUE;
     }
@@ -358,6 +360,7 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
 
     if (adaptExt->reset_in_progress)
     {
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
         return TRUE;
     }
@@ -440,6 +443,7 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     }
     if (adaptExt->reset_in_progress)
     {
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
         return TRUE;
     }

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -132,10 +132,8 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     {
         VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
     }
-    if (virtqueue_add_buf(vq,
-                     &srbExt->sg[0],
-                     srbExt->out, srbExt->in,
-                     (void *)srbExt->id, va, pa) == VQ_ADD_BUFFER_SUCCESS)
+    if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
+        VQ_ADD_BUFFER_SUCCESS)
     {
         notify = virtqueue_kick_prepare(vq);
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
@@ -146,7 +144,7 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
         }
         result = TRUE;
 #ifdef DBG
-        InterlockedIncrement((LONG volatile*)&adaptExt->inqueue_cnt);
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
 #endif
     }
     else
@@ -220,17 +218,15 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
 
     element = &adaptExt->processing_srbs[QueueNumber];
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
-    if (virtqueue_add_buf(vq,
-                     &srbExt->sg[0],
-                     srbExt->out, srbExt->in,
-                     (void *)srbExt->id, va, pa) == VQ_ADD_BUFFER_SUCCESS)
+    if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
+        VQ_ADD_BUFFER_SUCCESS)
     {
         notify = virtqueue_kick_prepare(vq);
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
 #ifdef DBG
-        InterlockedIncrement((LONG volatile*)&adaptExt->inqueue_cnt);
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
 #endif
         result = TRUE;
     }
@@ -367,21 +363,23 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
 
     srbExt->MessageID = MessageId;
     vq = adaptExt->vq[QueueNumber];
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " QueueNumber 0x%x vq = %p type = %d\n", QueueNumber, vq, srbExt->vbr.out_hdr.type);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION,
+                 " QueueNumber 0x%x vq = %p type = %d\n",
+                 QueueNumber,
+                 vq,
+                 srbExt->vbr.out_hdr.type);
 
     element = &adaptExt->processing_srbs[QueueNumber];
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
-    if (virtqueue_add_buf(vq,
-                     &srbExt->sg[0],
-                     srbExt->out, srbExt->in,
-                     (void *)srbExt->id, va, pa) == VQ_ADD_BUFFER_SUCCESS)
+    if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
+        VQ_ADD_BUFFER_SUCCESS)
     {
         notify = virtqueue_kick_prepare(vq);
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
 #ifdef DBG
-        InterlockedIncrement((LONG volatile*)&adaptExt->inqueue_cnt);
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
 #endif
         result = TRUE;
     }
@@ -393,7 +391,7 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     }
     if (notify)
     {
-        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " %s virtqueue_notify %d.\n", __FUNCTION__,  QueueNumber);
+        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " %s virtqueue_notify %d.\n", __FUNCTION__, QueueNumber);
         virtqueue_notify(vq);
     }
     return result;
@@ -467,10 +465,8 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
 
     element = &adaptExt->processing_srbs[QueueNumber];
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
-    if (virtqueue_add_buf(vq,
-                     &srbExt->sg[0],
-                     srbExt->out, srbExt->in,
-                     (void *)srbExt->id, va, pa) == VQ_ADD_BUFFER_SUCCESS)
+    if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
+        VQ_ADD_BUFFER_SUCCESS)
     {
         notify = virtqueue_kick_prepare(vq);
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
@@ -478,7 +474,7 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
         result = TRUE;
 #ifdef DBG
-        InterlockedIncrement((LONG volatile*)&adaptExt->inqueue_cnt);
+        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
 #endif
     }
     else

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -144,10 +144,6 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
-        result = TRUE;
-#ifdef DBG
-        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
     }
     else
     {
@@ -158,6 +154,10 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     {
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
     }
+#ifdef DBG
+    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
+    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
@@ -231,10 +231,6 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
-        result = TRUE;
-#ifdef DBG
-        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
     }
     else
     {
@@ -242,6 +238,10 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+#ifdef DBG
+    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
+    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);
@@ -388,10 +388,6 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
-        result = TRUE;
-#ifdef DBG
-        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
     }
     else
     {
@@ -399,6 +395,10 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+#ifdef DBG
+    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
+    result = TRUE;
     if (notify)
     {
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " %s virtqueue_notify %d.\n", __FUNCTION__, QueueNumber);
@@ -486,10 +486,6 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         element = &adaptExt->processing_srbs[QueueNumber];
         InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
         element->srb_cnt++;
-        result = TRUE;
-#ifdef DBG
-        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
-#endif
     }
     else
     {
@@ -497,6 +493,10 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
         StorPortBusy(DeviceExtension, 2);
     }
     VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+#ifdef DBG
+    InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+#endif
+    result = TRUE;
     if (notify)
     {
         virtqueue_notify(adaptExt->vq[QueueNumber]);


### PR DESCRIPTION
the motivation for this sequence is to synchronise the upstream with our downstream code-base. We reverted a couple of previously merged commutes and QE run very intensive functional and WHQL testing on theses changes. In addition to that there are two similar changes for viostor and vioscsi drivers to reset the transfer length to 0 for SRBs completed during bus reset processing. We found that out without this change the system reports the problem incorrectly, saying that it was a MEMORY MANAGER CRC problem (happened during page-in operation).

Thanks,
Vadim.