### PR TITLE
Remove an oversight from the mergeable RX buffer PR.

### DIFF
--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -68,12 +68,9 @@ class CParaNdisRX : public CParaNdisTemplatePath<CVirtQueue>, public CNdisAlloca
 
 // Maximum mergeable packet size per VirtIO spec: 65562 bytes (including 12-byte header)
 // Required buffers: ceil(65562 / 4096) = 17 PAGE-sized buffers maximum
-#define VIRTIO_NET_MAX_MRG_BUFS   17
+#define VIRTIO_NET_MAX_MRG_BUFS 17
 
-// Merge buffer context structure - pre-allocated to avoid hot-path allocation
-// Maximum PhysicalPages needed: First buffer (2 pages) + additional buffers (16 * 1 page) = 18 pages
-// Note: First buffer has 2 logical pages (PhysicalPages[0] and [1] alias to same physical page)
-#define MAX_MERGED_PHYSICAL_PAGES 18
+    // Merge buffer context structure - pre-allocated to avoid hot-path allocation
     struct _MergeBufferContext
     {
         pRxNetDescriptor BufferSequence[VIRTIO_NET_MAX_MRG_BUFS];
@@ -83,7 +80,7 @@ class CParaNdisRX : public CParaNdisTemplatePath<CVirtQueue>, public CNdisAlloca
         UINT32 TotalPacketLength;
 
         // Pre-allocated array for merged packet assembly (eliminates allocate/copy/free in hot path)
-        tCompletePhysicalAddress PhysicalPages[MAX_MERGED_PHYSICAL_PAGES];
+        tCompletePhysicalAddress PhysicalPages[VIRTIO_NET_MAX_MRG_BUFS];
     } m_MergeContext;
 
     void ReuseReceiveBufferNoLock(pRxNetDescriptor pBuffersDescriptor);


### PR DESCRIPTION
## Background

The `MAX_MERGED_PHYSICAL_PAGES` macro (set to 18) and its associated comment
were left behind from an earlier design iteration.

In the early design, physical page aliasing was used to preserve
`ParaNdis_BindRxBufferToPacket` compatibility: the existing MDL binding
function always started from `PhysicalPages[1]` (legacy design for traditional
mode). By creating an alias where both `PhysicalPages[0]` and `[1]` pointed to
the same physical memory, the function could work correctly for mergeable
buffers without modification, reducing regression risk. This led to the
calculation: first buffer (2 logical pages) + 16 additional buffers = 18 pages.

Later, this approach was replaced by introducing the `FirstRxDataPage` field
(instead of the hardcoded `PARANDIS_FIRST_RX_DATA_PAGE` macro), which provided
a cleaner solution. However, the redundant macro and outdated comment were
overlooked during that change.

## Changes

Remove `MAX_MERGED_PHYSICAL_PAGES` and use `VIRTIO_NET_MAX_MRG_BUFS` (17)
directly, since the final implementation uses exactly 1 page per buffer.