### PR TITLE
viostor: Reimplement bus reset operation

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -255,7 +255,7 @@ typedef struct _ADAPTER_EXTENSION
     STOR_ADDR_BTL8 device_address;
     blk_discard_write_zeroes blk_discard[16];
     REQUEST_LIST processing_srbs[MAX_CPU];
-    BOOLEAN reset_in_progress;
+    ULONG reset_in_progress_count;
     ULONGLONG fw_ver;
 #ifdef DBG
     LONG srb_cnt;

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -113,13 +113,6 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
         MessageId = QueueNumber + 1;
     }
 
-    if (adaptExt->reset_in_progress)
-    {
-        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
-        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
-        return TRUE;
-    }
-
     srbExt->MessageID = MessageId;
     vq = adaptExt->vq[QueueNumber];
 
@@ -139,6 +132,15 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     {
         VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
 
+        if (adaptExt->reset_in_progress_count)
+        {
+            VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+            SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+            CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+            return TRUE;
+        }
+
         element = &adaptExt->processing_srbs[QueueNumber];
 
         ULONG_PTR id = element->next_id;
@@ -153,6 +155,13 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     }
     else
     {
+        if (adaptExt->reset_in_progress_count)
+        {
+            SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+            CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+            return TRUE;
+        }
+
         element = &adaptExt->processing_srbs[QueueNumber];
     }
 
@@ -210,18 +219,20 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
     MessageId = QueueNumber + 1;
 
-    if (adaptExt->reset_in_progress)
-    {
-        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
-        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
-        return TRUE;
-    }
-
     srbExt->MessageID = MessageId;
     vq = adaptExt->vq[QueueNumber];
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, " QueueNumber 0x%x vq = %p\n", QueueNumber, vq);
 
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+    if (adaptExt->reset_in_progress_count)
+    {
+        VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+        return TRUE;
+    }
 
     element = &adaptExt->processing_srbs[QueueNumber];
 
@@ -352,13 +363,6 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
     MessageId = QueueNumber + 1;
 
-    if (adaptExt->reset_in_progress)
-    {
-        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
-        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
-        return TRUE;
-    }
-
     srbExt->MessageID = MessageId;
     vq = adaptExt->vq[QueueNumber];
     RhelDbgPrint(TRACE_LEVEL_INFORMATION,
@@ -368,6 +372,15 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
                  srbExt->vbr.out_hdr.type);
 
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+    if (adaptExt->reset_in_progress_count)
+    {
+        VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+        return TRUE;
+    }
 
     element = &adaptExt->processing_srbs[QueueNumber];
 
@@ -431,13 +444,6 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
     MessageId = QueueNumber + 1;
 
-    if (adaptExt->reset_in_progress)
-    {
-        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
-        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
-        return TRUE;
-    }
-
     srbExt->MessageID = MessageId;
     vq = adaptExt->vq[QueueNumber];
 
@@ -456,6 +462,15 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     srbExt->sg[2].length = sizeof(srbExt->vbr.status);
 
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+    if (adaptExt->reset_in_progress_count)
+    {
+        VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+
+        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+        return TRUE;
+    }
 
     element = &adaptExt->processing_srbs[QueueNumber];
 


### PR DESCRIPTION

The VirtIO BLK device does not have special reset events/routines
like the VirtIO SCSI device (controlq command VIRTIO_SCSI_T_TMF_LOGICAL_UNIT_RESET),
but Windows requires to have some mechanism to fix a device when it hangs.
The most appropriate way is perform a full VirtIO reset and initialization
flow based on spec.

The following flow is implemented:

1. Reset VirtIO device (virtio_device_reset)
2. Delete VirtIO queues (virtio_delete_queues)
3. Clean up all device memory (virtio_device_shutdown)
4. Complete all pending SRBs (in guest, CompletePendingRequestsOnReset)
5. Perform VirtIO device initialization (virtio_device_initialize, virtio_find_queues, etc)

Note: We don't pause StorPort because the port driver pauses all device IO queues for the
adapter and then calls the HwStorResetBus routine
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/storport/nc-storport-hw_reset_bus

Note: We cannot just complete all pending SRBs and continue, because this
memory will be still in use by the device and free in Windows. As a result,
we got use-after-free when the device completes the request and sends it back to Windows.
This may cause a memory corruption, as Windows may already have reused the memory.

Before this commit, we only complete all pending SRBs and continue.