### PR TITLE
[viostor] Fix SRB Extension struct member alignment

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1467,7 +1467,7 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     srbExt->vbr.out_hdr.sector = lba;
     srbExt->vbr.out_hdr.ioprio = 0;
     srbExt->vbr.req = (PVOID)Srb;
-    srbExt->fua = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH) ? (cdb->CDB10.ForceUnitAccess == 1) : FALSE;
+    srbExt->flags.fua = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH) ? (cdb->CDB10.ForceUnitAccess == 1) : FALSE;
 
     if (SRB_FLAGS(Srb) & SRB_FLAGS_DATA_OUT)
     {
@@ -2205,14 +2205,14 @@ VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOO
                              Srb,
                              QueueNumber,
                              MessageID);
-                if (srbExt && srbExt->fua == TRUE)
+                if (srbExt && srbExt->flags.fua == TRUE)
                 {
                     SRB_SET_SRB_STATUS(Srb, SRB_STATUS_PENDING);
                     if (!RhelDoFlush(DeviceExtension, Srb, TRUE, bIsr))
                     {
                         CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SRB_STATUS_ERROR);
                     }
-                    srbExt->fua = FALSE;
+                    srbExt->flags.fua = FALSE;
                 }
                 else
                 {

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -271,17 +271,27 @@ typedef struct _VRING_DESC_ALIAS
     } u;
 } VRING_DESC_ALIAS;
 
+#pragma pack(1)
+typedef struct _SRB_EXTENSION_FLAGS
+{
+    BOOLEAN fua;
+    BOOLEAN unused1[3];
+} SRB_EXTENSION_FLAGS, *PSRB_EXTENSION_FLAGS;
+#pragma pack()
+
+#pragma pack(1)
 typedef struct _SRB_EXTENSION
 {
     blk_req vbr;
+    ULONG_PTR id;
     ULONG out;
     ULONG in;
     ULONG MessageID;
-    BOOLEAN fua;
-    ULONG_PTR id;
+    SRB_EXTENSION_FLAGS flags;
     VIO_SG sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS desc[VIRTIO_MAX_SG];
 } SRB_EXTENSION, *PSRB_EXTENSION;
+#pragma pack()
 
 BOOLEAN
 VirtIoInterrupt(IN PVOID DeviceExtension);


### PR DESCRIPTION
Refactors to fix a struct member misalignment in `_SRB_EXTENSION`:

1. Creates a new `_SRB_EXTENSION_FLAGS` struct of 32 bits length
2. The first bit is `fua` (Forced Unit Access)
3. The other bits are unused padding
4. Replaces the `_SRB_EXTENSION` member `fua` with new `flags` member
5. Updates references to `srbExt->fua` to use `srbExt->flags.fua`
6. Enforces 1-byte alignment of structs `_SRB_EXTENSION` and `_SRB_EXTENSION_FLAGS`