### PR TITLE
netkvm: treat temporary TX queue full as retry, not drop

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -893,6 +893,24 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList &toWaitingList)
 
                 switch (result)
                 {
+                    case SubmitTxPacketResult::SUBMIT_SUCCESS:
+                        // if this NBL finished?
+                        if (!NBLHolder->HaveMappedBuffers())
+                        {
+                            /* We use PeekMappedNBL method to get the current NBL
+                             * that should be processed from the queue, when we finish
+                             * sending all it's NBs, we should pop it from the queue.
+                             */
+                            PopMappedNBL();
+                            toWaitingList.Push(NBLHolder);
+                        }
+                        else
+                        {
+                            // no, keep it in the queue
+                        }
+                        SentOutSomeBuffers = true;
+                        break;
+
                     case SubmitTxPacketResult::SUBMIT_NO_PLACE_IN_QUEUE:
                         NBLHolder->PushMappedNB(NBHolder);
                         HaveBuffers = false;
@@ -900,8 +918,6 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList &toWaitingList)
                         break;
 
                     case SubmitTxPacketResult::SUBMIT_FAILURE:
-                        __fallthrough;
-                    case SubmitTxPacketResult::SUBMIT_SUCCESS:
                         __fallthrough;
                     case SubmitTxPacketResult::SUBMIT_PACKET_TOO_LARGE:
                         // if this NBL finished?
@@ -918,16 +934,8 @@ bool CParaNdisTX::SendMapped(bool IsInterrupt, CRawCNBLList &toWaitingList)
                         {
                             // no, keep it in the queue
                         }
-
-                        if (result == SubmitTxPacketResult::SUBMIT_SUCCESS)
-                        {
-                            SentOutSomeBuffers = true;
-                        }
-                        else
-                        {
-                            CNB::Destroy(NBHolder);
-                            NBLHolder->NBComplete();
-                        }
+                        CNB::Destroy(NBHolder);
+                        NBLHolder->NBComplete();
                         break;
                     default:
                         NETKVM_ASSERT(false);

--- a/NetKVM/Common/ParaNdis_VirtQueue.cpp
+++ b/NetKVM/Common/ParaNdis_VirtQueue.cpp
@@ -272,8 +272,8 @@ SubmitTxPacketResult CTXVirtQueue::SubmitPacket(CNB &NB)
         case SubmitTxPacketResult::SUBMIT_NO_PLACE_IN_QUEUE:
             {
                 KickQueueOnOverflow();
-                // Fall-through
-                __fallthrough;
+                m_Descriptors.Push(TXDescriptor);
+                break;
             }
         case SubmitTxPacketResult::SUBMIT_PACKET_TOO_LARGE:
             __fallthrough;


### PR DESCRIPTION
This series tries to clarify the TX-side handling of SUBMIT_NO_PLACE_IN_QUEUE and align the code flow with that meaning.

My understanding is that SUBMIT_NO_PLACE_IN_QUEUE represents temporary resource pressure (queue full / retry later), not a final transmit failure.
If that interpretation is off, I would really appreciate corrections.

Commit 1
netkvm: do not count temporary TX queue full as packet drop

This commit separates the SUBMIT_NO_PLACE_IN_QUEUE path from drop accounting, so temporary backpressure is not reported as dropped TX packets.

The goal is to avoid misleading TX statistics when packets are retried later instead of being lost.

Commit 2
netkvm: reorder SendMapped switch cases as success/retry/failure

This commit is intended as a readability/maintainability cleanup only (no functional change intended).
It handles SUBMIT_SUCCESS explicitly and orders the switch logic as:

success
retry
failure
This makes the control flow easier to follow and reduces the chance of mixing retry semantics with failure semantics in future changes.

Why these two commits are in one patch series
Both commits address the same semantic point from two angles:

Commit 1 fixes the observable behavior (statistics)
Commit 2 makes the related control flow clearer and easier to maintain
I grouped them together because they are tightly related in intent.
That said, if maintainers prefer the cleanup commit to be split further, I’m happy to reorganize accordingly.

