### PR TITLE
[viostor] Fix for clobbered SRB Extension IDs (alternative)

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -259,7 +259,6 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
-    adaptExt->last_srb_id = 1;
     adaptExt->system_io_bus_number = ConfigInfo->SystemIoBusNumber;
     adaptExt->slot_number = ConfigInfo->SlotNumber;
     adaptExt->dump_mode = IsCrashDumpMode;
@@ -895,17 +894,9 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
 {
     PCDB cdb = SRB_CDB(Srb);
     PADAPTER_EXTENSION adaptExt;
-    PSRB_EXTENSION srbExt;
     UCHAR ScsiStatus = SCSISTAT_GOOD;
 
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    srbExt = SRB_EXTENSION(Srb);
-    srbExt->id = adaptExt->last_srb_id;
-    adaptExt->last_srb_id++;
-    if (adaptExt->last_srb_id == 0)
-    {
-        adaptExt->last_srb_id++;
-    }
 
     SRB_SET_SCSI_STATUS(((PSRB_TYPE)Srb), ScsiStatus);
 
@@ -1004,7 +995,7 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
         case SRB_FUNCTION_SHUTDOWN:
             {
                 SRB_SET_SRB_STATUS(Srb, SRB_STATUS_PENDING);
-                if (!RhelDoFlush(DeviceExtension, (PSRB_TYPE)Srb, FALSE, FALSE))
+                if (!RhelDoFlush(DeviceExtension, (PSRB_TYPE)Srb, FALSE))
                 {
                     CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_ERROR);
                 }
@@ -1121,7 +1112,7 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
                     return TRUE;
                 }
                 SRB_SET_SRB_STATUS(Srb, SRB_STATUS_PENDING);
-                if (!RhelDoFlush(DeviceExtension, (PSRB_TYPE)Srb, FALSE, FALSE))
+                if (!RhelDoFlush(DeviceExtension, (PSRB_TYPE)Srb, FALSE))
                 {
                     CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_ERROR);
                 }
@@ -2136,6 +2127,7 @@ VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOO
 
                 Srb = (PSRB_TYPE)req->req;
                 srbExt = SRB_EXTENSION(Srb);
+
                 // Only SRBs with existing (i.e. non-NULL) extension
                 // are inserted into our queues, thus, we may help
                 // the Code Analysis and provide it with this information
@@ -2144,8 +2136,8 @@ VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOO
                 if (srbExt->id == srbId)
                 {
                     RemoveEntryList(le);
-                    element->srb_cnt--;
                     bFound = TRUE;
+                    element->srb_cnt--;
                     break;
                 }
             }
@@ -2208,7 +2200,7 @@ VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOO
                 if (srbExt && srbExt->fua == TRUE)
                 {
                     SRB_SET_SRB_STATUS(Srb, SRB_STATUS_PENDING);
-                    if (!RhelDoFlush(DeviceExtension, Srb, TRUE, bIsr))
+                    if (!RhelDoFlush(DeviceExtension, Srb, TRUE))
                     {
                         CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_ERROR);
                     }

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -204,6 +204,7 @@ typedef struct _REQUEST_LIST
 {
     LIST_ENTRY srb_list;
     ULONG srb_cnt;
+    ULONG_PTR next_id;
 } REQUEST_LIST, *PREQUEST_LIST;
 
 typedef struct _ADAPTER_EXTENSION
@@ -256,7 +257,6 @@ typedef struct _ADAPTER_EXTENSION
     REQUEST_LIST processing_srbs[MAX_CPU];
     BOOLEAN reset_in_progress;
     ULONGLONG fw_ver;
-    ULONG_PTR last_srb_id;
 #ifdef DBG
     LONG srb_cnt;
     LONG inqueue_cnt;

--- a/viostor/virtio_stor_hw_helper.h
+++ b/viostor/virtio_stor_hw_helper.h
@@ -95,11 +95,13 @@ FORCEINLINE VOID SrbGetPnpInfo(_In_ PVOID Srb, ULONG *PnPFlags, ULONG *PnPAction
 #define SRB_SET_SRB_STATUS(Srb, status)            SrbSetSrbStatus(Srb, status)
 #define SRB_SET_DATA_TRANSFER_LENGTH(Srb, Len)     SrbSetDataTransferLength(Srb, Len)
 
+FORCEINLINE BOOLEAN ProcessQueue(IN PVOID DeviceExtension, IN PSRB_TYPE Srb, IN BOOLEAN resend, IN BOOLEAN bComplete);
+
 BOOLEAN
 RhelDoReadWrite(IN PVOID DeviceExtension, IN PSRB_TYPE Srb);
 
 BOOLEAN
-RhelDoFlush(IN PVOID DeviceExtension, IN PSRB_TYPE Srb, IN BOOLEAN resend, BOOLEAN bIsr);
+RhelDoFlush(IN PVOID DeviceExtension, IN PSRB_TYPE Srb, IN BOOLEAN resend);
 
 BOOLEAN
 RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb);


### PR DESCRIPTION
Refactors SRB Extension ID assignment:

1. Moves assignment from VirtIoStartIo() in virtio_stor.c to new ProcessQueue() inline function in virtio_stor_hw_helper.c
2. Common parts of the following were moved to the ProcessQueue() inline function:
  - RhelDoFlush()
  - RhelDoReadWrite()
  - RhelDoUnMap()
  - RhelGetSerialNumber()
3. The STOR_PERF_OPTIMIZE_FOR_COMPLETION_DURING_STARTIO option for RhelDoReadWrite() was moved to the ProcessQueue() inline function.
4. Moves ULONG_PTR from _ADAPTER_EXTENSION stuct to _REQUEST_LIST struct
5. Renames ULONG_PTR from last_srb_id to next_id (semantically correct mnemonic)
6. Refactors element assignment to be under spinlock

The refactor solves the problem because the assignments now occur under spinlock.

Resolves #1466

Alternative to #1467

Reported by: @iops-hunter