### PR TITLE
[viogpu] Add indirect descriptor support for large framebuffers

### DIFF
--- a/viogpu/common/viogpu_queue.h
+++ b/viogpu/common/viogpu_queue.h
@@ -57,6 +57,10 @@ typedef struct virtio_gpu_vbuffer
     void *complete_ctx;
 
     bool auto_release;
+
+    // Indirect descriptor table (PVOID since we only need to allocate/free, not access fields)
+    PVOID desc;
+    PHYSICAL_ADDRESS desc_pa;
 } GPU_VBUFFER, *PGPU_VBUFFER;
 // #pragma pack()
 
@@ -72,9 +76,11 @@ class VioGpuBuf
     PGPU_VBUFFER GetBuf(_In_ int size, _In_ int resp_size, _In_opt_ void *resp_buf);
     void FreeBuf(_In_ PGPU_VBUFFER pbuf);
     BOOLEAN Init(_In_ UINT cnt);
+    BOOLEAN AllocateIndirectDescriptors(_In_ PGPU_VBUFFER pbuf, _In_ SIZE_T dataSize);
 
   private:
     void Close(void);
+    void DeleteBuffer(_In_ PGPU_VBUFFER pbuf);
 
   private:
     LIST_ENTRY m_FreeBufs;

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -2279,6 +2279,9 @@ NTSTATUS VioGpuAdapter::VioGpuAdapterInit(DXGK_DISPLAY_INFORMATION *pDispInfo)
 
         AckFeature(VIRTIO_F_ACCESS_PLATFORM);
 
+        // Enable indirect descriptors for large transfers
+        AckFeature(VIRTIO_RING_F_INDIRECT_DESC);
+
         status = virtio_set_features(&m_VioDev, m_u64GuestFeatures);
         if (!NT_SUCCESS(status))
         {

--- a/viogpu/viogpudo/viogpudo.vcxproj
+++ b/viogpu/viogpudo/viogpudo.vcxproj
@@ -251,6 +251,7 @@
     <ClInclude Include="..\common\bitops.h" />
     <ClInclude Include="..\common\edid.h" />
     <ClInclude Include="..\common\helper.h" />
+    <ClInclude Include="..\common\viogpu_queue.h" />
     <ClInclude Include="driver.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="viogpudo.h" />


### PR DESCRIPTION
Enable VIRTIO_RING_F_INDIRECT_DESC feature to support large framebuffer transfers that exceed the virtio queue descriptor limit.

## Problem
Previously, switching to large resolutions (8K and above) would fail with -ENOSPC during framebuffer backing memory attachment. Each memory page required a separate virtio descriptor, but high resolutions like 8K need ~24,000 descriptors while the queue only supports 64-128 descriptors.

## Solution
Indirect descriptors allow all scatter-gather entries to be placed in a separate descriptor table, consuming only one queue descriptor regardless of framebuffer size. This enables resolutions up to approximately 10K (limited by SGLIST_SIZE=256).

## Changes
- Only allocate indirect descriptors when dataPages > SGLIST_SIZE - 2 (small transfers like cursors use direct descriptors)
- Allocate on-demand in QueueBuffer, free in FreeBuf (no pre-allocation or reuse)
- Use PVOID for descriptor table pointer (no need to access internal fields)
- Dynamically calculate descriptor table size based on data_size
- Negotiate VIRTIO_RING_F_INDIRECT_DESC feature during initialization

## Relationship to PR #1474
This PR is complementary to [#1474](https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1474). While #1474 prevents switching to resolutions exceeding framebuffer capacity, this PR removes the virtio descriptor limitation that would otherwise cap maximum supported resolution even with sufficient memory.