### PR TITLE
[viogpu] Fix null pointer dereference in VioGpuObj::Init error path [SKIP-HCK-CI]

### DIFF
--- a/viogpu/common/viogpu_queue.cpp
+++ b/viogpu/common/viogpu_queue.cpp
@@ -1040,7 +1040,7 @@ BOOLEAN VioGpuObj::Init(_In_ UINT size, VioGpuMemSegment *pSegment)
     if (size > pSegment->GetSize())
     {
         DbgPrint(TRACE_LEVEL_FATAL,
-                 ("<--- %s segment size too small = %Iu (%u)\n", __FUNCTION__, m_pSegment->GetSize(), size));
+                 ("<--- %s segment size too small = %Iu (%u)\n", __FUNCTION__, pSegment->GetSize(), size));
         return FALSE;
     }
     m_pSegment = pSegment;


### PR DESCRIPTION
- Fix BSOD (0x3B SYSTEM_SERVICE_EXCEPTION) when resizing to a resolution that exceeds the pre-allocated framebuffer segment size
- Root cause: `VioGpuObj::Init` error path used uninitialized member `m_pSegment` instead of parameter `pSegment`, causing null pointer dereference

## Known Limitation

  This fix prevents the crash, but does not address the issue where resizing to a very large resolution and then back to a smaller one fails to restore display output. The rollback mechanism may need further investigation.