### PR TITLE
viogpudo: fix hardware cursor when HWCursor=1

### DIFF
--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -482,7 +482,6 @@ NTSTATUS VioGpuDod::QueryAdapterInfo(_In_ CONST DXGKARG_QUERYADAPTERINFO *pQuery
                     pDriverCaps->MaxPointerWidth = POINTER_SIZE;
                     pDriverCaps->MaxPointerHeight = POINTER_SIZE;
                     pDriverCaps->PointerCaps.Color = 1;
-                    pDriverCaps->PointerCaps.MaskedColor = 1;
                 }
                 pDriverCaps->SupportNonVGA = IsVgaDevice();
                 pDriverCaps->SupportSmoothRotation = TRUE;
@@ -3012,7 +3011,6 @@ NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION
         RtlZeroMemory(crsr, sizeof(*crsr));
 
         crsr->hdr.type = VIRTIO_GPU_CMD_MOVE_CURSOR;
-        crsr->resource_id = m_pCursorBuf->GetId();
 
         if (!pSetPointerPosition->Flags.Visible || (UINT)pSetPointerPosition->X > pModeCur->SrcModeWidth ||
             (UINT)pSetPointerPosition->Y > pModeCur->SrcModeHeight || pSetPointerPosition->X < 0 ||
@@ -3026,6 +3024,7 @@ NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION
                       pSetPointerPosition->Flags.Visible,
                       pSetPointerPosition->Flags.Value,
                       pSetPointerPosition->VidPnSourceId));
+            crsr->resource_id = 0;
             crsr->pos.x = 0;
             crsr->pos.y = 0;
         }
@@ -3041,6 +3040,7 @@ NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION
                       pSetPointerPosition->VidPnSourceId,
                       pSetPointerPosition->X,
                       pSetPointerPosition->Y));
+            crsr->resource_id = m_pCursorBuf->GetId();
             crsr->pos.x = pSetPointerPosition->X;
             crsr->pos.y = pSetPointerPosition->Y;
         }

--- a/viogpu/viogpudo/viogpudo.inx
+++ b/viogpu/viogpudo/viogpudo.inx
@@ -67,7 +67,7 @@ HKR,,EventMessageFile,%REG_EXPAND_SZ%,"%%SystemRoot%%\System32\IoLogMsg.dll"
 HKR,,TypesSupported,%REG_DWORD%,7
 
 [VioGpuDod_DeviceSettings]
-HKR,, HWCursor,                    %REG_DWORD%, 0
+HKR,, HWCursor,                    %REG_DWORD%, 1
 HKR,, FlexResolution,              %REG_DWORD%, 1
 HKR,, UsePhysicalMemory,           %REG_DWORD%, 0
 HKR,, UsePresentProgress,          %REG_DWORD%, 0


### PR DESCRIPTION
When HWCursor=1, three issues prevent hardware cursor from working correctly:

**1. MaskedColor declared but not handled → double cursor**

`PointerCaps.MaskedColor = 1` tells Windows the driver supports MaskedColor format, but `UpdateCursor` only handles `Flags.Color`. Windows sends I-Beam, text selection, and other cursors as MaskedColor, which falls through to `STATUS_UNSUCCESSFUL`. This causes Windows to fall back to software cursor rendering while the previous hardware cursor shape remains visible — resulting in a double cursor.

Fix: Remove `MaskedColor` from `PointerCaps`. Windows then converts all cursors to Color (A8R8G8B8) with proper alpha channel, which `UpdateCursor` already handles correctly via `BltBits`.

**2. SetPointerPosition ignores Visible flag → cursor stuck at (0,0)**

`resource_id` is always set to `m_pCursorBuf->GetId()` regardless of the `Visible` flag. When `Visible=FALSE`, the cursor should be hidden per VirtIO GPU spec ("If resource_id is set to 0, the cursor is hidden."), but instead it moves to position (0,0) and remains visible.

Fix: Set `resource_id = 0` when `Visible=FALSE`, and `resource_id = m_pCursorBuf->GetId()` when `Visible=TRUE`.

**3. HWCursor defaults to 0**

With the above two fixes, hardware cursor works correctly. Change the default to 1 to enable it out of the box.

**Testing:**
- Tested on Windows 11 ARM64 (26200.8037) with VirtIO GPU 2D
- Standard arrow, I-Beam, resize handles, web custom cursors (CSS cursor) all render correctly
- Cursor hide/show transitions work properly (e.g., fullscreen video, text input)
- No double cursor artifacts

Signed-off-by: lonefondness.com <support@lonefondness.com>