### PR TITLE
viosock: Fix socket lifetime races and getsockname() behavior

### DIFF
--- a/viosock/lib/native.c
+++ b/viosock/lib/native.c
@@ -82,12 +82,14 @@ NtReadFile(_In_ HANDLE FileHandle,
 #define STATUS_LOCAL_DISCONNECT           ((NTSTATUS)0xC000013BL)
 #define STATUS_HOST_UNREACHABLE           ((NTSTATUS)0xC000023DL)
 #define STATUS_IO_TIMEOUT                 ((NTSTATUS)0xC00000B5L)
+#define STATUS_INVALID_DEVICE_STATE       ((NTSTATUS)0xC0000184L)
 
 INT NtStatusToWsaError(_In_ NTSTATUS Status)
 {
     INT wsaError = (NT_SUCCESS(Status)) ? ERROR_SUCCESS : ERROR_INTERNAL_ERROR;
     switch (Status)
     {
+        case STATUS_INVALID_DEVICE_STATE:
         case STATUS_INVALID_PARAMETER:
             wsaError = WSAEINVAL;
             break;

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -264,6 +264,7 @@ VIOSockEvtDeviceAdd(IN WDFDRIVER Driver, IN PWDFDEVICE_INIT DeviceInit)
     fileConfig.FileObjectClass = WdfFileObjectWdfCanUseFsContext;
 
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attributes, SOCKET_CONTEXT);
+    Attributes.EvtCleanupCallback = VIOSockObjectCleanup;
 
     WdfDeviceInitSetFileObjectConfig(DeviceInit, &fileConfig, &Attributes);
 

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -673,7 +673,7 @@ static VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt, IN VIRTIO_VSOCK
         ASSERT(pHandleSet[i].Socket);
 
         InterlockedDecrement(&GetSocketContext(pHandleSet[i].Socket)->SelectRefs[iFdSet]); // dereference socket
-        VioSockDereference(pHandleSet[i].Socket);
+        WdfObjectDereference(pHandleSet[i].Socket);
     }
 
     pPkt->FdCount[iFdSet] = 0;

--- a/viosock/sys/Loopback.c
+++ b/viosock/sys/Loopback.c
@@ -161,7 +161,7 @@ static NTSTATUS VIOSockLoopbackConnect(PSOCKET_CONTEXT pSocket)
 {
     NTSTATUS status;
     PDEVICE_CONTEXT pContext = GetDeviceContextFromSocket(pSocket);
-    PSOCKET_CONTEXT pListenSocket = VIOSockBoundFindByPort(pContext, pSocket->dst_port);
+    PSOCKET_CONTEXT pListenSocket = VIOSockBoundFindByPortLocked(pContext, pSocket->dst_port);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -944,12 +944,12 @@ _Requires_lock_not_held_(pContext->RxLock) VOID VIOSockRxVqProcess(IN PDEVICE_CO
         pPkt = CONTAINING_RECORD(RemoveHeadList(&CompletionList), VIOSOCK_RX_PKT, CompletionListEntry);
 
         // find socket
-        pSocket = VIOSockConnectedFindByRxPkt(pContext, &pPkt->Header);
+        pSocket = VIOSockConnectedFindByRxPktLocked(pContext, &pPkt->Header);
         if (!pSocket)
         {
             // no connected socket for incoming packet
             TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "No connected socket found\n");
-            pSocket = VIOSockBoundFindByPort(pContext, pPkt->Header.dst_port);
+            pSocket = VIOSockBoundFindByPortLocked(pContext, pPkt->Header.dst_port);
         }
 
         if (pSocket && pSocket->type != pPkt->Header.type)

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -1913,13 +1913,14 @@ static NTSTATUS VIOSockGetPeerName(IN WDFREQUEST Request, OUT size_t *pLength)
         pAddr->svm_cid = pSocket->dst_cid;
         pAddr->svm_port = pSocket->dst_port;
         *pLength = sizeof(*pAddr);
+        status = STATUS_SUCCESS;
     }
     else
     {
         status = STATUS_INVALID_DEVICE_STATE;
     }
 
-    return STATUS_SUCCESS;
+    return status;
 }
 
 static NTSTATUS VIOSockGetSockName(IN WDFREQUEST Request, OUT size_t *pLength)
