### PR TITLE
[vioscsi] Fix for clobbered SRB Extension IDs

### DIFF
--- a/vioscsi/helper.c
+++ b/vioscsi/helper.c
@@ -120,6 +120,19 @@ VOID SendSRB(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     vq_req_idx = QueueNumber - VIRTIO_SCSI_REQUEST_QUEUE_0;
 
     VioScsiVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+    element = &adaptExt->processing_srbs[vq_req_idx];
+
+    ULONG_PTR id = element->next_id;
+
+    while ((adaptExt->tmf_cmd.SrbExtension && id == (ULONG_PTR)&adaptExt->tmf_cmd.SrbExtension->cmd) || (id == 0))
+    {
+        id++;
+    }
+
+    srbExt->id = id;
+    element->next_id = ++id;
+
     SET_VA_PA();
     add_buffer_req_status = virtqueue_add_buf(adaptExt->vq[QueueNumber],
                                               srbExt->psgl,

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -360,7 +360,6 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     RtlZeroMemory(adaptExt, sizeof(ADAPTER_EXTENSION));
 
     adaptExt->dump_mode = IsCrashDumpMode;
-    adaptExt->last_srb_id = 1;
     adaptExt->hba_id = HBA_ID;
     ConfigInfo->Master = TRUE;
     ConfigInfo->ScatterGather = TRUE;
@@ -839,17 +838,6 @@ VioScsiStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     }
     else
     {
-        PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-        PSRB_EXTENSION srbExt = SRB_EXTENSION(Srb);
-
-        srbExt->id = adaptExt->last_srb_id;
-        adaptExt->last_srb_id++;
-        if (adaptExt->last_srb_id == 0 || (adaptExt->tmf_cmd.SrbExtension &&
-                                           adaptExt->last_srb_id == (ULONG_PTR)&adaptExt->tmf_cmd.SrbExtension->cmd))
-        {
-            adaptExt->last_srb_id++;
-        }
-
         SendSRB(DeviceExtension, (PSRB_TYPE)Srb);
     }
     EXIT_FN_SRB();

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -276,6 +276,7 @@ typedef struct _REQUEST_LIST
 {
     LIST_ENTRY srb_list;
     ULONG srb_cnt;
+    ULONG_PTR next_id;
 } REQUEST_LIST, *PREQUEST_LIST;
 
 typedef struct virtio_bar
@@ -353,7 +354,6 @@ typedef struct _ADAPTER_EXTENSION
     ULONGLONG fw_ver;
     ULONG resp_time;
     BOOLEAN bRemoved;
-    ULONG_PTR last_srb_id;
 } ADAPTER_EXTENSION, *PADAPTER_EXTENSION;
 
 #ifndef PCIX_TABLE_POINTER


### PR DESCRIPTION
Refactors SRB Extension ID assignment:

1. Moves assignment from VioScsiStartIo() in vioscsi.c to SendSRB() in helper.c
2. Moves ULONG_PTR from _ADAPTER_EXTENSION stuct to _REQUEST_LIST struct
3. Renames ULONG_PTR from last_srb_id to next_id
4. Refactors conditional checks into while loop for efficiency and readability

The refactor solves the problem because the assignment now occurs under spinlock.

Resolves #1453

Labelled as Patch 4 in the issue.

Credits: @iops-hunter