### PR TITLE
[vioscsi] Fix off-by one errors in PORT_CONFIGURATION_INFORMATION members

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1303,17 +1303,17 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     PSRB_EXTENSION srbExt;
     PSTOR_SCATTER_GATHER_LIST sgList;
     VirtIOSCSICmd *cmd;
-    UCHAR TargetId;
+    UCHAR Target;
     UCHAR Lun;
 
     ENTER_FN_SRB();
     cdb = SRB_CDB(Srb);
     srbExt = SRB_EXTENSION(Srb);
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
-    TargetId = SRB_TARGET_ID(Srb);
+    Target = SRB_TARGET_ID(Srb);
     Lun = SRB_LUN(Srb);
 
-    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (TargetId >= adaptExt->scsi_config.max_target) ||
+    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (Target >= adaptExt->scsi_config.max_target) ||
         (Lun >= adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
     {
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
@@ -1332,7 +1332,7 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     cmd = &srbExt->cmd;
     cmd->srb = (PVOID)Srb;
     cmd->req.cmd.lun[0] = 1;
-    cmd->req.cmd.lun[1] = TargetId;
+    cmd->req.cmd.lun[1] = Target;
     cmd->req.cmd.lun[2] = 0;
     cmd->req.cmd.lun[3] = Lun;
     cmd->req.cmd.tag = (ULONG_PTR)(Srb);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -394,9 +394,25 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     SetGuestFeatures(DeviceExtension);
 
     ConfigInfo->NumberOfBuses = 1;
-    ConfigInfo->MaximumNumberOfTargets = min((UCHAR)adaptExt->scsi_config.max_target,
-                                             255 /*SCSI_MAXIMUM_TARGETS_PER_BUS*/);
-    ConfigInfo->MaximumNumberOfLogicalUnits = min((UCHAR)adaptExt->scsi_config.max_lun, SCSI_MAXIMUM_LUNS_PER_TARGET);
+    /* The following *NumberOf* PORT_CONFIGURATION_INFORMATION members are set by values with a zero-based index,
+     * so add one (1) to each: MaximumNumberOfTargets and MaximumNumberOfLogicalUnits.
+     * -----------------------------------------------------------------------------------------------------------
+     **  MaximumNumberOfTargets:
+     **  Most hypervisors will report the max_target value as 255 per the VirtIO standard,
+     **  and whilst SCSI port used SCSI_MAXIMUM_TARGETS_PER_BUS (128), in Storport the limit is 255.
+     **  To avoid an integer wrap-around following scsi_config.max_target + 1, we also initially cast
+     **  max_target as ULONG.
+     **
+     **  MaximumNumberOfLogicalUnits:
+     **  Most hypervisors will report the max_lun value as 16383 per the VirtIO standard,
+     **  but the Storport limit is SCSI_MAXIMUM_LUNS_PER_TARGET (255). We also need to cast to UCHAR
+     **  as MaximumNumberOfLogicalUnits is UCHAR but max_lun is ULONG. To avoid an integer wrap-around
+     **  following scsi_config.max_lun + 1, we also initially cast max_lun as ULONGLONG.
+     */
+    ConfigInfo->MaximumNumberOfTargets = (UCHAR)min((ULONG)adaptExt->scsi_config.max_target + 1, 255);
+    ConfigInfo->MaximumNumberOfLogicalUnits = (UCHAR)min((ULONGLONG)adaptExt->scsi_config.max_lun + 1,
+                                                         SCSI_MAXIMUM_LUNS_PER_TARGET);
+
     ConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;  // Unlimited
     ConfigInfo->NumberOfPhysicalBreaks = SP_UNINITIALIZED_VALUE; // Unlimited
 
@@ -1313,8 +1329,8 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     Target = SRB_TARGET_ID(Srb);
     Lun = SRB_LUN(Srb);
 
-    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (Target >= adaptExt->scsi_config.max_target) ||
-        (Lun >= adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
+    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (Target > adaptExt->scsi_config.max_target) ||
+        (Lun > adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
     {
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);

--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -348,6 +348,7 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     ULONG num_cpus;
     ULONG max_cpus;
     ULONG max_queues;
+    UCHAR max_channels;
 
     UNREFERENCED_PARAMETER(HwContext);
     UNREFERENCED_PARAMETER(BusInformation);
@@ -393,10 +394,19 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     GetScsiConfig(DeviceExtension);
     SetGuestFeatures(DeviceExtension);
 
-    ConfigInfo->NumberOfBuses = 1;
     /* The following *NumberOf* PORT_CONFIGURATION_INFORMATION members are set by values with a zero-based index,
-     * so add one (1) to each: MaximumNumberOfTargets and MaximumNumberOfLogicalUnits.
+     * so add one (1) to each: NumberOfBuses, MaximumNumberOfTargets and MaximumNumberOfLogicalUnits.
      * -----------------------------------------------------------------------------------------------------------
+     **  NumberOfBuses:
+     **  Most hypervisors will report the max_channel value as zero (0) per the VirtIO standard.
+     **  The supported limit of virtio-scsi is VIRTIO_SCSI_MAX_BUSES_PER_HBA (1). The Storport limit
+     **  is SCSI_MAXIMUM_BUSES_PER_ADAPTER (255). To retain similar logic to max_target and max_lun
+     **  as shown below, and provide for additional channels should the VIrtIO standard ever accommodate
+     **  more buses per adapter, we define max_channels as the lesser of SCSI_MAXIMUM_BUSES_PER_ADAPTER
+     **  and VIRTIO_SCSI_MAX_BUSES_PER_HBA. We then use max_channels and scsi_config.max_channel + 1 as
+     **  limits. To avoid an integer wrap-around following scsi_config.max_channel + 1, we also initially
+     **  cast max_channel as ULONG.
+     **
      **  MaximumNumberOfTargets:
      **  Most hypervisors will report the max_target value as 255 per the VirtIO standard,
      **  and whilst SCSI port used SCSI_MAXIMUM_TARGETS_PER_BUS (128), in Storport the limit is 255.
@@ -409,6 +419,8 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
      **  as MaximumNumberOfLogicalUnits is UCHAR but max_lun is ULONG. To avoid an integer wrap-around
      **  following scsi_config.max_lun + 1, we also initially cast max_lun as ULONGLONG.
      */
+    max_channels = (UCHAR)min(VIRTIO_SCSI_MAX_BUSES_PER_HBA, SCSI_MAXIMUM_BUSES_PER_ADAPTER);
+    ConfigInfo->NumberOfBuses = (UCHAR)min((ULONG)adaptExt->scsi_config.max_channel + 1, max_channels);
     ConfigInfo->MaximumNumberOfTargets = (UCHAR)min((ULONG)adaptExt->scsi_config.max_target + 1, 255);
     ConfigInfo->MaximumNumberOfLogicalUnits = (UCHAR)min((ULONGLONG)adaptExt->scsi_config.max_lun + 1,
                                                          SCSI_MAXIMUM_LUNS_PER_TARGET);
@@ -1319,6 +1331,7 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     PSRB_EXTENSION srbExt;
     PSTOR_SCATTER_GATHER_LIST sgList;
     VirtIOSCSICmd *cmd;
+    UCHAR Channel;
     UCHAR Target;
     UCHAR Lun;
 
@@ -1326,12 +1339,27 @@ VioScsiBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     cdb = SRB_CDB(Srb);
     srbExt = SRB_EXTENSION(Srb);
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    Channel = SRB_PATH_ID(Srb);
     Target = SRB_TARGET_ID(Srb);
     Lun = SRB_LUN(Srb);
 
-    if ((SRB_PATH_ID(Srb) > (UCHAR)adaptExt->num_queues) || (Target > adaptExt->scsi_config.max_target) ||
+    if ((Channel >= VIRTIO_SCSI_MAX_BUSES_PER_HBA) || (Target > adaptExt->scsi_config.max_target) ||
         (Lun > adaptExt->scsi_config.max_lun) || adaptExt->bRemoved)
     {
+        if (adaptExt->bRemoved)
+        {
+            RhelDbgPrint(TRACE_LEVEL_ERROR,
+                         " Storport attempted to build an I/O request but the adapter is no longer present.\n");
+        }
+        else
+        {
+            RhelDbgPrint(TRACE_LEVEL_ERROR,
+                         " Storport attempted to build an I/O request for a device that is not present."
+                         " The BTL8 address is %d:%d:%d.\n",
+                         Channel,
+                         Target,
+                         Lun);
+        }
         SRB_SET_SRB_STATUS(Srb, SRB_STATUS_NO_DEVICE);
         SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
         StorPortNotification(RequestComplete, DeviceExtension, Srb);

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -119,6 +119,8 @@ typedef struct VirtIOBufferDescriptor VIO_SG, *PVIO_SG;
 #define VIRTIO_SCSI_REQUEST_QUEUE_0          2
 #define VIRTIO_SCSI_QUEUE_LAST               VIRTIO_SCSI_REQUEST_QUEUE_0 + MAX_CPU
 
+#define VIRTIO_SCSI_MAX_BUSES_PER_HBA        1
+
 /* MSI messages and virtqueue indices are offset by 1, MSI 0 is not used */
 #define QUEUE_TO_MESSAGE(QueueId)            ((QueueId) + 1)
 #define MESSAGE_TO_QUEUE(MessageId)          ((MessageId)-1)


### PR DESCRIPTION
Fixes off-by one errors in `VioScsiFindAdapter()` for `PORT_CONFIGURATION_INFORMATION` members `MaximumNumberOfTargets` and `MaximumNumberOfLogicalUnits`, and introduces a similar method used by these to also define the `NumberOfBuses` member. Includes minor refactoring in separate commits.

**_Commit summary:_**

<ins>_Rename `TargetId` variable to `Target`_</ins>

Renames `TargetId` variable to `Target` in `VioScsiBuildIo()`.

`TargetId` is a member of the legacy `SCSI_REQUEST_BLOCK` struct, as was `PathId` and `Lun`. Since porting from the SCSI port driver to the Storport driver, we now use the `STORAGE_REQUEST_BLOCK` struct instead, which contains an `AddressOffset` member which is used to locate a `STOR_ADDRESS` struct. The `STOR_ADDRESS` struct
contains an `AddressData` array member containing a `STOR_ADDR_BTL8` struct, which in-turn contains `Path`, `Target` and `Lun` members. The term Path is interchangeable with the terms Bus and Channel. Here we update the use of the `TargetId` variable to use `Target` instead. `Lun` remains the same.

Per `Lun` variable and proposed `Channel` variable which do not use the Id suffix.

<ins>_Fix off-by-one error in `PORT_CONFIGURATION_INFORMATION` members_</ins> 

Fixes off-by one errors in the following `PORT_CONFIGURATION_INFORMATION` members:

 * `MaximumNumberOfTargets`
 * `MaximumNumberOfLogicalUnits`

These members are respectively derived from the `scsi_config.max_target` and `scsi_config.max_lun` `ADAPTER_EXTENSION` struct members via the `VirtIOSCSIConfig` struct, and represent the highest Target and Lun with a zero-based index rather than the number of Targets and Luns. Therefore, we need to add one to this value in order to properly populate the `PORT_CONFIGURATION_INFORMATION` `*NumberOf*` members in `VioScsiFindAdapter()`.

This commit also update the initial check in `VioScsiBuildIo()` to permit a maximum `Target` and `Lun` of zero (0) as can be reported by some hypervisors, e.g. bhyve. More specifically, the previous behaviour would not permit the last Target and Lun to proceed. Some hypervisors will report the installed maximum Target and Lun rather than the theoretical maximum. When the last Target and Lun are processed, e.g. T:L = 0:0 (the common case), the existing check will return early after setting the SRB status to `SRB_STATUS_NO_DEVICE`.

This commit also adds relevant comments.

Fixes #1442

Credit: @hrosenfeld - Hans Rosenfeld

<ins>_Populate `NumberOfBuses` with `scsi_config.max_channel` value_</ins>

Populates the `PORT_CONFIGURATION_INFORMATION` member `NumberOfBuses` found in `VioScsiFindAdapter()` with the value from `scsi_config.max_channel` + 1 as this is a zero-based index of the maximum channel rather than the maximum number of channels. This is the same behaviour as now used for Target and Lun.

Whilst Storport permits `SCSI_MAXIMUM_BUSES_PER_ADAPTER` (255) channels, we must limit this to `VIRTIO_SCSI_MAX_BUSES_PER_HBA` (1), which we add in this commit to `vioscsi.h`. This is presently the maximum permitted number of buses in the VirtIO standard. To facilitate the comparison we introduce the new variable `max_channels` of type `UCHAR`.

This commit also updates the initial check in `VioScsiBuildIo()` to use the new variable `Channel` of type `UCHAR`, which we define with `SRB_PATH_ID(Srb)` and compare it with `VIRTIO_SCSI_MAX_BUSES_PER_HBA` rather than `num_queues`, which we previously used in error. Using `Channel` here makes it clearer that we are performing a check to ensure the C:T:L is within bounds (plus a check to ensure the adapter has not been removed).

The reason for the previous use of `num_queues` as a check against the Channel / Bus / Path identified by Storport is unknown. Speculation as to the reason is perhaps due to a confusion with Storport `ConcurrentChannels` or as a result of porting from another Storport driver. Using `num_queues` would also accommodate use of the PDA `BUS IDENTIFIER` per the SAM and the description in the VirtIO standard to set the first byte (representing the Bus) to 1 when used to address a Target and LUN. This is the PDA method for addressing Targets and LUNs in a SCSI domain beyond the current level and is necessary when addressing targets other than LUN 0, i.e. 0:0:0, e.g. 0:1:0. However, Storport never calls the `VioScsiBuildIo()` routine with a `Path` greater than zero, but rather we use this technique to create SCSI commands for addressable targets in the initial steps to build the I/O request.

Trace messages are added for when the adapter has been removed or the device is not present. The Storport addressing jargon BTL8 is used, noting C:T:L and BTL8 addressing are synonymous with each other.

This commit also updates relevant comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCSI device discovery by correctly honoring the bus, target, and LUN limits reported by the VirtIO configuration.
  * Added validation for channel, target, and LUN values to prevent unsupported requests.
  * Unsupported requests continue to complete with the appropriate “no device” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->