### PR TITLE
[vioscsi] Fix potential typecast overflow error casting to num_queues

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -439,7 +439,7 @@ VioScsiFindAdapter(IN PVOID DeviceExtension,
     }
     else
     {
-        adaptExt->num_queues = min(adaptExt->num_queues, (USHORT)num_cpus);
+        adaptExt->num_queues = min(adaptExt->num_queues, num_cpus);
     }
 
     adaptExt->action_on_reset = VioscsiResetCompleteRequests;
@@ -665,7 +665,7 @@ VioScsiHwInitialize(IN PVOID DeviceExtension)
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Queues %d msix_vectors %d\n", adaptExt->num_queues, adaptExt->msix_vectors);
     if (adaptExt->num_queues > 1 && ((adaptExt->num_queues + 3) > adaptExt->msix_vectors))
     {
-        adaptExt->num_queues = (USHORT)adaptExt->msix_vectors;
+        adaptExt->num_queues = adaptExt->msix_vectors;
     }
 
     if (!adaptExt->dump_mode && adaptExt->msix_vectors > 0)


### PR DESCRIPTION
Fixes a potential typecast overflow error casting to `num_queues` caused when `num_queues` was updated to a ULONG from USHORT. The objects being cast are the ULONG variable `num_cpus` in `VioScsiFindAdapter()`, and the ULONG struct member `msix_vectors` from `ADAPTER_EXTENSION` accessed in `VioScsiHwInitialize()`. Removal of the cast is all that is necessary to avoid any potential typecast overflow error. It is noteworthy that the overflow error could presently only occur if `MAX_CPU` was ever increased to 65,536, which is very unlikely.