### PR TITLE
[viogpu] Use infinite wait for device response in release builds

### DIFF
--- a/viogpu/common/viogpu_queue.cpp
+++ b/viogpu/common/viogpu_queue.cpp
@@ -225,17 +225,21 @@ BOOLEAN CtrlQueue::AskDisplayInfo(PGPU_VBUFFER *buf)
     vbuf->complete_ctx = &event;
     vbuf->auto_release = false;
 
+    QueueBuffer(vbuf);
+
+#if DBG
     LARGE_INTEGER timeout = {0};
     timeout.QuadPart = Int32x32To64(1000, -10000);
-
-    QueueBuffer(vbuf);
     status = KeWaitForSingleObject(&event, Executive, KernelMode, FALSE, &timeout);
-
     if (status == STATUS_TIMEOUT)
     {
         DbgPrint(TRACE_LEVEL_FATAL, ("---> Failed to ask display info\n"));
         VioGpuDbgBreak();
     }
+#else
+    status = KeWaitForSingleObject(&event, Executive, KernelMode, FALSE, NULL);
+    (void)status;
+#endif
     *buf = vbuf;
 
     DbgPrint(TRACE_LEVEL_VERBOSE, ("<--- %s\n", __FUNCTION__));
@@ -273,18 +277,21 @@ BOOLEAN CtrlQueue::AskEdidInfo(PGPU_VBUFFER *buf, UINT id)
     vbuf->complete_ctx = &event;
     vbuf->auto_release = false;
 
-    LARGE_INTEGER timeout = {0};
-    timeout.QuadPart = Int32x32To64(1000, -10000);
-
     QueueBuffer(vbuf);
 
+#if DBG
+    LARGE_INTEGER timeout = {0};
+    timeout.QuadPart = Int32x32To64(1000, -10000);
     status = KeWaitForSingleObject(&event, Executive, KernelMode, FALSE, &timeout);
-
     if (status == STATUS_TIMEOUT)
     {
         DbgPrint(TRACE_LEVEL_FATAL, ("---> Failed to get edid info\n"));
         VioGpuDbgBreak();
     }
+#else
+    status = KeWaitForSingleObject(&event, Executive, KernelMode, FALSE, NULL);
+    (void)status;
+#endif
 
     *buf = vbuf;
 


### PR DESCRIPTION
When AskEdidInfo or AskDisplayInfo times out waiting for device response, the buffer's resp_buf is freed and set to NULL by ReleaseBuffer/FreeBuf. However, the buffer remains in the virtio queue. When the device eventually completes the request and triggers an interrupt, DpcRoutine dequeues the buffer and attempts to access resp->type, causing a NULL pointer dereference (BSOD 0xD1 DRIVER_IRQL_NOT_LESS_OR_EQUAL).

Fix by using infinite wait in release builds to avoid the race condition. Keep the 1-second timeout with VioGpuDbgBreak() in debug builds to detect device communication issues during development.