### PR TITLE
RHEL-173203: viostor: Fix write cache mode detection and allow changing it

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -229,6 +229,18 @@ static ULONG InitVirtIODevice(PVOID DeviceExtension)
     return SP_RETURN_FOUND;
 }
 
+static BOOLEAN HasWritebackCache(PADAPTER_EXTENSION adaptExt)
+{
+    if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_CONFIG_WCE))
+    {
+        UCHAR v;
+        virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, wce), &v, sizeof(v));
+        return !!v;
+    }
+
+    return CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH);
+}
+
 ULONG
 VirtIoFindAdapter(IN PVOID DeviceExtension,
                   IN PVOID HwContext,
@@ -388,8 +400,16 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
     ConfigInfo->MaximumNumberOfTargets = 1;
     ConfigInfo->MaximumNumberOfLogicalUnits = 1;
 
-    ConfigInfo->CachesData = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH) ? TRUE : FALSE;
-    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_BLK_F_WCACHE = %d\n", ConfigInfo->CachesData);
+    /*
+     * With VIRTIO_BLK_F_CONFIG_WCE, CachesData must be TRUE even if the write
+     * cache is currently disabled, because it could be enabled at a later
+     * point.
+     */
+    ConfigInfo->CachesData = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH);
+    adaptExt->writeback_cache = HasWritebackCache(adaptExt);
+
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Writeback cache enabled = %d\n", adaptExt->writeback_cache);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Writeback cache supported = %d\n", ConfigInfo->CachesData);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_BLK_F_MQ = %d\n", CHECKBIT(adaptExt->features, VIRTIO_BLK_F_MQ));
 
     virtio_query_queue_allocation(&adaptExt->vdev,
@@ -608,6 +628,11 @@ VOID RhelSetGuestFeatures(IN PVOID DeviceExtension)
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH))
     {
         guestFeatures |= (1ULL << VIRTIO_BLK_F_FLUSH);
+    }
+
+    if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_CONFIG_WCE))
+    {
+        guestFeatures |= (1ULL << VIRTIO_BLK_F_CONFIG_WCE);
     }
 
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_BARRIER))
@@ -1603,7 +1628,7 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     srbExt->vbr.out_hdr.sector = lba;
     srbExt->vbr.out_hdr.ioprio = 0;
     srbExt->vbr.req = (PVOID)Srb;
-    srbExt->fua = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH) ? (cdb->CDB10.ForceUnitAccess == 1) : FALSE;
+    srbExt->fua = adaptExt->writeback_cache ? (cdb->CDB10.ForceUnitAccess == 1) : FALSE;
 
     if (SRB_FLAGS(Srb) & SRB_FLAGS_DATA_OUT)
     {
@@ -1894,7 +1919,7 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
             memset(cachePage, 0, sizeof(MODE_CACHING_PAGE));
             cachePage->PageCode = MODE_PAGE_CACHING;
             cachePage->PageLength = 10;
-            cachePage->WriteCacheEnable = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH) ? 1 : 0;
+            cachePage->WriteCacheEnable = adaptExt->writeback_cache ? 1 : 0;
 
             SRB_SET_DATA_TRANSFER_LENGTH(Srb, (sizeof(MODE_PARAMETER_HEADER) + sizeof(MODE_CACHING_PAGE)));
         }

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -94,6 +94,8 @@ RhelScsiGetInquiryData(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb);
 
 UCHAR
 RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb);
+UCHAR
+RhelScsiModeSelect(PVOID DeviceExtension, PSRB_TYPE Srb);
 
 UCHAR
 RhelScsiGetCapacity(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb);
@@ -1145,6 +1147,12 @@ VirtIoStartIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
                 CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SrbStatus);
                 return TRUE;
             }
+        case SCSIOP_MODE_SELECT:
+            {
+                UCHAR SrbStatus = RhelScsiModeSelect(DeviceExtension, (PSRB_TYPE)Srb);
+                CompleteRequestWithStatus(DeviceExtension, (PSRB_TYPE)Srb, SrbStatus);
+                return TRUE;
+            }
         case SCSIOP_INQUIRY:
             {
                 UCHAR SrbStatus = RhelScsiGetInquiryData(DeviceExtension, (PSRB_TYPE)Srb);
@@ -1879,13 +1887,22 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     PMODE_PARAMETER_BLOCK blockDescriptor;
     PADAPTER_EXTENSION adaptExt;
 
+    NT_ASSERT(cdb != NULL);
+
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
 
     ModeSenseDataLen = SRB_DATA_TRANSFER_LENGTH(Srb);
 
     SrbStatus = SRB_STATUS_INVALID_REQUEST;
 
-    if (!cdb)
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION,
+                 " MODE SENSE page = 0x%x, subpage = 0x%x, Pc = %d\n",
+                 cdb->MODE_SENSE.PageCode,
+                 cdb->MODE_SENSE.SubPageCode,
+                 cdb->MODE_SENSE.Pc);
+
+    /* We don't support saved values */
+    if (cdb->MODE_SENSE.Pc == 3)
     {
         return SRB_STATUS_ERROR;
     }
