### PR TITLE
netkvm: failback to in-driver checksum calculation

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -436,6 +436,9 @@ static bool ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
 
 void ParaNdis_ResetOffloadSettings(PARANDIS_ADAPTER *pContext, tOffloadSettingsFlags *pDest, PULONG from)
 {
+    BOOLEAN bOffloadv4Enabled = pContext->bOffloadv4Enabled;
+    BOOLEAN bOffloadv6Enabled = pContext->bOffloadv6Enabled;
+
     if (!pDest)
     {
         pDest = &pContext->Offload.flags;
@@ -445,11 +448,11 @@ void ParaNdis_ResetOffloadSettings(PARANDIS_ADAPTER *pContext, tOffloadSettingsF
         from = &pContext->Offload.flagsValue;
     }
 
-    pDest->fTxIPChecksum = !!(*from & osbT4IpChecksum);
-    pDest->fTxTCPChecksum = !!(*from & osbT4TcpChecksum);
-    pDest->fTxUDPChecksum = !!(*from & osbT4UdpChecksum);
-    pDest->fTxTCPOptions = !!(*from & osbT4TcpOptionsChecksum);
-    pDest->fTxIPOptions = !!(*from & osbT4IpOptionsChecksum);
+    pDest->fTxIPChecksum = !!(*from & osbT4IpChecksum) && bOffloadv4Enabled;
+    pDest->fTxTCPChecksum = !!(*from & osbT4TcpChecksum) && bOffloadv4Enabled;
+    pDest->fTxUDPChecksum = !!(*from & osbT4UdpChecksum) && bOffloadv4Enabled;
+    pDest->fTxTCPOptions = !!(*from & osbT4TcpOptionsChecksum) && bOffloadv4Enabled;
+    pDest->fTxIPOptions = !!(*from & osbT4IpOptionsChecksum) && bOffloadv4Enabled;
 
     pDest->fTxLso = !!(*from & osbT4Lso);
     pDest->fTxLsoIP = !!(*from & osbT4LsoIp);
@@ -461,10 +464,10 @@ void ParaNdis_ResetOffloadSettings(PARANDIS_ADAPTER *pContext, tOffloadSettingsF
     pDest->fRxTCPOptions = !!(*from & osbT4RxTCPOptionsChecksum);
     pDest->fRxUDPChecksum = !!(*from & osbT4RxUDPChecksum);
 
-    pDest->fTxTCPv6Checksum = !!(*from & osbT6TcpChecksum);
-    pDest->fTxTCPv6Options = !!(*from & osbT6TcpOptionsChecksum);
-    pDest->fTxUDPv6Checksum = !!(*from & osbT6UdpChecksum);
-    pDest->fTxIPv6Ext = !!(*from & osbT6IpExtChecksum);
+    pDest->fTxTCPv6Checksum = !!(*from & osbT6TcpChecksum) && bOffloadv6Enabled;
+    pDest->fTxTCPv6Options = !!(*from & osbT6TcpOptionsChecksum) && bOffloadv6Enabled;
+    pDest->fTxUDPv6Checksum = !!(*from & osbT6UdpChecksum) && bOffloadv6Enabled;
+    pDest->fTxIPv6Ext = !!(*from & osbT6IpExtChecksum) && bOffloadv6Enabled;
 
     pDest->fTxLsov6 = !!(*from & osbT6Lso);
     pDest->fTxLsov6IP = !!(*from & osbT6LsoIpExt);

--- a/NetKVM/wlh/ParaNdis6_Oid.cpp
+++ b/NetKVM/wlh/ParaNdis6_Oid.cpp
@@ -1537,6 +1537,7 @@ NDIS_STATUS OnSetOffloadEncapsulation(PARANDIS_ADAPTER *pContext, tOidDesc *pOid
                 status = NDIS_STATUS_SUCCESS;
             }
         }
+        ParaNdis_ResetOffloadSettings(pContext, NULL, NULL);
     }
     return status;
 }


### PR DESCRIPTION
This PR is to start discussion of one interesting problem that we encountered recently. If you believe that there is a better way to address the below problem, I am happy to discuss it. 

If Windows is configured to disable checksum offloading for IPv4 and IPv6, it does not use OID_OFFLOAD_ENCAPSULATION OID to set offload encapsulation. It will make ipHeaderOffset remain zero. Consequently, it will break CNB::SetupCSO and it will set VirtioHeader->csum_start to the wrong value (not to the offset where IP header begins). 
```
netsh int ipv4 set global taskoffload=disabled
netsh int ipv6 set global taskoffload=disabled
```

