### PR TITLE
[viorng] Fix array delete in viorngtest

### DIFF
--- a/viorng/test/viorngtest.cpp
+++ b/viorng/test/viorngtest.cpp
@@ -102,6 +102,6 @@ int __cdecl wmain(int argc, LPWSTR argv[])
         BCryptCloseAlgorithmProvider(h, 0);
     }
 
-    delete Buffer;
+    delete[] Buffer;
     return status;
 }


### PR DESCRIPTION
Fix Coverity CID 317317. 
The Buffer array was allocated with new[] but freed with delete instead of delete[].
Changed to use delete[] to properly free the array.