@@ -1925,7 +1942,18 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
             memset(cachePage, 0, sizeof(MODE_CACHING_PAGE));
             cachePage->PageCode = MODE_PAGE_CACHING;
             cachePage->PageLength = 10;
-            cachePage->WriteCacheEnable = adaptExt->writeback_cache ? 1 : 0;
+
+            if (cdb->MODE_SENSE.Pc == 1)
+            {
+                /* Changeable bits requested */
+                cachePage->WriteCacheEnable = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_CONFIG_WCE);
+            }
+            else
+            {
+                /* Current status; use it for default status, too */
+                cachePage->WriteCacheEnable = adaptExt->writeback_cache ? 1 : 0;
+            }
+            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " WriteCacheEnable = %d\n", cachePage->WriteCacheEnable);
 
             SRB_SET_DATA_TRANSFER_LENGTH(Srb, (sizeof(MODE_PARAMETER_HEADER) + sizeof(MODE_CACHING_PAGE)));
         }
@@ -1946,6 +1974,10 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
             blockDescriptor = (PMODE_PARAMETER_BLOCK)((unsigned char *)(blockDescriptor) +
                                                       (ULONG)sizeof(MODE_PARAMETER_HEADER));
 
+            /*
+             * cdb->MODE_SENSE.Pc can be ignored because the result is all zeros
+             * both for current values and changable bits.
+             */
             memset(blockDescriptor, 0, sizeof(MODE_PARAMETER_BLOCK));
 
             SRB_SET_DATA_TRANSFER_LENGTH(Srb, (sizeof(MODE_PARAMETER_HEADER) + sizeof(MODE_PARAMETER_BLOCK)));
@@ -1962,6 +1994,53 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     }
 
     return SrbStatus;
+}
+
+UCHAR
+RhelScsiModeSelect(PVOID DeviceExtension, PSRB_TYPE Srb)
+{
+    PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    ULONG srbdatalen = SRB_DATA_TRANSFER_LENGTH(Srb);
+    PMODE_PARAMETER_HEADER header;
+    PMODE_CACHING_PAGE page;
+    UCHAR wce;
+
+    if (!CHECKBIT(adaptExt->features, VIRTIO_BLK_F_CONFIG_WCE))
+    {
+        return SRB_STATUS_INVALID_REQUEST;
+    }
+
+    if (srbdatalen < sizeof(*header))
+    {
+        return SRB_STATUS_INVALID_REQUEST;
+    }
+
+    header = (PMODE_PARAMETER_HEADER)SRB_DATA_BUFFER(Srb);
+
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION,
+                 " MODE SELECT BDLen = %d, srbdatalen = %ld\n",
+                 header->BlockDescriptorLength,
+                 srbdatalen);
+
+    if (srbdatalen < sizeof(*header) + header->BlockDescriptorLength + sizeof(*page))
+    {
+        return SRB_STATUS_INVALID_REQUEST;
+    }
+
+    page = (PMODE_CACHING_PAGE)((PUCHAR)(header + 1) + header->BlockDescriptorLength);
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " MODE SELECT Page = 0x%x\n", page->PageCode);
+
+    if (page->PageCode != MODE_PAGE_CACHING)
+    {
+        return SRB_STATUS_INVALID_REQUEST;
+    }
+
+    wce = !!page->WriteCacheEnable;
+    virtio_set_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, wce), &wce, sizeof(wce));
+    adaptExt->writeback_cache = wce;
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Set writeback cache = %d\n", wce);
+
+    return SRB_STATUS_SUCCESS;
 }
 
 UCHAR

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1890,26 +1890,26 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
         return SRB_STATUS_ERROR;
     }
 
