### PR TITLE
[viostor] Fixup VirtIoAdapterControl()

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1292,6 +1292,7 @@ VirtIoAdapterControl(IN PVOID DeviceExtension, IN SCSI_ADAPTER_CONTROL_TYPE Cont
     SupportedControlTypes[ScsiQuerySupportedControlTypes] = TRUE;
     SupportedControlTypes[ScsiStopAdapter] = TRUE;
     SupportedControlTypes[ScsiRestartAdapter] = TRUE;
+    SupportedControlTypes[ScsiAdapterSurpriseRemoval] = TRUE;
 
     switch (ControlType)
     {
@@ -1337,6 +1338,13 @@ VirtIoAdapterControl(IN PVOID DeviceExtension, IN SCSI_ADAPTER_CONTROL_TYPE Cont
                     break;
                 }
                 adaptExt->removed = FALSE;
+                status = ScsiAdapterControlSuccess;
+                break;
+            }
+        case ScsiAdapterSurpriseRemoval:
+            {
+                RhelDbgPrint(TRACE_LEVEL_FATAL, " ScsiAdapterSurpriseRemoval\n");
+                adaptExt->removed = TRUE;
                 status = ScsiAdapterControlSuccess;
                 break;
             }


### PR DESCRIPTION
Fixes up `VirtIoAdapterControl()`.

**_By commit:_**

<ins>_Cleanup variables_</ins>

Consolidates the `adaptExt` declaration and definition to top of list.

Refactors the `index` variable as `list_idx`.

Also removes unnecessary whitespace in switch-case ladder.


<ins>_Tracing_</ins>

Relocates catch-all Control Type trace message to the default case for unsupported Control Types only.
This is reasonable as all supported Control Types have an identifying trace message anyway.


<ins>_SupportedControlTypes_</ins>

Refactors the `SupportedControlTypes` bit field to use the Storport `ScsiAdapterControlMax` method rather than an explicit BOOLEAN array.


<ins>_Add ScsiAdapterSurpriseRemoval_</ins>

Adds a `ScsiAdapterSurpriseRemoval` Control Type.

**_NOTE:_** Storport does not appear to call the `ScsiAdapterSurpriseRemoval` Control Type on hot-unplug. It calls the `ScsiStopAdapter` Control Type instead. We include this Control Type for completeness.

