### PR TITLE
[viogpu] BSOD during shutdown: DPC races with virtqueue teardown

### DIFF
--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -3542,7 +3542,9 @@ void VioGpuAdapter::VioGpuAdapterClose()
         m_pVioGpuDod->SetHardwareInit(FALSE);
         m_CtrlQueue.DisableInterrupt();
         m_CursorQueue.DisableInterrupt();
-        KeFlushQueuedDpcs();
+        if (KeGetCurrentIrql() < DISPATCH_LEVEL) {
+            KeFlushQueuedDpcs();
+        }
         virtio_device_reset(&m_VioDev);
         virtio_delete_queues(&m_VioDev);
         m_CtrlQueue.Close();


### PR DESCRIPTION
## Problem

A BSOD can occur during shutdown or power transitions when a queued DPC fires after `VioGpuAdapterClose` has already reset and deleted the virtqueues. The DPC calls into `CtrlQueue::DequeueBuffer`, which reaches `virtqueue_get_buf_split`, and crashes on the freed queue memory. It's a tight race condition; however it can be reproduced by repeatedly rebooting windows from within the OS. Because the crash happens during shutdown, the VM will hang until it is reset.

## Observed stack trace:
```
# Child-SP          RetAddr               Call Site
00 ffffbd86`6d82ec08 fffff807`79a28969    nt!KeBugCheckEx
01 ffffbd86`6d82ec10 fffff807`79a24ac0    nt!KiBugCheckDispatch+0x69
02 ffffbd86`6d82ed50 fffff807`79a24ac0    nt!KiPageFault+0x440
03 ffffbd86`6d82ee00 fffff807`805b7fbc    viogpudo!virtqueue_get_buf_split+0x1c [C:\Users\nielsen\kvm-guest-drivers-windows\VirtIO\VirtIORing.c @ 310]
04 (Inline Function)                     viogpudo!virtqueue_get_buf+0xd [C:\Users\nielsen\kvm-guest-drivers-windows\VirtIO\VirtIO.h @ 77]
05 (Inline Function)                     viogpudo!VioGpuQueue::GetBuf+0x15 [C:\Users\nielsen\kvm-guest-drivers-windows\viogpu\common\viogpu_queue.h @ 180]
06 ffffbd86`6d82ef10 fffff807`805b3ee4    viogpudo!CtrlQueue::DequeueBuffer+0x78 [C:\Users\nielsen\kvm-guest-drivers-windows\viogpu\viogpudo\viogpudo.cpp @ 581]
07 ffffbd86`6d82ef40 fffff807`805b406d    viogpudo!VioGpuAdapter::DpcRoutine+0x198 [C:\Users\nielsen\kvm-guest-drivers-windows\viogpu\viogpudo\viogpudo.cpp @ 3669]
08 ffffbd86`6d82efc0 fffff807`805b3780    viogpudo!VioGpuDod::DpcRoutine+0x59 [C:\Users\nielsen\kvm-guest-drivers-windows\viogpu\viogpudo\viogpudo.cpp @ 1912]
09 ffffbd86`6d82eff0 fffff807`7fc14277    dxgkrnl!DpiFdoDpcForIsr+0x67
0a ffffbd86`6d82f020 fffff807`79912d3c    nt!KiExecuteAllDpcs+0x95c
0b ffffbd86`6d82f070 fffff807`7991190d    nt!KiRetireDpcList+0x25d
0c ffffbd86`6d82f2b0 00000000`00000000    nt!KiIdleLoop+0x9e
```

## Root Cause

`VioGpuAdapterClose` disables interrupts on both queues but does not wait for any already-queued DPCs to complete before tearing down the virtqueues. This leaves a window where a DPC can run against freed queue state.

## Fix

Call `KeFlushQueuedDpcs()` immediately after disabling interrupts and before calling `virtio_device_reset` / `virtio_delete_queues`. This ensures all in-flight DPCs have completed before the queues are torn down.

## Related Issues
Relates to issues described in #1432