### PR TITLE
[vioinput] Fix memory leak on allocation failure

### DIFF
--- a/vioinput/sys/HidKeyboard.c
+++ b/vioinput/sys/HidKeyboard.c
@@ -493,7 +493,8 @@ HIDKeyboardProbe(PINPUT_DEVICE pContext,
                                                                        VIOINPUT_DRIVER_MEMORY_TAG);
         if (pKeyboardDesc->pLastOutputReport == NULL)
         {
-            return STATUS_INSUFFICIENT_RESOURCES;
+            status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Exit;
         }
         RtlZeroMemory(pKeyboardDesc->pLastOutputReport, pKeyboardDesc->cbOutputReport);
     }


### PR DESCRIPTION
Fix Coverity CID 203180. Use goto Exit instead of direct return when pLastOutputReport allocation fails to properly free pKeyboardDesc.