### PR TITLE
[vioscsi] vioscsi misses last target and last LUN #1442

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -395,9 +395,10 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     SetGuestFeatures(DeviceExtension);
 
     ConfigInfo->NumberOfBuses = 1;
-    ConfigInfo->MaximumNumberOfTargets = min((UCHAR)adaptExt->scsi_config.max_target,
-                                             255 /*SCSI_MAXIMUM_TARGETS_PER_BUS*/);
-    ConfigInfo->MaximumNumberOfLogicalUnits = min((UCHAR)adaptExt->scsi_config.max_lun, SCSI_MAXIMUM_LUNS_PER_TARGET);
+    ConfigInfo->MaximumNumberOfTargets = (UCHAR)min(adaptExt->scsi_config.max_target + 1,
+                                                    255 /*SCSI_MAXIMUM_TARGETS_PER_BUS*/);
+    ConfigInfo->MaximumNumberOfLogicalUnits = (UCHAR)min(adaptExt->scsi_config.max_lun + 1,
+                                                         SCSI_MAXIMUM_LUNS_PER_TARGET);
     ConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;  // Unlimited
     ConfigInfo->NumberOfPhysicalBreaks = SP_UNINITIALIZED_VALUE; // Unlimited
 
@@ -1325,8 +1326,8 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     TargetId = SRB_TARGET_ID(Srb);
     Lun = SRB_LUN(Srb);
 
-    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (TargetId >= adaptExt->scsi_config.max_target) ||
-        (Lun >= adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
+    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (TargetId > adaptExt->scsi_config.max_target) ||
+        (Lun > adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
     {
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);


### PR DESCRIPTION
As mandated by the virtio spec, adjust the check in VioScsiBuildIo() to allow TargetId and Lun being equal to max_target and max_lun, respectively.

Should fix https://github.com/virtio-win/kvm-guest-drivers-windows/issues/1442, but as I don't have a way to rebuild the drivers for Windows I can't test this change. If someone else would rebuild the driver for me with this change, I can test them on bhyve on illumos and FreeBSD. Alternatively, I can help setting up an appropriate bhyve test environment.