### PR TITLE
netkvm: set ipHeaderOffset to ETH_HEADER_SIZE

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -298,6 +298,7 @@ static bool ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             pContext->uNumberOfHandledRXPacketsInDPC = pConfiguration->NumberOfHandledRXPacketsInDPC.ulValue;
             pContext->bDoSupportPriority = pConfiguration->PrioritySupport.ulValue != 0;
             pContext->Offload.flagsValue = 0;
+            pContext->Offload.ipHeaderOffset = ETH_HEADER_SIZE;
             pContext->MinRxBufferPercent = pConfiguration->MinRxBufferPercent.ulValue;
             pContext->bRxSeparateTail = pConfiguration->RxSeparateTail.ulValue != 0;
             // TX caps: 1 - TCP, 2 - UDP, 4 - IP, 8 - TCPv6, 16 - UDPv6


### PR DESCRIPTION
If Windows is configured to disable checksum offloading for IPv4 and IPv6, it does not use OID_OFFLOAD_ENCAPSULATION OID to set offload encapsulation.

As the result, OnSetOffloadEncapsulation is not executed and it makes, ipHeaderOffset remain zero. It will break CNB::SetupCSO and it will set VirtioHeader->csum_start to the wrong value (not to the offset where IP header begins). Effectively, it will affect the checksum offloading resulting in packets being dropped somewhere on the path and network connectivity inside the guest will be affected.

With the proposed change, we set ipHeaderOffset to ETH_HEADER_SIZE by default and it helps avoid the problem if/when OnSetOffloadEncapsulation is not called.

This change is a simplified way to address  the problem reported in https://github.com/virtio-win/kvm-guest-drivers-windows/pull/1487