### PR TITLE
RHEL-114565: [viostor] Fix debug message flooding in WinDbg

### DIFF
--- a/viostor/virtio_stor_utils.c
+++ b/viostor/virtio_stor_utils.c
@@ -106,7 +106,7 @@ tDebugPrintFunc VirtioDebugPrintProc;
 #else
 #include "virtio_stor_trace.h"
 bDebugPrint = 1;
-virtioDebugLevel = 0xFF;
+virtioDebugLevel = 0;
 nViostorDebugLevel = 0xFF;
 tDebugPrintFunc VirtioDebugPrintProc = DbgPrint;
 #endif


### PR DESCRIPTION
Set virtioDebugLevel to 5 to suppress level-6 vp_notify() messages that flood
the kernel debugger during intensive I/O operations. The change reduces noise
in WinDbg and prevents debug output from impacting debugging performance.