### PR TITLE
RHEL-137735: Fix critical event size validation bug

### DIFF
--- a/viosock/sys/Evt.c
+++ b/viosock/sys/Evt.c
@@ -158,9 +158,13 @@ _IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockEvtVqProcess(IN PDEVICE_CONTEXT 
         {
             /* Drop short/long events */
 
-            if (len != sizeof(pEvt))
+            if (len != sizeof(VIRTIO_VSOCK_EVENT))
             {
-                TraceEvents(TRACE_LEVEL_ERROR, DBG_HW_ACCESS, "Invalid event\n");
+                TraceEvents(TRACE_LEVEL_ERROR,
+                            DBG_HW_ACCESS,
+                            "Invalid event received, received %u bytes\n, expected %u bytes\n",
+                            len,
+                            sizeof(VIRTIO_VSOCK_EVENT));
             }
             else
             {


### PR DESCRIPTION
This error will prevent user from connecting to the VM after migration, and restarting the VM will cause a BSOD.