+    if (sizeof(MODE_PARAMETER_HEADER) > ModeSenseDataLen)
+    {
+        SrbStatus = SRB_STATUS_ERROR;
+        return SrbStatus;
+    }
+
+    header = (PMODE_PARAMETER_HEADER)SRB_DATA_BUFFER(Srb);
+
+    memset(header, 0, sizeof(MODE_PARAMETER_HEADER));
+    header->DeviceSpecificParameter = MODE_DSP_FUA_SUPPORTED;
+
+    if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_RO))
+    {
+        header->DeviceSpecificParameter |= MODE_DSP_WRITE_PROTECT;
+    }
+
+    ModeSenseDataLen -= sizeof(MODE_PARAMETER_HEADER);
+
     if ((cdb->MODE_SENSE.PageCode == MODE_PAGE_CACHING) || (cdb->MODE_SENSE.PageCode == MODE_SENSE_RETURN_ALL))
     {
-
-        if (sizeof(MODE_PARAMETER_HEADER) > ModeSenseDataLen)
-        {
-            SrbStatus = SRB_STATUS_ERROR;
-            return SrbStatus;
-        }
-
-        header = (PMODE_PARAMETER_HEADER)SRB_DATA_BUFFER(Srb);
-
-        memset(header, 0, sizeof(MODE_PARAMETER_HEADER));
-        header->DeviceSpecificParameter = MODE_DSP_FUA_SUPPORTED;
-
-        if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_RO))
-        {
-            header->DeviceSpecificParameter |= MODE_DSP_WRITE_PROTECT;
-        }
-
-        ModeSenseDataLen -= sizeof(MODE_PARAMETER_HEADER);
         if (ModeSenseDataLen >= sizeof(MODE_CACHING_PAGE))
         {
 
@@ -1932,23 +1932,6 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     }
     else if (cdb->MODE_SENSE.PageCode == MODE_PAGE_VENDOR_SPECIFIC)
     {
-
-        if (sizeof(MODE_PARAMETER_HEADER) > ModeSenseDataLen)
-        {
-            SrbStatus = SRB_STATUS_ERROR;
-            return SrbStatus;
-        }
-
-        header = (PMODE_PARAMETER_HEADER)SRB_DATA_BUFFER(Srb);
-        memset(header, 0, sizeof(MODE_PARAMETER_HEADER));
-        header->DeviceSpecificParameter = MODE_DSP_FUA_SUPPORTED;
-
-        if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_RO))
-        {
-            header->DeviceSpecificParameter |= MODE_DSP_WRITE_PROTECT;
-        }
-
-        ModeSenseDataLen -= sizeof(MODE_PARAMETER_HEADER);
         if (ModeSenseDataLen >= sizeof(MODE_PARAMETER_BLOCK))
         {
 

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1899,12 +1899,18 @@ RhelScsiGetModeSense(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     header = (PMODE_PARAMETER_HEADER)SRB_DATA_BUFFER(Srb);
 
     memset(header, 0, sizeof(MODE_PARAMETER_HEADER));
-    header->DeviceSpecificParameter = MODE_DSP_FUA_SUPPORTED;
+
+    if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH))
+    {
+        header->DeviceSpecificParameter = MODE_DSP_FUA_SUPPORTED;
+    }
 
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_RO))
     {
         header->DeviceSpecificParameter |= MODE_DSP_WRITE_PROTECT;
     }
+
+    RhelDbgPrint(TRACE_LEVEL_INFORMATION, " DeviceSpecificParameter = 0x%x\n", header->DeviceSpecificParameter);
 
     ModeSenseDataLen -= sizeof(MODE_PARAMETER_HEADER);
 

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -238,6 +238,7 @@ typedef struct _ADAPTER_EXTENSION
     BOOLEAN sn_ok;
     blk_req vbr;
     BOOLEAN indirect;
+    BOOLEAN writeback_cache;
     ULONGLONG lastLBA;
 
     union {


### PR DESCRIPTION
This series improves the write cache mode behaviour of viostor in two ways:

- So far viostor didn't negotiate `VIRTIO_BLK_F_CONFIG_WCE`. QEMU offers `VIRTIO_BLK_F_CONFIG_WCE` by default, which means that it then has no way to communicate "this device can support flushes, but the user wants it to be writethrough at boot". This means that even a cache mode like `cache=directsync` or `cache=writethrough` on the QEMU command line will effectively be overridden and a writeback cache mode will be negotiated.
  
  This changes the driver to use `VIRTIO_BLK_F_CONFIG_WCE` so that the real requested value is read from the config space and these cache modes do what the user would expect them to do.
- Support is added for changing the cache mode at runtime (e.g. for a disk in Disk Management, in Properties / Policy). Note that Windows persists any changes made by the user here, so once the user has manually changed the cache mode from the guest, the cache mode on the QEMU command line will be overridden by Windows on future boots.