It is the state of `Offload` member:
```
3: kd> dx -id 0,0,ffff8c8b54c29080 -r1 (*((netkvm!_tagOffloadSettings *)0xffff8c8b5208c6f4))
(*((netkvm!_tagOffloadSettings *)0xffff8c8b5208c6f4))                 [Type: _tagOffloadSettings]
    [+0x000] flags            [Type: _tagOffloadSettingsFlags]
    [+0x004] flagsValue       : 0x37affff [Type: unsigned long]
    [+0x008] ipHeaderOffset   : 0x0 [Type: unsigned long]
```

Effectively, it will affect the checksum offloading resulting in packets being dropped somewhere on the path and network connectivity inside the guest will be affected.

With some models of physical NICs we also saw that TX queues will get hung, so it will cause denial of services for all VMs on the hypervisor. 

With the proposed change, such condition is handled better and if task offload set to disabled, it will fail over to in-driver checksums calculation. Hence, behaviour is more reliable. The configuration of `Offload` with this change, in the default configuration when taskoffload is not set, is correct as well:
```
0: kd> dt netkvm!_PARANDIS_ADAPTER ffff8906d9536000 Offload.
   +0x70c Offload  : 
      +0x000 flags    : _tagOffloadSettingsFlags
      +0x004 flagsValue : 0x7affff
      +0x008 ipHeaderOffset : 0xe
0: kd> dx -id 0,0,ffff8906d0f79080 -r1 (*((netkvm!_tagOffloadSettingsFlags *)0xffff8906d953670c))
(*((netkvm!_tagOffloadSettingsFlags *)0xffff8906d953670c))                 [Type: _tagOffloadSettingsFlags]
    [+0x000 ( 0: 0)] fTxIPChecksum    : -1 [Type: int]
    [+0x000 ( 1: 1)] fTxTCPChecksum   : -1 [Type: int]
    [+0x000 ( 2: 2)] fTxUDPChecksum   : -1 [Type: int]
    [+0x000 ( 3: 3)] fTxTCPOptions    : -1 [Type: int]
    [+0x000 ( 4: 4)] fTxIPOptions     : -1 [Type: int]
    [+0x000 ( 5: 5)] fTxLso           : -1 [Type: int]
    [+0x000 ( 6: 6)] fTxLsoIP         : -1 [Type: int]
    [+0x000 ( 7: 7)] fTxLsoTCP        : -1 [Type: int]
    [+0x000 ( 8: 8)] fRxIPChecksum    : -1 [Type: int]
    [+0x000 ( 9: 9)] fRxTCPChecksum   : -1 [Type: int]
    [+0x000 (10:10)] fRxUDPChecksum   : -1 [Type: int]
    [+0x000 (11:11)] fRxTCPOptions    : -1 [Type: int]
    [+0x000 (12:12)] fRxIPOptions     : -1 [Type: int]
    [+0x000 (13:13)] fTxTCPv6Checksum : -1 [Type: int]
    [+0x000 (14:14)] fTxUDPv6Checksum : -1 [Type: int]
    [+0x000 (15:15)] fTxTCPv6Options  : -1 [Type: int]
    [+0x000 (16:16)] fTxIPv6Ext       : 0 [Type: int]
    [+0x000 (17:17)] fTxLsov6         : -1 [Type: int]
    [+0x000 (18:18)] fTxLsov6IP       : 0 [Type: int]
    [+0x000 (19:19)] fTxLsov6TCP      : -1 [Type: int]
    [+0x000 (20:20)] fRxTCPv6Checksum : -1 [Type: int]
    [+0x000 (21:21)] fRxUDPv6Checksum : -1 [Type: int]
    [+0x000 (22:22)] fRxTCPv6Options  : -1 [Type: int]
    [+0x000 (23:23)] fRxIPv6Ext       : 0 [Type: int]
    [+0x000 (24:24)] fUsov4           : 0 [Type: int]
    [+0x000 (25:25)] fUsov6           : 0 [Type: int]
```

I have validated that this change passes HLK for Windows Server 2025 without any problems. Moreover, I also validated that the change does what is expected:
In the default configuration when both IPv4 and IPv6 do not have taskoffload disabled, I have checked UDP packets (on the transmit path, so outgoing packets):

1. Default netkvm configuration, I see partial check sums on the tap interface.
2. RX/TX checksum offload disabled, checksum is calculated by the driver.
3. RX enabled and TX disabled, partial checksum on the wire.
4. RX disabled and TX enabled, checksum is calculated by the driver.
(I can share the captures in private)

When taskoffload is disabled for IPv4 and IPv6, I see the checksum being calculated by the driver regardless of the checksum offload configuration. 