### PR TITLE
[viofs] Fix Coverity findings: Input validation and code cleanup

### DIFF
--- a/viofs/pci/ioctl.c
+++ b/viofs/pci/ioctl.c
@@ -372,7 +372,6 @@ static VOID HandleGetVolumeName(IN PDEVICE_CONTEXT Context, IN WDFREQUEST Reques
     if (!NT_SUCCESS(status))
     {
         TraceEvents(TRACE_LEVEL_VERBOSE, DBG_POWER, "Failed to convert config tag: %!STATUS!", status);
-        status = STATUS_SUCCESS;
     }
     else
     {

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -1049,13 +1049,13 @@ static NTSTATUS GetFileInfoInternal(VIRTFS *VirtFs,
 
     FUSE_HEADER_INIT(&getattr_in.hdr, FUSE_GETATTR, FileContext->NodeId, sizeof(getattr_in.getattr));
 
+    ZeroMemory(&getattr_in.getattr, sizeof(getattr_in.getattr));
+
     if (FileContext->FileHandle != INVALID_FILE_HANDLE)
     {
         getattr_in.getattr.fh = FileContext->FileHandle;
         getattr_in.getattr.getattr_flags |= FUSE_GETATTR_FH;
     }
-
-    getattr_in.getattr.getattr_flags = 0;
 
     Status = VirtFsFuseRequest(VirtFs->Device, &getattr_in, sizeof(getattr_in), &getattr_out, sizeof(getattr_out));
 


### PR DESCRIPTION
This PR addresses static analysis issues to improve driver stability:

- Validation (TAINTED_SCALAR): Added validation for device-supplied lengths (hdr.len) in Read, Write, and Directory functions to prevent buffer overruns and infinite loops. Returns STATUS_IO_DEVICE_ERROR on invalid input.
- Cleanup: Fixed uninitialized variable in GetFileInfoInternal and removed dead code in HandleGetVolumeName.

Fixes CIDs: 475514, 475483, 475494, 475409, 475415, 475462, 475416, 475428, 475487
