### PR TITLE
[vioscsi] Limit maximum LUN index in TransportReset() and ParamChange()

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1783,7 +1783,20 @@ VOID LogError(IN PVOID DeviceExtension, IN ULONG ErrorCode, IN ULONG UniqueId)
 VOID TransportReset(IN PVOID DeviceExtension, IN PVirtIOSCSIEvent evt)
 {
     UCHAR TargetId = evt->lun[1];
-    UCHAR Lun = (evt->lun[2] << 8) | evt->lun[3];
+    USHORT lun_candidate = (evt->lun[2] << 8) | evt->lun[3];
+    if (lun_candidate >= SCSI_MAXIMUM_LUNS_PER_TARGET)
+    {
+        RhelDbgPrint(TRACE_LEVEL_WARNING,
+                     " The LUN specified (%u) is out-of-bounds."
+                     " Storport can only address a maximum of %d LUNs."
+                     " The event reason was 0x%x."
+                     " Returning...\n",
+                     lun_candidate,
+                     SCSI_MAXIMUM_LUNS_PER_TARGET,
+                     evt->reason);
+        return;
+    }
+    UCHAR Lun = (UCHAR)lun_candidate;
     ENTER_FN();
 
     switch (evt->reason)
@@ -1803,7 +1816,20 @@ VOID TransportReset(IN PVOID DeviceExtension, IN PVirtIOSCSIEvent evt)
 VOID ParamChange(IN PVOID DeviceExtension, IN PVirtIOSCSIEvent evt)
 {
     UCHAR TargetId = evt->lun[1];
-    UCHAR Lun = (evt->lun[2] << 8) | evt->lun[3];
+    USHORT lun_candidate = (evt->lun[2] << 8) | evt->lun[3];
+    if (lun_candidate >= SCSI_MAXIMUM_LUNS_PER_TARGET)
+    {
+        RhelDbgPrint(TRACE_LEVEL_WARNING,
+                     " The LUN specified (%u) is out-of-bounds."
+                     " Storport can only address a maximum of %d LUNs."
+                     " The event reason was 0x%x."
+                     " Returning...\n",
+                     lun_candidate,
+                     SCSI_MAXIMUM_LUNS_PER_TARGET,
+                     evt->reason);
+        return;
+    }
+    UCHAR Lun = (UCHAR)lun_candidate;
     UCHAR AdditionalSenseCode = (UCHAR)(evt->reason & 255);
     UCHAR AdditionalSenseCodeQualifier = (UCHAR)(evt->reason >> 8);
     ENTER_FN();


### PR DESCRIPTION
The `Lun` variable in `TransportReset()` and `ParamChange()` is rightly declared as a UCHAR value. However, the value is derived from two UCHAR members of a `VirtIOSCSIEvent` struct (`lun[2]` and `lun[3]`). When the `lun[2]` member is left shifted 8 bits it is promoted to type USHORT, and then bitwise OR'ed with `lun[3]`. This leads to an integer truncation if the LUN index is greater than 256. Whilst Storport does not support more than 255 LUNs per Target as defined by `SCSI_MAXIMUM_LUNS_PER_TARGET`, a malicious or misconfigured hypervisor could send an event for a higher LUN index. In `TransportReset()` this could result in another LUN being reset, and in `ParamChange()` this could result in processing parameter changes for the wrong LUN.

The solution in this commit is to first obtain the LUN index via new USHORT variable `lun_candidate` and then check if it is within the bounds of `SCSI_MAXIMUM_LUNS_PER_TARGET`. If out-of-bounds, we log a warning message - including the reason for the event - and return without further processing. Otherwise we cast `lun_candidate` to `Lun` as a UCHAR and continue.