### PR TITLE
RHEL-120741: netkvm: remove TextModeFlags from INF

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -265,7 +265,7 @@ StartType       = 3 ;%SERVICE_DEMAND_START%
 ErrorControl    = 1 ;%SERVICE_ERROR_NORMAL%
 ServiceBinary   = %INX_PLATFORM_DRIVERS_DIR%\netkvm.sys
 LoadOrderGroup  = NDIS
-AddReg          = TextModeFlags.Reg
+AddReg          = NicService.AddReg
 
 [kvmnet6.EventLog]
 AddReg = kvmnet6.AddEventLog.Reg
@@ -274,8 +274,7 @@ AddReg = kvmnet6.AddEventLog.Reg
 HKR, , EventMessageFile, 0x00020000, "%%SystemRoot%%\System32\netevent.dll"
 HKR, , TypesSupported,   0x00010001, 7
 
-[TextModeFlags.Reg]
-HKR,,TextModeFlags,0x00010001, 0x0001
+[NicService.AddReg]
 HKR,Parameters,DisableMSI,,"0"
 HKR,Parameters,EarlyDebug,,"3"
 HKR,Parameters,DmaRemappingCompatible,0x00010001,INX_NETKVM_DMAREMAP


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/RHEL-120741 This line now triggers error on INF validation due to registry write that not under Parameters key.
This way of making the driver working in Safe Mode is at least obsolete.
The proper one, if needed, is documented under
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bcd/bcdlibrary-safeboot