@@ -1951,13 +1952,14 @@ static NTSTATUS VIOSockGetSockName(IN WDFREQUEST Request, OUT size_t *pLength)
         pAddr->svm_cid = (ULONG32)pContext->Config.guest_cid;
         pAddr->svm_port = pSocket->src_port;
         *pLength = sizeof(*pAddr);
+        status = STATUS_SUCCESS;
     }
     else
     {
         status = STATUS_INVALID_DEVICE_STATE;
     }
 
-    return STATUS_SUCCESS;
+    return status;
 }
 /*
  * Structure used for manipulating linger option.

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -928,8 +928,6 @@ static NTSTATUS VIOSockAccept(IN HANDLE hListenSocket, IN WDFREQUEST Request)
     {
         PSOCKET_CONTEXT pListenSocket = VIOSockBoundFindByFileLocked(pContext, pFileObj);
 
-        ObDereferenceObject(pFileObj);
-
         if (!pListenSocket)
         {
             TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Listen socket not found\n");
@@ -974,6 +972,9 @@ static NTSTATUS VIOSockAccept(IN HANDLE hListenSocket, IN WDFREQUEST Request)
                 }
             }
         }
+
+        // Keep listen socket file object alive during accept
+        ObDereferenceObject(pFileObj);
     }
     else
     {
@@ -1238,12 +1239,6 @@ VOID VIOSockCleanup(IN WDFFILEOBJECT FileObject)
         WdfRequestComplete(Request, STATUS_CANCELLED);
     }
 
-    if (pSocket->EventObject)
-    {
-        ObDereferenceObject(pSocket->EventObject);
-        pSocket->EventObject = NULL;
-    }
-
     if (pSocket->LoopbackSocket != WDF_NO_HANDLE)
     {
         VioSockDereference(pSocket->LoopbackSocket);
@@ -1262,6 +1257,21 @@ VOID VIOSockCleanup(IN WDFFILEOBJECT FileObject)
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Socket %d closed\n", pSocket->SocketId);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_CREATE_CLOSE, "<-- %s\n", __FUNCTION__);
+}
+
+VOID VIOSockObjectCleanup(IN WDFOBJECT Object)
+{
+    PSOCKET_CONTEXT pSocket = GetSocketContext(Object);
+
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+
+    if (pSocket->EventObject)
+    {
+        ObDereferenceObject(pSocket->EventObject);
+        pSocket->EventObject = NULL;
+    }
+
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "<-- %s\n", __FUNCTION__);
 }
 
 __inline BOOLEAN VIOSockIsGuestAddrValid(IN PSOCKADDR_VM pAddr)

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -338,6 +338,23 @@ _Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindBy
     return VIOSockBoundEnumLocked(pContext, VIOSockFindByFileCallback, pFileObject);
 }
 
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByFileLockedReferenced(
+                                                                                                    IN PDEVICE_CONTEXT pContext,
+                                                                                                    IN PFILE_OBJECT pFileObject)
+{
+    PSOCKET_CONTEXT pSocket;
+
+    WdfSpinLockAcquire(pContext->BoundLock);
+    pSocket = VIOSockBoundEnum(pContext, VIOSockFindByFileCallback, pFileObject);
+    if (pSocket)
+    {
+        WdfObjectReference(pSocket->ThisSocket);
+    }
+    WdfSpinLockRelease(pContext->BoundLock);
+
+    return pSocket;
+}
+
 NTSTATUS
 VIOSockConnectedListInit(IN WDFDEVICE hDevice)
 {
@@ -444,6 +461,23 @@ _Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnect
                                                                                                    IN PFILE_OBJECT pFileObject)
 {
     return VIOSockConnectedEnumLocked(pContext, VIOSockFindByFileCallback, pFileObject);
+}
+
+_Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedFindByFileLockedReferenced(
+                                                                                                    IN PDEVICE_CONTEXT pContext,
+                                                                                                    IN PFILE_OBJECT pFileObject)
+{
+    PSOCKET_CONTEXT pSocket;
+
+    WdfSpinLockAcquire(pContext->ConnectedLock);
+    pSocket = VIOSockConnectedEnum(pContext, VIOSockFindByFileCallback, pFileObject);
+    if (pSocket)
+    {
+        WdfObjectReference(pSocket->ThisSocket);
+    }
+    WdfSpinLockRelease(pContext->ConnectedLock);
+
+    return pSocket;
 }
 
 _Requires_lock_held_(pSocket->StateLock) VIOSOCK_STATE VIOSockStateSet(IN PSOCKET_CONTEXT pSocket,
@@ -2565,17 +2599,16 @@ VIOSockGetSocketFromHandle(IN PDEVICE_CONTEXT pContext, IN ULONGLONG uSocket, IN
 
     if (NT_SUCCESS(status))
     {
-        PSOCKET_CONTEXT pSocket = VIOSockConnectedFindByFileLocked(pContext, pFileObj);
+        PSOCKET_CONTEXT pSocket = VIOSockConnectedFindByFileLockedReferenced(pContext, pFileObj);
         if (!pSocket)
         {
-            pSocket = VIOSockBoundFindByFileLocked(pContext, pFileObj);
+            pSocket = VIOSockBoundFindByFileLockedReferenced(pContext, pFileObj);
         }
 
         ObDereferenceObject(pFileObj);
 
         if (pSocket)
         {
-            VioSockReference(pSocket->ThisSocket);
             return pSocket->ThisSocket;
         }
     }

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -215,7 +215,7 @@ VIOSockBoundAdd(IN PSOCKET_CONTEXT pSocket, IN ULONG32 svm_port)
             svm_port = uSvmPort++;
 
             WdfSpinLockAcquire(pContext->BoundLock);
-            if (!VIOSockBoundFindByPortUnlocked(pContext, svm_port))
+            if (!VIOSockBoundFindByPort(pContext, svm_port))
             {
                 bFound = TRUE;
                 pSocket->src_port = svm_port;
@@ -238,7 +238,7 @@ VIOSockBoundAdd(IN PSOCKET_CONTEXT pSocket, IN ULONG32 svm_port)
     else
     {
         WdfSpinLockAcquire(pContext->BoundLock);
-        if (VIOSockBoundFindByPortUnlocked(pContext, svm_port))
+        if (VIOSockBoundFindByPort(pContext, svm_port))
         {
             TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "Local port %u is already in use\n", svm_port);
             status = STATUS_ADDRESS_ALREADY_ASSOCIATED;
@@ -275,8 +275,9 @@ __inline VOID VIOSockBoundRemove(IN PSOCKET_CONTEXT pSocket)
 
 typedef BOOLEAN (*PSOCKET_CALLBACK)(IN PSOCKET_CONTEXT pSocket, IN PVOID pCallbackContext);
 
-PSOCKET_CONTEXT
-VIOSockBoundEnumUnlocked(IN PDEVICE_CONTEXT pContext, IN PSOCKET_CALLBACK pEnumCallback, IN PVOID pCallbackContext)
+_Requires_lock_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundEnum(IN PDEVICE_CONTEXT pContext,
+                                                                           IN PSOCKET_CALLBACK pEnumCallback,
+                                                                           IN PVOID pCallbackContext)
 {
     PSOCKET_CONTEXT pSocket = NULL;
     ULONG i, ItemCount;
@@ -296,13 +297,14 @@ VIOSockBoundEnumUnlocked(IN PDEVICE_CONTEXT pContext, IN PSOCKET_CALLBACK pEnumC
     return pSocket;
 }
 
-PSOCKET_CONTEXT
-VIOSockBoundEnum(IN PDEVICE_CONTEXT pContext, IN PSOCKET_CALLBACK pEnumCallback, IN PVOID pCallbackContext)
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundEnumLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                     IN PSOCKET_CALLBACK pEnumCallback,
+                                                                                     IN PVOID pCallbackContext)
 {
     PSOCKET_CONTEXT pSocket;
 
     WdfSpinLockAcquire(pContext->BoundLock);
-    pSocket = VIOSockBoundEnumUnlocked(pContext, pEnumCallback, pCallbackContext);
+    pSocket = VIOSockBoundEnum(pContext, pEnumCallback, pCallbackContext);
     WdfSpinLockRelease(pContext->BoundLock);
 
     return pSocket;
@@ -313,16 +315,16 @@ static BOOLEAN VIOSockBoundFindByPortCallback(IN PSOCKET_CONTEXT pSocket, IN PVO
     return pSocket->src_port == (ULONG32)(ULONG_PTR)pCallbackContext;
 }
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByPort(IN PDEVICE_CONTEXT pContext, IN ULONG32 ulSrcPort)
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByPortLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                           IN ULONG32 ulSrcPort)
 {
-    return VIOSockBoundEnum(pContext, VIOSockBoundFindByPortCallback, (PVOID)ulSrcPort);
+    return VIOSockBoundEnumLocked(pContext, VIOSockBoundFindByPortCallback, (PVOID)ulSrcPort);
 }
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByPortUnlocked(IN PDEVICE_CONTEXT pContext, IN ULONG32 ulSrcPort)
+_Requires_lock_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByPort(IN PDEVICE_CONTEXT pContext,
+                                                                                 IN ULONG32 ulSrcPort)
 {
-    return VIOSockBoundEnumUnlocked(pContext, VIOSockBoundFindByPortCallback, (PVOID)ulSrcPort);
+    return VIOSockBoundEnum(pContext, VIOSockBoundFindByPortCallback, (PVOID)ulSrcPort);
 }
 
 static BOOLEAN VIOSockFindByFileCallback(IN PSOCKET_CONTEXT pSocket, IN PVOID pCallbackContext)
@@ -330,10 +332,10 @@ static BOOLEAN VIOSockFindByFileCallback(IN PSOCKET_CONTEXT pSocket, IN PVOID pC
     return WdfFileObjectWdmGetFileObject(pSocket->ThisSocket) == (PFILE_OBJECT)pCallbackContext;
 }
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByFile(IN PDEVICE_CONTEXT pContext, IN PFILE_OBJECT pFileObject)
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByFileLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                           IN PFILE_OBJECT pFileObject)
 {
-    return VIOSockBoundEnum(pContext, VIOSockFindByFileCallback, pFileObject);
+    return VIOSockBoundEnumLocked(pContext, VIOSockFindByFileCallback, pFileObject);
 }
 
 NTSTATUS
@@ -390,13 +392,13 @@ __inline VOID VIOSockConnectedRemove(IN PSOCKET_CONTEXT pSocket)
     WdfSpinLockRelease(pContext->ConnectedLock);
 }
 
-PSOCKET_CONTEXT
-VIOSockConnectedEnum(IN PDEVICE_CONTEXT pContext, IN PSOCKET_CALLBACK pEnumCallback, IN PVOID pCallbackContext)
+_Requires_lock_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedEnum(IN PDEVICE_CONTEXT pContext,
+                                                                                   IN PSOCKET_CALLBACK pEnumCallback,
+                                                                                   IN PVOID pCallbackContext)
 {
     PSOCKET_CONTEXT pSocket = NULL;
     ULONG i, ItemCount;
 
-    WdfSpinLockAcquire(pContext->ConnectedLock);
     ItemCount = WdfCollectionGetCount(pContext->ConnectedList);
     for (i = 0; i < ItemCount; ++i)
     {
@@ -408,6 +410,18 @@ VIOSockConnectedEnum(IN PDEVICE_CONTEXT pContext, IN PSOCKET_CALLBACK pEnumCallb
             break;
         }
     }
+
+    return pSocket;
+}
+
+_Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedEnumLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                             IN PSOCKET_CALLBACK pEnumCallback,
+                                                                                             IN PVOID pCallbackContext)
+{
+    PSOCKET_CONTEXT pSocket;
+
+    WdfSpinLockAcquire(pContext->ConnectedLock);
+    pSocket = VIOSockConnectedEnum(pContext, pEnumCallback, pCallbackContext);
     WdfSpinLockRelease(pContext->ConnectedLock);
 
     return pSocket;
@@ -420,16 +434,16 @@ static BOOLEAN VIOSockConnectedFindByRxPktCallback(IN PSOCKET_CONTEXT pSocket, I
             pPkt->dst_port == pSocket->src_port);
 }
 
-PSOCKET_CONTEXT
-VIOSockConnectedFindByRxPkt(IN PDEVICE_CONTEXT pContext, IN PVIRTIO_VSOCK_HDR pPkt)
+_Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedFindByRxPktLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                                    IN PVIRTIO_VSOCK_HDR pPkt)
 {
-    return VIOSockConnectedEnum(pContext, VIOSockConnectedFindByRxPktCallback, pPkt);
+    return VIOSockConnectedEnumLocked(pContext, VIOSockConnectedFindByRxPktCallback, pPkt);
 }
 
-PSOCKET_CONTEXT
-VIOSockConnectedFindByFile(IN PDEVICE_CONTEXT pContext, IN PFILE_OBJECT pFileObject)
+_Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedFindByFileLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                                   IN PFILE_OBJECT pFileObject)
 {
-    return VIOSockConnectedEnum(pContext, VIOSockFindByFileCallback, pFileObject);
+    return VIOSockConnectedEnumLocked(pContext, VIOSockFindByFileCallback, pFileObject);
 }
 
 _Requires_lock_held_(pSocket->StateLock) VIOSOCK_STATE VIOSockStateSet(IN PSOCKET_CONTEXT pSocket,
@@ -878,7 +892,7 @@ static NTSTATUS VIOSockAccept(IN HANDLE hListenSocket, IN WDFREQUEST Request)
 
     if (NT_SUCCESS(status))
     {
-        PSOCKET_CONTEXT pListenSocket = VIOSockBoundFindByFile(pContext, pFileObj);
+        PSOCKET_CONTEXT pListenSocket = VIOSockBoundFindByFileLocked(pContext, pFileObj);
 
         ObDereferenceObject(pFileObj);
 
@@ -2551,10 +2565,10 @@ VIOSockGetSocketFromHandle(IN PDEVICE_CONTEXT pContext, IN ULONGLONG uSocket, IN
 
     if (NT_SUCCESS(status))
     {
-        PSOCKET_CONTEXT pSocket = VIOSockConnectedFindByFile(pContext, pFileObj);
+        PSOCKET_CONTEXT pSocket = VIOSockConnectedFindByFileLocked(pContext, pFileObj);
         if (!pSocket)
         {
-            pSocket = VIOSockBoundFindByFile(pContext, pFileObj);
+            pSocket = VIOSockBoundFindByFileLocked(pContext, pFileObj);
         }
 
         ObDereferenceObject(pFileObj);

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -321,20 +321,20 @@ VIOSockBoundListInit(IN WDFDEVICE hDevice);
 NTSTATUS
 VIOSockBoundAdd(IN PSOCKET_CONTEXT pSocket, IN ULONG32 svm_port);
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByPort(IN PDEVICE_CONTEXT pContext, IN ULONG32 ulSrcPort);
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByPortLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                           IN ULONG32 ulSrcPort);
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByPortUnlocked(IN PDEVICE_CONTEXT pContext, IN ULONG32 ulSrcPort);
+_Requires_lock_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByPort(IN PDEVICE_CONTEXT pContext,
+                                                                                 IN ULONG32 ulSrcPort);
 
-PSOCKET_CONTEXT
-VIOSockBoundFindByFile(IN PDEVICE_CONTEXT pContext, IN PFILE_OBJECT pFileObject);
+_Requires_lock_not_held_(pContext->BoundLock) PSOCKET_CONTEXT VIOSockBoundFindByFileLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                           IN PFILE_OBJECT pFileObject);
 
 NTSTATUS
 VIOSockConnectedListInit(IN WDFDEVICE hDevice);
 
-PSOCKET_CONTEXT
-VIOSockConnectedFindByRxPkt(IN PDEVICE_CONTEXT pContext, IN PVIRTIO_VSOCK_HDR pPkt);
+_Requires_lock_not_held_(pContext->ConnectedLock) PSOCKET_CONTEXT VIOSockConnectedFindByRxPktLocked(IN PDEVICE_CONTEXT pContext,
+                                                                                                    IN PVIRTIO_VSOCK_HDR pPkt);
 
 _Requires_lock_held_(pSocket->StateLock) VIOSOCK_STATE VIOSockStateSet(IN PSOCKET_CONTEXT pSocket,
                                                                        IN VIOSOCK_STATE NewState);

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -306,6 +306,7 @@ VIOSockInterruptInit(IN WDFDEVICE hDevice);
 // Socket functions
 EVT_WDF_DEVICE_FILE_CREATE VIOSockCreateStub;
 EVT_WDF_FILE_CLEANUP VIOSockCleanup;
+EVT_WDF_OBJECT_CONTEXT_CLEANUP VIOSockObjectCleanup;
 
 NTSTATUS
 VIOSockDeviceControl(IN WDFREQUEST Request, IN ULONG IoControlCode, IN OUT size_t *pLength);


### PR DESCRIPTION
Batch of viosock fixes:

* **Rename collection search functions for consistent lock naming**: preparatory refactor: functions that take the list lock internally get a `Locked` suffix; ones that require the caller to hold it stay unsuffixed. SAL `_Requires_lock_*` annotations added.

* **Fix race in `VIOSockGetSocketFromHandle`**:  two races could BSOD or corrupt data: (1) `WdfObjectReference` could succeed on a socket already being torn down by a concurrent `VIOSockCleanup`; (2) a use-after-free on the `FILE_OBJECT` if the last handle was closed between `ObReferenceObjectByHandle` and `WdfObjectReference`. The WDF reference is now obtained under the list lock and socket state validated before return.

* **Fix lifetime issues in `VIOSockCleanup` / `VIOSockAccept`**: `VIOSockCleanup` cleared `EventObject` without `StateLock` while `VIOSockAcceptInitSocket` reads it under `StateLock`. Closing a listen socket concurrently with an incoming accept could call `ObReferenceObject` / `KeSetEvent` on a stale/NULL pointer. `StateLock` is now held in `VIOSockCleanup` when clearing the field.

* **Fix `GetSockName` / `GetPeerName` always returning `STATUS_SUCCESS`**: per Winsock spec, `getsockname()` on an unbound socket must fail with `WSAEINVAL` and `getpeername()` on an unconnected socket with `WSAENOTCONN`. The driver returned `STATUS_INVALID_DEVICE_STATE` but the userland mapping was missing, so both calls always succeeded with a zero-length `sockaddr_vm`.

* **Map `STATUS_INVALID_DEVICE_STATE` → `WSAEINVAL`** in `NtStatusToWsaError`, completing the fix above.