### PR TITLE
viostor: Fix buffer overrun in unmap code

### DIFF
--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -258,7 +258,6 @@ typedef struct _ADAPTER_EXTENSION
     PGROUP_AFFINITY pmsg_affinity;
     ULONG num_affinity;
     STOR_ADDR_BTL8 device_address;
-    blk_discard_write_zeroes blk_discard[MAX_DISCARD_SEGMENTS];
     REQUEST_LIST processing_srbs[MAX_CPU];
     BOOLEAN reset_in_progress;
     ULONGLONG fw_ver;
@@ -286,6 +285,7 @@ typedef struct _SRB_EXTENSION
     BOOLEAN fua;
     VIO_SG sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS desc[VIRTIO_MAX_SG];
+    blk_discard_write_zeroes blk_discard[MAX_DISCARD_SEGMENTS];
 } SRB_EXTENSION, *PSRB_EXTENSION;
 
 BOOLEAN

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -324,7 +324,7 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
      * the request. Doing something more sophisticated like splitting into
      * multiple requests is not needed.
      */
-    if (BlockDescrCount > ARRAYSIZE(adaptExt->blk_discard))
+    if (BlockDescrCount > ARRAYSIZE(srbExt->blk_discard))
     {
         Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
         return FALSE;
@@ -342,9 +342,9 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
                      BlockDescrCount,
                      blockDescrStartingLba,
                      blockDescrLbaCount);
-        adaptExt->blk_discard[i].sector = blockDescrStartingLba * (adaptExt->info.blk_size / SECTOR_SIZE);
-        adaptExt->blk_discard[i].num_sectors = blockDescrLbaCount * (adaptExt->info.blk_size / SECTOR_SIZE);
-        adaptExt->blk_discard[i].flags = 0;
+        srbExt->blk_discard[i].sector = blockDescrStartingLba * (adaptExt->info.blk_size / SECTOR_SIZE);
+        srbExt->blk_discard[i].num_sectors = blockDescrLbaCount * (adaptExt->info.blk_size / SECTOR_SIZE);
+        srbExt->blk_discard[i].flags = 0;
     }
 
     srbExt->vbr.out_hdr.sector = 0;
@@ -356,7 +356,7 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
 
     srbExt->sg[0].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.out_hdr, &fragLen);
     srbExt->sg[0].length = sizeof(srbExt->vbr.out_hdr);
-    srbExt->sg[1].physAddr = MmGetPhysicalAddress(&adaptExt->blk_discard[0]);
+    srbExt->sg[1].physAddr = MmGetPhysicalAddress(&srbExt->blk_discard[0]);
     srbExt->sg[1].length = sizeof(blk_discard_write_zeroes) * BlockDescrCount;
     srbExt->sg[2].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.status, &fragLen);
     srbExt->sg[2].length = sizeof(srbExt->vbr.status);


### PR DESCRIPTION
`adaptExt->blk_discard` is limited to 16 descriptors, but `RhelDoUnMap()` never validates the number of descriptors it writes to the array. This is wrong for two separate reasons:

`MAX_DISCARD_SEGMENTS` is 256, so we may in theory even advertise support for a lot more segments than can actually fit in the array and even well behaving applications could trigger an overrun. (This is mostly theoretical because QEMU's virtio-blk implementation advertises 1 currently.)

The other reason is that `BlockDescrCount` is taken from a user buffer and has never been validated, so it can exceed the advertised maximum. I reproduced the problem by issuing an unmap request with 1024 descriptors and got an immediate BSOD. `RhelDoUnMap()` must explicitly validate the number of descriptors.

Use `MAX_DISCARD_SEGMENTS` as the size of `adaptExt->blk_discard` to make sure the advertised maximum is actually supported; advertise the full range instead of limiting to `MAX_DISCARD_SEGMENTS - 1`. Reduce `MAX_DISCARD_SEGMENTS` to 16 to avoid increasing the array size. And finally check first that the user buffer is even large enough that we can safely access `blockDescrDataLength` in it.