### PR TITLE
RHEL-149879: [viostor] Limit num_cpus and max_cpus to MAX_CPU

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -431,8 +431,8 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
     ConfigInfo->NumberOfPhysicalBreaks++;
     adaptExt->max_tx_length = ConfigInfo->MaximumTransferLength;
 
-    num_cpus = KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
-    max_cpus = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);
+    num_cpus = min(KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS), MAX_CPU);
+    max_cpus = min(KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS), MAX_CPU);
     /* Set num_cpus and max_cpus to some sane values, to keep Static Driver Verification happy */
     num_cpus = max(1, num_cpus);
     max_cpus = max(1, max_cpus);


### PR DESCRIPTION
Limits the maxmimum CPU count to the global macro constant `MAX_CPU`.

The bot has identified potential out-of-bounds memory access on systems with > 256 CPUs as `ADAPTER_EXTENSION` members `vq` and `processing_srbs` are limited to MAX_CPU (which is 256) but the `num_queues` is not.

This was previously managed by casting `num_cpus` to `num_queues` as USHORT. PR #1502 removes this cast and reimplements `num_queues` as ULONG.

This PR proposes an alternate solution to limit the `num_queues` member by limiting the `num_cpus` and `max_cpus` variables to MAX_CPU. This seems the appropriate place to limit CPU counts.