### PR TITLE
NetKVM: negotiate mergeable buffers based on adapter setting

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -404,7 +404,7 @@ static bool ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
                                      CheckOSNdisVersion(6, bPollModeTestOnWin11 ? 85 : 89);
 #endif
             // Allow fallback to non-mergeable buffers via registry.
-            // Setting MergeableBuffers=0 disables the feature even if device supports it.
+            // Setting MergeableBuffers=0 prevents negotiating the mergeable RX buffers feature.
             pContext->bMergeableBuffersConfigured = pConfiguration->MergeableBuffers.ulValue != 0;
 
             if (!pContext->bDoSupportPriority)
@@ -898,14 +898,12 @@ NDIS_STATUS ParaNdis_InitializeContext(PARANDIS_ADAPTER *pContext, PNDIS_RESOURC
         InitializeMAC(pContext, CurrentMAC);
         InitializeMaxMTUConfig(pContext);
 
-        // Always ACK VIRTIO_NET_F_MRG_RXBUF if suggested by the device for compatibility.
-        // Registry setting bMergeableBuffersConfigured controls whether we use small 4KB buffers
-        // or traditional large buffers.
-        pContext->bUseMergedBuffers = AckFeature(pContext, VIRTIO_NET_F_MRG_RXBUF);
-        if (!pContext->bMergeableBuffersConfigured && pContext->bUseMergedBuffers)
+        // ACK VIRTIO_NET_F_MRG_RXBUF conditionally to align with VirtIO spec.
+        pContext->bUseMergedBuffers = pContext->bMergeableBuffersConfigured &&
+                                      AckFeature(pContext, VIRTIO_NET_F_MRG_RXBUF);
+        if (!pContext->bMergeableBuffersConfigured)
         {
-            DPrintf(0,
-                    "Mergeable buffers feature ACKed, but disabled by configuration (using traditional large buffers)");
+            DPrintf(5, "Mergeable buffers disabled by configuration");
         }
         pContext->nVirtioHeaderSize = (pContext->bUseMergedBuffers) ? sizeof(virtio_net_hdr_mrg_rxbuf)
                                                                     : sizeof(virtio_net_hdr);

--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -289,8 +289,7 @@ error_exit:
 
 pRxNetDescriptor CParaNdisRX::CreateRxDescriptorOnInit()
 {
-    if (m_Context->bUseMergedBuffers && m_Context->bMergeableBuffersConfigured && m_Context->bAnyLayout &&
-        m_Context->RxLayout.TotalAllocationsPerBuffer > 1)
+    if (m_Context->bUseMergedBuffers && m_Context->bAnyLayout && m_Context->RxLayout.TotalAllocationsPerBuffer > 1)
     {
         DPrintf(5, "Using mergeable buffer allocation");
         return CreateMergeableRxDescriptorOnInit();
@@ -972,21 +971,6 @@ pRxNetDescriptor CParaNdisRX::ProcessMergedBuffers(pRxNetDescriptor pFirstBuffer
     m_MergeContext.ExpectedBuffers = numBuffers;
     m_MergeContext.CollectedBuffers = 1;
     m_MergeContext.TotalPacketLength = nFullLength - m_Context->nVirtioHeaderSize;
-
-    if (!m_Context->bMergeableBuffersConfigured)
-    {
-        // Unexpected multi-buffer packet in traditional mode (ACKed for compatibility but no 4KB pool).
-        // Even if the packet is dropped, we MUST drain all remaining descriptors (fragments)
-        // belonging to this packet from the VirtQueue. If we don't, the next GetBuf call would
-        // retrieve a data-only fragment (which has no VirtIO header) and misinterpret it as
-        // the start of a new packet, causing VirtIO protocol desynchronization
-        DPrintf(0, "ERROR: Received merged packet (%u buffers) in traditional mode. Dropping.", numBuffers);
-
-        CollectRemainingMergeBuffers();
-        ReuseCollectedBuffers();
-
-        return NULL;
-    }
 
     DPrintf(5,
             "Multi-buffer packet: expecting %u total buffers, first buffer payload=%u",


### PR DESCRIPTION
Only ACK VIRTIO_NET_F_MRG_RXBUF when the "MergeableBuffers" adapter setting is enabled. ACKing the feature while the adapter setting is disabled is confusing and makes this property inconsistent with other NetKVM offload settings.

In the existing implementation, "MergeableBuffers" is disabled by default, but VIRTIO_NET_F_MRG_RXBUF is still ACKed. In that mode the driver posts traditional RX descriptors while accepting the mergeable-buffer protocol. If the device returns a packet with num_buffers > 1, the packet has to be dropped after draining the remaining buffers.

Avoid that grey area by making the adapter setting control feature negotiation directly. When "MergeableBuffers" is disabled, the driver does not ACK VIRTIO_NET_F_MRG_RXBUF and uses the non-mergeable virtio-net header with the traditional RX descriptor layout.

Note: "MergeableBuffers" should ideally default to enabled, but this patch preserves the existing default of disabled and only makes feature negotiation match that setting.