### PR TITLE
viosock: Fix spec compliance issues in WSP library and socket driver

### DIFF
--- a/viosock/buildAll.bat
+++ b/viosock/buildAll.bat
@@ -5,6 +5,8 @@ call ..\build\build.bat viosock.sln "Win10 Win11" %*
 if errorlevel 1 goto :eof
 call ..\build\build.bat sys\viosock.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :eof
+call ..\build\build.bat lib\viosocklib.vcxproj "Win11_SDV" %*
+if errorlevel 1 goto :eof
 call ..\build\build.bat wsk\wsk.vcxproj "Win11_SDV" %*
 if errorlevel 1 goto :eof
 call ..\build\build.bat viosock-wsk-test\viosock-wsk-test.vcxproj "Win11_SDV" %*

--- a/viosock/lib/native.c
+++ b/viosock/lib/native.c
@@ -34,6 +34,15 @@
 #include "native.tmh"
 #endif
 
+/*
+ * We use Native API functions here because they expose parameters that have
+ * no Win32 equivalent: NtCreateFile allows passing extended attributes (EA)
+ * with socket parameters at file creation time, and NtReadFile/NtWriteFile
+ * allow specifying a ByteOffset required for socket I/O on the underlying
+ * device. NtDeviceIoControlFile returns NTSTATUS directly, which we map to
+ * WSA error codes via NtStatusToWsaError.
+ */
+
 NTSTATUS
 NTAPI
 NtWriteFile(_In_ HANDLE FileHandle,
@@ -72,7 +81,7 @@ NtReadFile(_In_ HANDLE FileHandle,
 #define STATUS_CONNECTION_RESET           ((NTSTATUS)0xC000020DL)
 #define STATUS_LOCAL_DISCONNECT           ((NTSTATUS)0xC000013BL)
 #define STATUS_HOST_UNREACHABLE           ((NTSTATUS)0xC000023DL)
-#define STATUS_IO_TIMEOUT                 ((NTSTATUS)0xc00000b5L)
+#define STATUS_IO_TIMEOUT                 ((NTSTATUS)0xC00000B5L)
 
 INT NtStatusToWsaError(_In_ NTSTATUS Status)
 {
@@ -82,7 +91,6 @@ INT NtStatusToWsaError(_In_ NTSTATUS Status)
         case STATUS_INVALID_PARAMETER:
             wsaError = WSAEINVAL;
             break;
-        case STATUS_TIMEOUT:
         case STATUS_IO_TIMEOUT:
             wsaError = WSAETIMEDOUT;
             break;
@@ -146,8 +154,7 @@ typedef struct _FILE_FULL_EA_INFORMATION
     CHAR EaName[1];
 } FILE_FULL_EA_INFORMATION, *PFILE_FULL_EA_INFORMATION;
 
-HANDLE
-VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErrno)
+_Must_inspect_result_ HANDLE VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErrno)
 {
     HANDLE hFile = INVALID_HANDLE_VALUE;
     NTSTATUS status;
@@ -157,6 +164,8 @@ VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErr
 
     UCHAR EaBuffer[sizeof(FILE_FULL_EA_INFORMATION) + sizeof(*pSocketParams)] = {0};
     PFILE_FULL_EA_INFORMATION pEaBuffer = (PFILE_FULL_EA_INFORMATION)EaBuffer;
+
+    *lpErrno = ERROR_SUCCESS;
 
     if (pSocketParams)
     {
@@ -195,18 +204,21 @@ VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErr
     return hFile;
 }
 
-BOOL VIOSockDeviceControl(_In_ SOCKET s,
-                          _In_ DWORD dwIoControlCode,
-                          _In_reads_bytes_opt_(nInBufferSize) LPVOID lpInBuffer,
-                          _In_ DWORD nInBufferSize,
-                          _Out_writes_bytes_to_opt_(nOutBufferSize, *lpBytesReturned) LPVOID lpOutBuffer,
-                          _In_ DWORD nOutBufferSize,
-                          _Out_opt_ LPDWORD lpBytesReturned,
-                          _Out_ LPINT lpErrno)
+_Must_inspect_result_ BOOL VIOSockDeviceControl(_In_ SOCKET s,
+                                                _In_ DWORD dwIoControlCode,
+                                                _In_reads_bytes_opt_(nInBufferSize) LPVOID lpInBuffer,
+                                                _In_ DWORD nInBufferSize,
+                                                _Out_writes_bytes_to_opt_(nOutBufferSize,
+                                                                          *lpBytesReturned) LPVOID lpOutBuffer,
+                                                _In_ DWORD nOutBufferSize,
+                                                _Out_opt_ LPDWORD lpBytesReturned,
+                                                _Out_ LPINT lpErrno)
 {
     BOOL bRes = TRUE;
     NTSTATUS status;
     IO_STATUS_BLOCK iosb = {0};
+
+    *lpErrno = ERROR_SUCCESS;
 
     if (lpBytesReturned)
     {
@@ -216,6 +228,7 @@ BOOL VIOSockDeviceControl(_In_ SOCKET s,
     HANDLE evt = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (!evt)
     {
+        *lpErrno = ERROR_INTERNAL_ERROR;
         return FALSE;
     }
 
@@ -254,16 +267,18 @@ BOOL VIOSockDeviceControl(_In_ SOCKET s,
     return bRes;
 }
 
-BOOL VIOSockWriteFile(_In_ SOCKET s,
-                      _In_reads_bytes_(nNumberOfBytesToWrite) LPVOID lpBuffer,
-                      _In_ DWORD nNumberOfBytesToWrite,
-                      _Out_opt_ LPDWORD lpNumberOfBytesWritten,
-                      _Out_ LPINT lpErrno)
+_Must_inspect_result_ BOOL VIOSockWriteFile(_In_ SOCKET s,
+                                            _In_reads_bytes_(nNumberOfBytesToWrite) LPVOID lpBuffer,
+                                            _In_ DWORD nNumberOfBytesToWrite,
+                                            _Out_opt_ LPDWORD lpNumberOfBytesWritten,
+                                            _Out_ LPINT lpErrno)
 {
     BOOL bRes = TRUE;
     NTSTATUS status;
     IO_STATUS_BLOCK iosb = {0};
     LARGE_INTEGER liBytesOffset = {0};
+
+    *lpErrno = ERROR_SUCCESS;
 
     if (lpNumberOfBytesWritten)
     {
@@ -273,6 +288,7 @@ BOOL VIOSockWriteFile(_In_ SOCKET s,
     HANDLE evt = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (!evt)
     {
+        *lpErrno = ERROR_INTERNAL_ERROR;
         return FALSE;
     }
 
@@ -301,16 +317,18 @@ BOOL VIOSockWriteFile(_In_ SOCKET s,
     return bRes;
 }
 
-BOOL VIOSockReadFile(_In_ SOCKET s,
-                     _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
-                     _In_ DWORD nNumberOfBytesToRead,
-                     _Out_opt_ LPDWORD lpNumberOfBytesRead,
-                     _Out_ LPINT lpErrno)
+_Must_inspect_result_ BOOL VIOSockReadFile(_In_ SOCKET s,
+                                           _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
+                                           _In_ DWORD nNumberOfBytesToRead,
+                                           _Out_opt_ LPDWORD lpNumberOfBytesRead,
+                                           _Out_ LPINT lpErrno)
 {
     BOOL bRes = TRUE;
     NTSTATUS status;
     IO_STATUS_BLOCK iosb = {0};
     LARGE_INTEGER liBytesOffset = {0};
+
+    *lpErrno = ERROR_SUCCESS;
 
     if (lpNumberOfBytesRead)
     {
@@ -320,6 +338,7 @@ BOOL VIOSockReadFile(_In_ SOCKET s,
     HANDLE evt = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (!evt)
     {
+        *lpErrno = ERROR_INTERNAL_ERROR;
         return FALSE;
     }
 

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -175,7 +175,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockAccept(_In_ SOCKET s,
     return s;
 }
 
-INT WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR lpsaAddress,
+int WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR lpsaAddress,
                                   _In_ DWORD dwAddressLength,
                                   _In_opt_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
                                   _Out_writes_to_(*lpdwAddressStringLength,
@@ -670,17 +670,15 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
     return iRes;
 }
 
-SOCKET
-WSPAPI
-VIOSockJoinLeaf(_In_ SOCKET s,
-                _In_reads_bytes_(namelen) const struct sockaddr FAR *name,
-                _In_ int namelen,
-                _In_opt_ LPWSABUF lpCallerData,
-                _Out_opt_ LPWSABUF lpCalleeData,
-                _In_opt_ LPQOS lpSQOS,
-                _In_opt_ LPQOS lpGQOS,
-                _In_ DWORD dwFlags,
-                _Out_ LPINT lpErrno)
+_Must_inspect_result_ SOCKET WSPAPI VIOSockJoinLeaf(_In_ SOCKET s,
+                                                    _In_reads_bytes_(namelen) const struct sockaddr FAR *name,
+                                                    _In_ int namelen,
+                                                    _In_opt_ LPWSABUF lpCallerData,
+                                                    _Out_opt_ LPWSABUF lpCalleeData,
+                                                    _In_opt_ LPQOS lpSQOS,
+                                                    _In_opt_ LPQOS lpGQOS,
+                                                    _In_ DWORD dwFlags,
+                                                    _Out_ LPINT lpErrno)
 {
     UNREFERENCED_PARAMETER(name);
     UNREFERENCED_PARAMETER(namelen);
@@ -720,7 +718,7 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
                        _Inout_opt_ LPWSAOVERLAPPED lpOverlapped,
                        _In_opt_ LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine,
                        _In_opt_ LPWSATHREADID lpThreadId,
-                       _In_ LPINT lpErrno)
+                       _Out_ LPINT lpErrno)
 {
     int iRes = ERROR_SUCCESS;
     DWORD i, dwNumberOfBytesRecvd = 0;
@@ -843,6 +841,7 @@ static int CopyFromFdSet(_Out_ VIRTIO_VSOCK_FD_SET *Dst, _In_opt_ fd_set *Src)
 {
     UINT i;
 
+    Dst->fd_count = 0;
     if (!Src)
     {
         return 0;
@@ -1097,7 +1096,7 @@ int WSPAPI VIOSockSendTo(_In_ SOCKET s,
 int WSPAPI VIOSockSetSockOpt(_In_ SOCKET s,
                              _In_ int level,
                              _In_ int optname,
-                             _In_reads_bytes_opt_(optlen) const char FAR *optval,
+                             _In_reads_bytes_(optlen) const char FAR *optval,
                              _In_ int optlen,
                              _Out_ LPINT lpErrno)
 {
@@ -1212,7 +1211,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
     return s;
 }
 
-INT WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
+int WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
                                   _In_ INT AddressFamily,
                                   _In_opt_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
                                   _Out_writes_bytes_to_(*lpAddressLength, *lpAddressLength) LPSOCKADDR lpAddress,

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -42,6 +42,14 @@ WSPUPCALLTABLE g_UpcallTable;
 
 C_ASSERT(sizeof(VIOSOCK_PROTOCOL) / sizeof(VIOSOCK_PROTOCOL[0]) <= 0xFF);
 
+__inline int WspError(_Out_ LPINT lpErrno, _In_ INT Errno)
+{
+    *lpErrno = Errno;
+    return SOCKET_ERROR;
+}
+
+#define WSP_ERROR(err) WspError(lpErrno, (err))
+
 _Must_inspect_result_ int WSPAPI WSPStartup(_In_ WORD wVersionRequested,
                                             _In_ LPWSPDATA lpWSPData,
                                             _In_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
@@ -191,8 +199,7 @@ int WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR l
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI
@@ -204,8 +211,7 @@ VIOSockAsyncSelect(_In_ SOCKET s, _In_ HWND hWnd, _In_ unsigned int wMsg, _In_ l
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI VIOSockBind(_In_ SOCKET s,
@@ -220,15 +226,13 @@ int WSPAPI VIOSockBind(_In_ SOCKET s,
     if (namelen < sizeof(SOCKADDR_VM))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!name)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_BIND, (PVOID)name, (DWORD)namelen, NULL, 0, NULL, lpErrno))
@@ -245,8 +249,7 @@ int WSPAPI VIOSockCancelBlockingCall(_Out_ LPINT lpErrno)
 {
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI VIOSockCleanup(_Out_ LPINT lpErrno)
@@ -310,15 +313,13 @@ int WSPAPI VIOSockConnect(_In_ SOCKET s,
     if (namelen < sizeof(SOCKADDR_VM))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!name)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_CONNECT, (PVOID)name, (DWORD)namelen, NULL, 0, NULL, lpErrno))
@@ -341,8 +342,7 @@ int WSPAPI VIOSockDuplicateSocket(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
@@ -372,8 +372,7 @@ int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
     else if (dwBytesReturned != sizeof(NetEvents))
     {
         TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid output len: %d\n", dwBytesReturned);
-        *lpErrno = WSAEINVAL;
-        iRes = SOCKET_ERROR;
+        iRes = WSP_ERROR(WSAEINVAL);
     }
     else
     {
@@ -458,15 +457,13 @@ int WSPAPI VIOSockGetPeerName(_In_ SOCKET s,
     if (!namelen || *namelen < sizeof(SOCKADDR_VM))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!name)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_GET_PEER_NAME, NULL, 0, (PVOID)name, *namelen, (LPDWORD)namelen, lpErrno))
@@ -491,15 +488,13 @@ int WSPAPI VIOSockGetSockName(_In_ SOCKET s,
     if (!namelen || *namelen < sizeof(SOCKADDR_VM))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!name)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_GET_SOCK_NAME, NULL, 0, (PVOID)name, *namelen, (LPDWORD)namelen, lpErrno))
@@ -528,15 +523,13 @@ int WSPAPI VIOSockGetSockOpt(_In_ SOCKET s,
     if (!optlen)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optlen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!optval)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optval\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     Opt.level = level;
@@ -562,8 +555,7 @@ int WSPAPI VIOSockGetSockOpt(_In_ SOCKET s,
     }
     else
     {
-        *lpErrno = WSAEINVAL;
-        return SOCKET_ERROR;
+        iRes = WSP_ERROR(WSAEINVAL);
     }
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
@@ -604,29 +596,25 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
     if (cbInBuffer && !lpvInBuffer)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpvInBuffer\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (cbOutBuffer && !lpvOutBuffer)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpvOutBuffer\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!lpcbBytesReturned)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpcbBytesReturned\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (lpOverlapped || lpCompletionRoutine)
     {
         TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
-        *lpErrno = WSAEOPNOTSUPP;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEOPNOTSUPP);
     }
 
     if (dwIoControlCode == SIO_BSP_HANDLE ||
@@ -641,8 +629,7 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
         }
         else
         {
-            *lpErrno = WSAEFAULT;
-            return SOCKET_ERROR;
+            return WSP_ERROR(WSAEFAULT);
         }
     }
 
@@ -733,15 +720,13 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
     if (lpOverlapped || lpCompletionRoutine)
     {
         TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
-        *lpErrno = WSAEOPNOTSUPP;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEOPNOTSUPP);
     }
 
     if (!lpBuffers)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpBuffers\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     for (i = 0; i < dwBufferCount; ++i)
@@ -795,8 +780,7 @@ int WSPAPI VIOSockRecvDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpInboundDisco
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI VIOSockRecvFrom(_In_ SOCKET s,
@@ -897,39 +881,34 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
     if (!readfds && !writefds && !exceptfds)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "All three descriptor parameters are NULL\n");
-        *lpErrno = WSAEINVAL;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEINVAL);
     }
 
     iReadCount = CopyFromFdSet(&Select.Fdss[FDSET_READ], readfds);
     if (iReadCount == SOCKET_ERROR)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid readfds parameter\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     iWriteCount = CopyFromFdSet(&Select.Fdss[FDSET_WRITE], writefds);
     if (iWriteCount == SOCKET_ERROR)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid writefds parameter\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     iExceptCount = CopyFromFdSet(&Select.Fdss[FDSET_EXCPT], exceptfds);
     if (iExceptCount == SOCKET_ERROR)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid exceptfds parameter\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if ((iReadCount + iWriteCount + iExceptCount) > FD_SETSIZE)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Input set is too large\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (timeout)
@@ -972,8 +951,7 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
         else
         {
             TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid output len: %u\n", dwBytesReturned);
-            *lpErrno = WSAEINVAL;
-            iRes = SOCKET_ERROR;
+            iRes = WSP_ERROR(WSAEINVAL);
         }
 
         CloseHandle(hFile);
@@ -1014,15 +992,13 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
     if (lpOverlapped || lpCompletionRoutine)
     {
         TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
-        *lpErrno = WSAEOPNOTSUPP;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEOPNOTSUPP);
     }
 
     if (!lpBuffers)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpBuffers\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     for (i = 0; i < dwBufferCount; ++i)
@@ -1058,8 +1034,7 @@ int WSPAPI VIOSockSendDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpOutboundDisc
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }
 
 int WSPAPI VIOSockSendTo(_In_ SOCKET s,
@@ -1105,15 +1080,13 @@ int WSPAPI VIOSockSetSockOpt(_In_ SOCKET s,
     if (!optlen)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optlen\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     if (!optval)
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optval\n");
-        *lpErrno = WSAEFAULT;
-        return SOCKET_ERROR;
+        return WSP_ERROR(WSAEFAULT);
     }
 
     Opt.level = level;
@@ -1223,6 +1196,5 @@ int WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
 
     TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    *lpErrno = WSAEOPNOTSUPP;
-    return SOCKET_ERROR;
+    return WSP_ERROR(WSAEOPNOTSUPP);
 }

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -111,7 +111,7 @@ _Must_inspect_result_ int WSPAPI WSPStartup(_In_ WORD wVersionRequested,
     lpProcTable->lpWSPSocket = VIOSockSocket;
     lpProcTable->lpWSPStringToAddress = VIOSockStringToAddress;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_INIT, "<-- %s\n", __FUNCTION__);
 
     return ERROR_SUCCESS;
 }
@@ -189,7 +189,7 @@ int WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR l
     UNREFERENCED_PARAMETER(lpszAddressString);
     UNREFERENCED_PARAMETER(lpdwAddressStringLength);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -202,7 +202,7 @@ VIOSockAsyncSelect(_In_ SOCKET s, _In_ HWND hWnd, _In_ unsigned int wMsg, _In_ l
     UNREFERENCED_PARAMETER(wMsg);
     UNREFERENCED_PARAMETER(lEvent);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -243,7 +243,7 @@ int WSPAPI VIOSockBind(_In_ SOCKET s,
 
 int WSPAPI VIOSockCancelBlockingCall(_Out_ LPINT lpErrno)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -276,7 +276,7 @@ int WSPAPI VIOSockCloseSocket(_In_ SOCKET s, _Out_ LPINT lpErrno)
 
     *lpErrno = ERROR_SUCCESS;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (!CloseHandle((HANDLE)s))
     {
@@ -285,7 +285,7 @@ int WSPAPI VIOSockCloseSocket(_In_ SOCKET s, _Out_ LPINT lpErrno)
         TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "CloseHandle failed, socket: %p, error: %d\n", (PVOID)s, *lpErrno);
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -323,7 +323,7 @@ int WSPAPI VIOSockConnect(_In_ SOCKET s,
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_CONNECT, (PVOID)name, (DWORD)namelen, NULL, 0, NULL, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -339,7 +339,7 @@ int WSPAPI VIOSockDuplicateSocket(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(dwProcessId);
     UNREFERENCED_PARAMETER(lpProtocolInfo);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -355,7 +355,7 @@ int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
     ULONGLONG ulEvent = (ULONG_PTR)hEventObject;
     VIRTIO_VSOCK_NETWORK_EVENTS NetEvents = {0};
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (!VIOSockDeviceControl(s,
                               IOCTL_SOCKET_ENUM_NET_EVENTS,
@@ -366,7 +366,7 @@ int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
                               &dwBytesReturned,
                               lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
     else if (dwBytesReturned != sizeof(NetEvents))
@@ -394,7 +394,7 @@ int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
         }
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -406,7 +406,7 @@ int WSPAPI VIOSockEventSelect(_In_ SOCKET s,
     int iRes = ERROR_SUCCESS;
     VIRTIO_VSOCK_EVENT_SELECT EventSelect;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     EventSelect.hEventObject = (ULONG_PTR)hEventObject;
     EventSelect.lNetworkEvents = lNetworkEvents;
@@ -420,11 +420,11 @@ int WSPAPI VIOSockEventSelect(_In_ SOCKET s,
                               NULL,
                               lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -440,7 +440,7 @@ BOOL WSPAPI VIOSockGetOverlappedResult(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(fWait);
     UNREFERENCED_PARAMETER(lpdwFlags);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return FALSE;
@@ -471,7 +471,7 @@ int WSPAPI VIOSockGetPeerName(_In_ SOCKET s,
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_GET_PEER_NAME, NULL, 0, (PVOID)name, *namelen, (LPDWORD)namelen, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -504,7 +504,7 @@ int WSPAPI VIOSockGetSockName(_In_ SOCKET s,
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_GET_SOCK_NAME, NULL, 0, (PVOID)name, *namelen, (LPDWORD)namelen, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -553,7 +553,7 @@ int WSPAPI VIOSockGetSockOpt(_In_ SOCKET s,
                               &dwBytesReturned,
                               lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
     else if (dwBytesReturned == sizeof(Opt))
@@ -576,7 +576,7 @@ BOOL WSPAPI VIOSockGetQOSByName(_In_ SOCKET s, _In_ LPWSABUF lpQOSName, _Out_ LP
     UNREFERENCED_PARAMETER(lpQOSName);
     UNREFERENCED_PARAMETER(lpQOS);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return FALSE;
@@ -659,7 +659,7 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
                               lpcbBytesReturned,
                               lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -685,7 +685,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockJoinLeaf(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(lpGQOS);
     UNREFERENCED_PARAMETER(dwFlags);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return INVALID_SOCKET;
@@ -695,15 +695,15 @@ int WSPAPI VIOSockListen(_In_ SOCKET s, _In_ int backlog, _Out_ LPINT lpErrno)
 {
     int iRes = ERROR_SUCCESS;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_LISTEN, &backlog, (DWORD)sizeof(backlog), NULL, 0, NULL, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -723,7 +723,7 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(lpFlags);
     UNREFERENCED_PARAMETER(lpThreadId);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (lpNumberOfBytesRecvd)
     {
@@ -761,14 +761,14 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
                                       &dwNumberOfBytesRead,
                                       lpErrno))
             {
-                TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+                TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
                 iRes = SOCKET_ERROR;
                 break;
             }
         }
         else if (!VIOSockReadFile(s, lpBuffers[i].buf, lpBuffers[i].len, &dwNumberOfBytesRead, lpErrno))
         {
-            TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockReadFile failed: %d\n", *lpErrno);
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockReadFile failed: %d\n", *lpErrno);
             iRes = SOCKET_ERROR;
             break;
         }
@@ -785,7 +785,7 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
         *lpNumberOfBytesRecvd = dwNumberOfBytesRecvd;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -793,7 +793,7 @@ int WSPAPI VIOSockRecvDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpInboundDisco
 {
     UNREFERENCED_PARAMETER(lpInboundDisconnectData);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -811,14 +811,14 @@ int WSPAPI VIOSockRecvFrom(_In_ SOCKET s,
                            _In_opt_ LPWSATHREADID lpThreadId,
                            _Out_ LPINT lpErrno)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (lpFromlen)
     {
         _Analysis_assume_(lpFrom != NULL);
         if (VIOSockGetPeerName(s, lpFrom, lpFromlen, lpErrno) == SOCKET_ERROR)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "VIOSockGetPeerName failed: %u\n", *lpErrno);
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetPeerName failed: %u\n", *lpErrno);
             return SOCKET_ERROR;
         }
     }
@@ -961,7 +961,7 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
             else
             {
                 iRes = SOCKET_ERROR;
-                TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+                TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
             }
         }
         else if (dwBytesReturned == sizeof(Select))
@@ -1004,7 +1004,7 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(dwFlags);
     UNREFERENCED_PARAMETER(lpThreadId);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (lpNumberOfBytesSent)
     {
@@ -1048,7 +1048,7 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
         *lpNumberOfBytesSent = dwNumberOfBytesSent;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -1056,7 +1056,7 @@ int WSPAPI VIOSockSendDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpOutboundDisc
 {
     UNREFERENCED_PARAMETER(lpOutboundDisconnectData);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;
@@ -1077,7 +1077,7 @@ int WSPAPI VIOSockSendTo(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(lpTo);
     UNREFERENCED_PARAMETER(iTolen);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     return VIOSockSend(s,
                        lpBuffers,
@@ -1135,7 +1135,7 @@ int WSPAPI VIOSockShutdown(_In_ SOCKET s, _In_ int how, _Out_ LPINT lpErrno)
 {
     int iRes = ERROR_SUCCESS;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_SHUTDOWN, &how, (DWORD)sizeof(how), NULL, 0, NULL, lpErrno))
     {
@@ -1143,7 +1143,7 @@ int WSPAPI VIOSockShutdown(_In_ SOCKET s, _In_ int how, _Out_ LPINT lpErrno)
         iRes = SOCKET_ERROR;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return iRes;
 }
 
@@ -1163,7 +1163,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
     UNREFERENCED_PARAMETER(g);
     UNREFERENCED_PARAMETER(dwFlags);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
     if (af != AF_VSOCK)
     {
@@ -1204,7 +1204,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
         CloseHandle(hFile);
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
     return s;
 }
 
@@ -1221,7 +1221,7 @@ int WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
     UNREFERENCED_PARAMETER(lpAddress);
     UNREFERENCED_PARAMETER(lpAddressLength);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
     *lpErrno = WSAEOPNOTSUPP;
     return SOCKET_ERROR;

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -56,6 +56,11 @@ _Must_inspect_result_ int WSPAPI WSPStartup(_In_ WORD wVersionRequested,
         return WSAVERNOTSUPPORTED;
     }
 
+    if (lpWSPData == NULL || lpProcTable == NULL)
+    {
+        return WSAEFAULT;
+    }
+
     /* Since we only support 2.2, set both wVersion and  */
     /* wHighVersion to 2.2.                              */
 
@@ -72,6 +77,8 @@ _Must_inspect_result_ int WSPAPI WSPStartup(_In_ WORD wVersionRequested,
     StringCbCopy(lpWSPData->szDescription,
                  sizeof(lpWSPData->szDescription) - sizeof(lpWSPData->szDescription[0]),
                  VIOSOCK_PROTOCOL);
+
+    memset(lpProcTable, 0, sizeof(*lpProcTable));
 
     lpProcTable->lpWSPAccept = VIOSockAccept;
     lpProcTable->lpWSPAddressToString = VIOSockAddressToString;
@@ -125,10 +132,17 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockAccept(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
+    if (addr && addrlen && *addrlen < sizeof(SOCKADDR_VM))
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid addrlen\n");
+        *lpErrno = WSAEFAULT;
+        return INVALID_SOCKET;
+    }
+
     if (s == 0 || s == INVALID_SOCKET)
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid listen socket\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid listen socket\n");
+        *lpErrno = WSAENOTSOCK;
         return INVALID_SOCKET;
     }
 
@@ -147,9 +161,14 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockAccept(_In_ SOCKET s,
         TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "g_UpcallTable.lpWPUModifyIFSHandle failed: %u\n", *lpErrno);
         CloseHandle(hFile);
     }
-    else
+    else if (addr && addrlen)
     {
-        VIOSockGetPeerName(s, addr, addrlen, lpErrno);
+        if (VIOSockGetPeerName(s, addr, addrlen, lpErrno) != ERROR_SUCCESS)
+        {
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockGetPeerName failed: %u\n", *lpErrno);
+            s = INVALID_SOCKET;
+            CloseHandle(hFile);
+        }
     }
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
@@ -200,15 +219,23 @@ int WSPAPI VIOSockBind(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    if (namelen < sizeof(SOCKADDR_VM) || !name)
+    if (namelen < sizeof(SOCKADDR_VM))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid namelen\n");
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!name)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
         *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_BIND, (PVOID)name, (DWORD)namelen, NULL, 0, NULL, lpErrno))
     {
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -229,11 +256,14 @@ int WSPAPI VIOSockCleanup(_Out_ LPINT lpErrno)
 {
     int iRes = 0;
 
+    *lpErrno = ERROR_SUCCESS;
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT, "--> %s\n", __FUNCTION__);
 
-    if (InterlockedDecrement(&g_StartupRef) < 0)
+    LONG lRef = InterlockedDecrement(&g_StartupRef);
+    if (lRef < 0)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "Invalid g_StartupRef value: %d\n", g_StartupRef);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "Invalid g_StartupRef value: %d\n", lRef);
 
         *lpErrno = WSANOTINITIALISED;
         iRes = -1;
@@ -247,14 +277,15 @@ int WSPAPI VIOSockCloseSocket(_In_ SOCKET s, _Out_ LPINT lpErrno)
 {
     int iRes = ERROR_SUCCESS;
 
+    *lpErrno = ERROR_SUCCESS;
+
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
     if (!CloseHandle((HANDLE)s))
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "CloseHandle failed, socket: %p\n", (PVOID)s);
-
-        *lpErrno = WSAEINVAL;
+        *lpErrno = WSAENOTSOCK;
         iRes = SOCKET_ERROR;
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "CloseHandle failed, socket: %p, error: %d\n", (PVOID)s, *lpErrno);
     }
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
@@ -281,7 +312,14 @@ int WSPAPI VIOSockConnect(_In_ SOCKET s,
 
     if (namelen < sizeof(SOCKADDR_VM))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid namelen\n");
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!name)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
         *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
@@ -420,10 +458,17 @@ int WSPAPI VIOSockGetPeerName(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    if (*namelen < sizeof(SOCKADDR_VM))
+    if (!namelen || *namelen < sizeof(SOCKADDR_VM))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!name)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -446,10 +491,17 @@ int WSPAPI VIOSockGetSockName(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    if (*namelen < sizeof(SOCKADDR_VM))
+    if (!namelen || *namelen < sizeof(SOCKADDR_VM))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid namelen\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid namelen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!name)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid name\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -478,8 +530,15 @@ int WSPAPI VIOSockGetSockOpt(_In_ SOCKET s,
 
     if (!optlen)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid optlen\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optlen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!optval)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optval\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -545,9 +604,30 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
+    if (cbInBuffer && !lpvInBuffer)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpvInBuffer\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (cbOutBuffer && !lpvOutBuffer)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpvOutBuffer\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!lpcbBytesReturned)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpcbBytesReturned\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
     if (lpOverlapped || lpCompletionRoutine)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Overlapped sockets not supported\n");
+        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
         *lpErrno = WSAEOPNOTSUPP;
         return SOCKET_ERROR;
     }
@@ -556,13 +636,10 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
         //        dwIoControlCode == SIO_BSP_HANDLE_POLL ||
         dwIoControlCode == SIO_BSP_HANDLE_SELECT)
     {
-        if (lpvOutBuffer && cbOutBuffer >= sizeof(s))
+        if (cbOutBuffer >= sizeof(s))
         {
             *(SOCKET *)lpvOutBuffer = s;
-            if (lpcbBytesReturned)
-            {
-                *lpcbBytesReturned = sizeof(s);
-            }
+            *lpcbBytesReturned = sizeof(s);
             return ERROR_SUCCESS;
         }
         else
@@ -660,14 +737,16 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
 
     if (lpOverlapped || lpCompletionRoutine)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Overlapped sockets not supported\n");
+        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
         *lpErrno = WSAEOPNOTSUPP;
         return SOCKET_ERROR;
     }
 
-    if (!dwBufferCount)
+    if (!lpBuffers)
     {
-        return ERROR_SUCCESS;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpBuffers\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
     }
 
     for (i = 0; i < dwBufferCount; ++i)
@@ -739,8 +818,9 @@ int WSPAPI VIOSockRecvFrom(_In_ SOCKET s,
 {
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    if (lpFrom && lpFromlen)
+    if (lpFromlen)
     {
+        _Analysis_assume_(lpFrom != NULL);
         if (VIOSockGetPeerName(s, lpFrom, lpFromlen, lpErrno) == SOCKET_ERROR)
         {
             TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "VIOSockGetPeerName failed: %u\n", *lpErrno);
@@ -818,34 +898,41 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
+    if (!readfds && !writefds && !exceptfds)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "All three descriptor parameters are NULL\n");
+        *lpErrno = WSAEINVAL;
+        return SOCKET_ERROR;
+    }
+
     iReadCount = CopyFromFdSet(&Select.Fdss[FDSET_READ], readfds);
     if (iReadCount == SOCKET_ERROR)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid readfds parameter\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid readfds parameter\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
     iWriteCount = CopyFromFdSet(&Select.Fdss[FDSET_WRITE], writefds);
     if (iWriteCount == SOCKET_ERROR)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid writefds parameter\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid writefds parameter\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
     iExceptCount = CopyFromFdSet(&Select.Fdss[FDSET_EXCPT], exceptfds);
     if (iExceptCount == SOCKET_ERROR)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid exceptfds parameter\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid exceptfds parameter\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
     if ((iReadCount + iWriteCount + iExceptCount) > FD_SETSIZE)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Input set is too large\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Input set is too large\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -930,8 +1017,15 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
 
     if (lpOverlapped || lpCompletionRoutine)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Overlapped sockets not supported\n");
+        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Overlapped sockets not supported\n");
         *lpErrno = WSAEOPNOTSUPP;
+        return SOCKET_ERROR;
+    }
+
+    if (!lpBuffers)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid lpBuffers\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -941,6 +1035,7 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
 
         if (!VIOSockWriteFile(s, lpBuffers[i].buf, lpBuffers[i].len, &dwNumberOfBytesWritten, lpErrno))
         {
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockWriteFile failed: %d\n", *lpErrno);
             iRes = SOCKET_ERROR;
             break;
         }
@@ -1013,8 +1108,15 @@ int WSPAPI VIOSockSetSockOpt(_In_ SOCKET s,
 
     if (!optlen)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid optlen\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optlen\n");
+        *lpErrno = WSAEFAULT;
+        return SOCKET_ERROR;
+    }
+
+    if (!optval)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Invalid optval\n");
+        *lpErrno = WSAEFAULT;
         return SOCKET_ERROR;
     }
 
@@ -1025,7 +1127,7 @@ int WSPAPI VIOSockSetSockOpt(_In_ SOCKET s,
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_SET_SOCK_OPT, &Opt, sizeof(Opt), NULL, 0, NULL, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -1041,7 +1143,7 @@ int WSPAPI VIOSockShutdown(_In_ SOCKET s, _In_ int how, _Out_ LPINT lpErrno)
 
     if (!VIOSockDeviceControl(s, IOCTL_SOCKET_SHUTDOWN, &how, (DWORD)sizeof(how), NULL, 0, NULL, lpErrno))
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         iRes = SOCKET_ERROR;
     }
 
@@ -1067,17 +1169,17 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    if (af != AF_VSOCK || protocol != 0)
+    if (af != AF_VSOCK)
     {
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "Invalid AF!\n");
-        *lpErrno = WSAEINVAL;
+        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Invalid AF!\n");
+        *lpErrno = WSAEAFNOSUPPORT;
         return INVALID_SOCKET;
     }
 
     if (protocol != 0)
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Unsupported protocol\n");
-        *lpErrno = WSAEPROTOTYPE;
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Unsupported protocol\n");
+        *lpErrno = WSAEPROTONOSUPPORT;
         return INVALID_SOCKET;
     }
 
@@ -1087,7 +1189,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
     }
     else
     {
-        TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Unsupported socket type\n");
+        TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Unsupported socket type\n");
         *lpErrno = WSAESOCKTNOSUPPORT;
         return INVALID_SOCKET;
     }

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -871,8 +871,15 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
                                   &dwBytesReturned,
                                   lpErrno))
         {
-            TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
-            iRes = SOCKET_ERROR;
+            if (*lpErrno == WSAETIMEDOUT)
+            {
+                TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "VIOSockDeviceControl timed out\n");
+            }
+            else
+            {
+                iRes = SOCKET_ERROR;
+                TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
+            }
         }
         else if (dwBytesReturned == sizeof(Select))
         {

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -188,26 +188,24 @@ int WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR l
     UNREFERENCED_PARAMETER(lpProtocolInfo);
     UNREFERENCED_PARAMETER(lpszAddressString);
     UNREFERENCED_PARAMETER(lpdwAddressStringLength);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI
 VIOSockAsyncSelect(_In_ SOCKET s, _In_ HWND hWnd, _In_ unsigned int wMsg, _In_ long lEvent, _Out_ LPINT lpErrno)
 {
-    int iRes = -1;
-
     UNREFERENCED_PARAMETER(hWnd);
     UNREFERENCED_PARAMETER(wMsg);
     UNREFERENCED_PARAMETER(lEvent);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return iRes;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI VIOSockBind(_In_ SOCKET s,
@@ -245,11 +243,10 @@ int WSPAPI VIOSockBind(_In_ SOCKET s,
 
 int WSPAPI VIOSockCancelBlockingCall(_Out_ LPINT lpErrno)
 {
-    UNREFERENCED_PARAMETER(lpErrno);
-
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI VIOSockCleanup(_Out_ LPINT lpErrno)
@@ -341,11 +338,11 @@ int WSPAPI VIOSockDuplicateSocket(_In_ SOCKET s,
 {
     UNREFERENCED_PARAMETER(dwProcessId);
     UNREFERENCED_PARAMETER(lpProtocolInfo);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI VIOSockEnumNetworkEvents(_In_ SOCKET s,
@@ -442,11 +439,11 @@ BOOL WSPAPI VIOSockGetOverlappedResult(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(lpcbTransfer);
     UNREFERENCED_PARAMETER(fWait);
     UNREFERENCED_PARAMETER(lpdwFlags);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return FALSE;
 }
 
 int WSPAPI VIOSockGetPeerName(_In_ SOCKET s,
@@ -578,11 +575,11 @@ BOOL WSPAPI VIOSockGetQOSByName(_In_ SOCKET s, _In_ LPWSABUF lpQOSName, _Out_ LP
     UNREFERENCED_PARAMETER(s);
     UNREFERENCED_PARAMETER(lpQOSName);
     UNREFERENCED_PARAMETER(lpQOS);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return FALSE;
 }
 
 int WSPAPI VIOSockIoctl(_In_ SOCKET s,
@@ -687,11 +684,11 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockJoinLeaf(_In_ SOCKET s,
     UNREFERENCED_PARAMETER(lpSQOS);
     UNREFERENCED_PARAMETER(lpGQOS);
     UNREFERENCED_PARAMETER(dwFlags);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return INVALID_SOCKET;
 }
 
 int WSPAPI VIOSockListen(_In_ SOCKET s, _In_ int backlog, _Out_ LPINT lpErrno)
@@ -795,11 +792,11 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
 int WSPAPI VIOSockRecvDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpInboundDisconnectData, _Out_ LPINT lpErrno)
 {
     UNREFERENCED_PARAMETER(lpInboundDisconnectData);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI VIOSockRecvFrom(_In_ SOCKET s,
@@ -1058,11 +1055,11 @@ int WSPAPI VIOSockSend(_In_ SOCKET s,
 int WSPAPI VIOSockSendDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpOutboundDisconnectData, _Out_ LPINT lpErrno)
 {
     UNREFERENCED_PARAMETER(lpOutboundDisconnectData);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s, socket: %p\n", __FUNCTION__, (PVOID)s);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }
 
 int WSPAPI VIOSockSendTo(_In_ SOCKET s,
@@ -1223,9 +1220,9 @@ int WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
     UNREFERENCED_PARAMETER(lpProtocolInfo);
     UNREFERENCED_PARAMETER(lpAddress);
     UNREFERENCED_PARAMETER(lpAddressLength);
-    UNREFERENCED_PARAMETER(lpErrno);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    return ERROR_SUCCESS;
+    *lpErrno = WSAEOPNOTSUPP;
+    return SOCKET_ERROR;
 }

--- a/viosock/lib/viosocklib.h
+++ b/viosock/lib/viosocklib.h
@@ -39,29 +39,29 @@
     }
 #endif
 
-HANDLE
-VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErrno);
+_Must_inspect_result_ HANDLE VIOSockCreateFile(_In_opt_ PVIRTIO_VSOCK_PARAMS pSocketParams, _Out_ LPINT lpErrno);
 
-BOOL VIOSockDeviceControl(_In_ SOCKET s,
-                          _In_ DWORD dwIoControlCode,
-                          _In_reads_bytes_opt_(nInBufferSize) LPVOID lpInBuffer,
-                          _In_ DWORD nInBufferSize,
-                          _Out_writes_bytes_to_opt_(nOutBufferSize, *lpBytesReturned) LPVOID lpOutBuffer,
-                          _In_ DWORD nOutBufferSize,
-                          _Out_opt_ LPDWORD lpBytesReturned,
-                          _Out_ LPINT lpErrno);
+_Must_inspect_result_ BOOL VIOSockDeviceControl(_In_ SOCKET s,
+                                                _In_ DWORD dwIoControlCode,
+                                                _In_reads_bytes_opt_(nInBufferSize) LPVOID lpInBuffer,
+                                                _In_ DWORD nInBufferSize,
+                                                _Out_writes_bytes_to_opt_(nOutBufferSize,
+                                                                          *lpBytesReturned) LPVOID lpOutBuffer,
+                                                _In_ DWORD nOutBufferSize,
+                                                _Out_opt_ LPDWORD lpBytesReturned,
+                                                _Out_ LPINT lpErrno);
 
-BOOL VIOSockWriteFile(_In_ SOCKET s,
-                      _In_reads_bytes_(nNumberOfBytesToWrite) LPVOID lpBuffer,
-                      _In_ DWORD nNumberOfBytesToWrite,
-                      _Out_opt_ LPDWORD lpNumberOfBytesWritten,
-                      _Out_ LPINT lpErrno);
+_Must_inspect_result_ BOOL VIOSockWriteFile(_In_ SOCKET s,
+                                            _In_reads_bytes_(nNumberOfBytesToWrite) LPVOID lpBuffer,
+                                            _In_ DWORD nNumberOfBytesToWrite,
+                                            _Out_opt_ LPDWORD lpNumberOfBytesWritten,
+                                            _Out_ LPINT lpErrno);
 
-BOOL VIOSockReadFile(_In_ SOCKET s,
-                     _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
-                     _In_ DWORD nNumberOfBytesToRead,
-                     _Out_opt_ LPDWORD lpNumberOfBytesRead,
-                     _Out_ LPINT lpErrno);
+_Must_inspect_result_ BOOL VIOSockReadFile(_In_ SOCKET s,
+                                           _Out_writes_bytes_(nNumberOfBytesToRead) LPVOID lpBuffer,
+                                           _In_ DWORD nNumberOfBytesToRead,
+                                           _Out_opt_ LPDWORD lpNumberOfBytesRead,
+                                           _Out_ LPINT lpErrno);
 
 INT NtStatusToWsaError(_In_ NTSTATUS Status);
 
@@ -74,7 +74,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockAccept(_In_ SOCKET s,
                                                   _In_opt_ DWORD_PTR dwCallbackData,
                                                   _Out_ LPINT lpErrno);
 
-INT WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR lpsaAddress,
+int WSPAPI VIOSockAddressToString(_In_reads_bytes_(dwAddressLength) LPSOCKADDR lpsaAddress,
                                   _In_ DWORD dwAddressLength,
                                   _In_opt_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
                                   _Out_writes_to_(*lpdwAddressStringLength,
@@ -158,17 +158,15 @@ int WSPAPI VIOSockIoctl(_In_ SOCKET s,
                         _In_opt_ LPWSATHREADID lpThreadId,
                         _Out_ LPINT lpErrno);
 
-SOCKET
-WSPAPI
-VIOSockJoinLeaf(_In_ SOCKET s,
-                _In_reads_bytes_(namelen) const struct sockaddr FAR *name,
-                _In_ int namelen,
-                _In_opt_ LPWSABUF lpCallerData,
-                _Out_opt_ LPWSABUF lpCalleeData,
-                _In_opt_ LPQOS lpSQOS,
-                _In_opt_ LPQOS lpGQOS,
-                _In_ DWORD dwFlags,
-                _Out_ LPINT lpErrno);
+_Must_inspect_result_ SOCKET WSPAPI VIOSockJoinLeaf(_In_ SOCKET s,
+                                                    _In_reads_bytes_(namelen) const struct sockaddr FAR *name,
+                                                    _In_ int namelen,
+                                                    _In_opt_ LPWSABUF lpCallerData,
+                                                    _Out_opt_ LPWSABUF lpCalleeData,
+                                                    _In_opt_ LPQOS lpSQOS,
+                                                    _In_opt_ LPQOS lpGQOS,
+                                                    _In_ DWORD dwFlags,
+                                                    _Out_ LPINT lpErrno);
 
 int WSPAPI VIOSockListen(_In_ SOCKET s, _In_ int backlog, _Out_ LPINT lpErrno);
 
@@ -180,7 +178,7 @@ int WSPAPI VIOSockRecv(_In_ SOCKET s,
                        _Inout_opt_ LPWSAOVERLAPPED lpOverlapped,
                        _In_opt_ LPWSAOVERLAPPED_COMPLETION_ROUTINE lpCompletionRoutine,
                        _In_opt_ LPWSATHREADID lpThreadId,
-                       _In_ LPINT lpErrno);
+                       _Out_ LPINT lpErrno);
 
 int WSPAPI VIOSockRecvDisconnect(_In_ SOCKET s, _In_opt_ LPWSABUF lpInboundDisconnectData, _Out_ LPINT lpErrno);
 
@@ -230,7 +228,7 @@ int WSPAPI VIOSockSendTo(_In_ SOCKET s,
 int WSPAPI VIOSockSetSockOpt(_In_ SOCKET s,
                              _In_ int level,
                              _In_ int optname,
-                             _In_reads_bytes_opt_(optlen) const char FAR *optval,
+                             _In_reads_bytes_(optlen) const char FAR *optval,
                              _In_ int optlen,
                              _Out_ LPINT lpErrno);
 
@@ -244,7 +242,7 @@ _Must_inspect_result_ SOCKET WSPAPI VIOSockSocket(_In_ int af,
                                                   _In_ DWORD dwFlags,
                                                   _Out_ LPINT lpErrno);
 
-INT WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
+int WSPAPI VIOSockStringToAddress(_In_ LPWSTR AddressString,
                                   _In_ INT AddressFamily,
                                   _In_opt_ LPWSAPROTOCOL_INFOW lpProtocolInfo,
                                   _Out_writes_bytes_to_(*lpAddressLength, *lpAddressLength) LPSOCKADDR lpAddress,

--- a/viosock/sys/Loopback.c
+++ b/viosock/sys/Loopback.c
@@ -100,7 +100,7 @@ _Requires_lock_not_held_(pListenSocket->RxLock) static NTSTATUS VIOSockLoopbackA
         InsertTailList(&pListenSocket->AcceptList, &pAccept->ListEntry);
         WdfSpinLockRelease(pListenSocket->RxLock);
 
-        VIOSockEventSetBit(pListenSocket, FD_ACCEPT_BIT, STATUS_SUCCESS);
+        VIOSockEventSetBitLocked(pListenSocket, FD_ACCEPT_BIT, STATUS_SUCCESS);
         status = STATUS_PENDING;
     }
     else
@@ -220,6 +220,7 @@ _Requires_lock_not_held_(pDestSocket->StateLock) static NTSTATUS VIOSockLoopback
                     pDestSocket->LoopbackSocket = pSrcSocket->ThisSocket;
                     VioSockReference(pDestSocket->LoopbackSocket);
 
+                    ASSERT(bTxHasSpace);
                     WdfSpinLockAcquire(pDestSocket->StateLock);
                     VIOSockStateSet(pDestSocket, VIOSOCK_STATE_CONNECTED);
                     VIOSockEventSetBit(pDestSocket, FD_CONNECT_BIT, STATUS_SUCCESS);

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -745,8 +745,8 @@ _Requires_lock_not_held_(pListenSocket->RxLock) VOID VIOSockAcceptRemovePkt(IN P
     WdfSpinLockRelease(pListenSocket->RxLock);
 }
 
-NTSTATUS
-VIOSockAcceptInitSocket(PSOCKET_CONTEXT pAcceptSocket, PSOCKET_CONTEXT pListenSocket)
+_Requires_lock_not_held_(pListenSocket->StateLock) NTSTATUS VIOSockAcceptInitSocket(PSOCKET_CONTEXT pAcceptSocket,
+                                                                                    PSOCKET_CONTEXT pListenSocket)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
@@ -762,9 +762,18 @@ VIOSockAcceptInitSocket(PSOCKET_CONTEXT pAcceptSocket, PSOCKET_CONTEXT pListenSo
 
     pAcceptSocket->buf_alloc = pListenSocket->buf_alloc;
 
-    VIOSockStateSetLocked(pAcceptSocket, VIOSOCK_STATE_CONNECTED);
+    WdfSpinLockAcquire(pListenSocket->StateLock);
+    pAcceptSocket->EventsMask = ~FD_ACCEPT & pListenSocket->EventsMask;
+    if (pAcceptSocket->EventsMask && pListenSocket->EventObject)
+    {
+        ObReferenceObject(pListenSocket->EventObject);
+        pAcceptSocket->EventObject = pListenSocket->EventObject;
+    }
+    WdfSpinLockRelease(pListenSocket->StateLock);
+
+    VIOSockStateSet(pAcceptSocket, VIOSOCK_STATE_CONNECTED);
     status = VIOSockSendResponse(pAcceptSocket);
-    VIOSockEventSetBit(pListenSocket, FD_ACCEPT_BIT, status);
+    VIOSockEventSetBit(pAcceptSocket, FD_WRITE_BIT, status);
 
     return status;
 }


### PR DESCRIPTION
Fix several Winsock SPI spec compliance and code quality issues in viosocklib and the viosock kernel driver.

viosock driver:
- VIOSockAcceptInitSocket: do not signal FD_ACCEPT on accepted sockets (semantically wrong); inherit event object and mask from listening socket per WSAEventSelect spec; unconditionally signal FD_WRITE on accepted sockets per spec

viosocklib:
- VIOSockSelect: return 0 on timeout instead of SOCKET_ERROR/WSAETIMEDOUT, per select spec
- Add parameter validation across WSP functions; return WSAEFAULT/WSAEINVAL per spec for invalid arguments
- Fix stub WSP functions returning ERROR_SUCCESS without setting lpErrno; unsupported operations now return WSAEOPNOTSUPP
- native.c: remove dead case STATUS_TIMEOUT in NtStatusToWsaError (I/O timeouts produce STATUS_IO_TIMEOUT, not STATUS_TIMEOUT); add annotations
- Adjust trace levels: VERBOSE for function entry/exit, INFORMATION for validation errors
- Add WspError() helper and WSP_ERROR() macro to unify error returns (last commit, can be dropped independently)
- Enable Win11_SDV static analysis build for viosocklib
