### PR TITLE
netkvm: Fix incorrect virtio header access in ProcessMergedBuffers

### DIFF
--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -953,7 +953,7 @@ VOID ParaNdis_ResetRxClassification(PARANDIS_ADAPTER *pContext)
 pRxNetDescriptor CParaNdisRX::ProcessMergedBuffers(pRxNetDescriptor pFirstBuffer, UINT nFullLength)
 {
     // Access mergeable header to get num_buffers
-    virtio_net_hdr_mrg_rxbuf *pMrgHeader = (virtio_net_hdr_mrg_rxbuf *)pFirstBuffer->PhysicalPages[0].Virtual;
+    virtio_net_hdr_mrg_rxbuf *pMrgHeader = (virtio_net_hdr_mrg_rxbuf *)pFirstBuffer->PhysicalPages[pFirstBuffer->HeaderPage].Virtual;
     UINT16 numBuffers = pMrgHeader->num_buffers;
 
     DPrintf(5, "Received packet: length=%u, num_buffers=%u", nFullLength, numBuffers);


### PR DESCRIPTION
## Fix virtio header access in ProcessMergedBuffers for modern devices

### Problem

`ProcessMergedBuffers()` reads `num_buffers` from the wrong memory location on modern virtio devices (traditional mode only).

### Root Cause

The code hardcodes `PhysicalPages[0]`:
```cpp
virtio_net_hdr_mrg_rxbuf *pMrgHeader = 
    (virtio_net_hdr_mrg_rxbuf *)pFirstBuffer->PhysicalPages[0].Virtual;
```

On modern devices (`bAnyLayout=true`) in traditional mode, `HeaderPage=1`, meaning:
- `PhysicalPages[0]` = IndirectArea (not virtio header!)
- `PhysicalPages[1]` = actual data buffer with virtio header

Note: Mergeable mode (`HeaderPage=0`) is unaffected since header is in `PhysicalPages[0]`.

### Why This Bug Went Undetected - The 64KB Coincidence

When indirect is enabled, IndirectArea is populated with `vring_desc`:

```
vring_desc (16 bytes)              virtio_net_hdr_mrg_rxbuf (12 bytes)
┌────────────────────────┐         ┌────────────────────────┐
│ addr     [0-7]  8B     │ ──────► │ flags      [0]    1B   │
│                        │         │ gso_type   [1]    1B   │
│                        │         │ hdr_len    [2-3]  2B   │
│                        │         │ gso_size   [4-5]  2B   │
│                        │         │ csum_start [6-7]  2B   │
├────────────────────────┤         ├────────────────────────┤
│ len      [8-11] 4B     │ ──────► │ csum_offset[8-9]  2B   │
│ = 0x00010000 (65536)   │         │ num_buffers[10-11]2B ◄─┼─ reads here!
├────────────────────────┤         └────────────────────────┘
│ flags    [12-13]       │
│ next     [14-15]       │
└────────────────────────┘
```

- `num_buffers` at offset 10-11 maps to **high 16 bits of `vring_desc.len`**
- With contiguous 64KB allocation (common case): `len = 65536 = 0x00010000`
- High 16 bits = `0x0001` = **1** = correct value for single-buffer packets

### When the Bug Manifests

| Condition | Result |
|-----------|--------|
| Indirect disabled | IndirectArea uninitialized → random garbage |
| Indirect enabled, but 64KB contiguous allocation fails (rare) | `len != 65536` → high 16 bits ≠ 1 |

### Fix

```cpp
virtio_net_hdr_mrg_rxbuf *pMrgHeader = 
    (virtio_net_hdr_mrg_rxbuf *)pFirstBuffer->PhysicalPages[pFirstBuffer->HeaderPage].Virtual;
```

This aligns with the correct pattern in `ParaNdis6_Impl.cpp:1010`.

### Testing

- Verified with packed ring + indirect disabled
- RX works correctly across various packet sizes
