### PR TITLE
CVE-2026-46655: viosock: Validate fd_count in VIOSockSelect against overflow and empt…

### DIFF
--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -960,6 +960,7 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
     BOOLEAN bIs32BitProcess = FALSE;
     WDF_OBJECT_ATTRIBUTES Attributes;
     PVIOSOCK_SELECT_PKT pPkt = NULL;
+    ULONG fdRead, fdWrite, fdExcpt, uTotalFdCount;
 
     PAGED_CODE();
 
@@ -987,8 +988,19 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
     // minimum length guaranteed by WdfRequestRetrieveInputBuffer above
     _Analysis_assume_(stSelectLen >= sizeof(*pSelect));
 
-    if (FD_SETSIZE <
-        pSelect->Fdss[FDSET_READ].fd_count + pSelect->Fdss[FDSET_WRITE].fd_count + pSelect->Fdss[FDSET_EXCPT].fd_count)
+    fdRead = pSelect->Fdss[FDSET_READ].fd_count;
+    fdWrite = pSelect->Fdss[FDSET_WRITE].fd_count;
+    fdExcpt = pSelect->Fdss[FDSET_EXCPT].fd_count;
+
+    // Validate each fd_count before summing to prevent integer overflow
+    // when these untrusted values are attacker-controlled.
+    if (fdRead > FD_SETSIZE || fdWrite > FD_SETSIZE || fdExcpt > FD_SETSIZE)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    uTotalFdCount = fdRead + fdWrite + fdExcpt;
+    if (uTotalFdCount == 0 || uTotalFdCount > FD_SETSIZE)
     {
         return STATUS_INVALID_PARAMETER;
     }


### PR DESCRIPTION
The previous entry check inspected only the sum of fd_count values in 32-bit arithmetic. An attacker-controlled tuple (e.g. 0xFFFFFFFE + 0x40 + 0x02) wraps the sum to a small non-zero value that passes both the zero and FD_SETSIZE bounds. VIOSockSelectCopyFds then iterates up to fd_count times and writes into pPkt->Fds[FD_SETSIZE], producing an out-of-bounds kernel write.

Validate each per-set fd_count against FD_SETSIZE before summing; the sum is then bounded by 3 * FD_SETSIZE and cannot overflow ULONG.

Also reject the empty fd_set tuple (all three counts zero) with STATUS_INVALID_PARAMETER, matching the documented WSAEINVAL for "all three descriptor parameters were null".

Resolves: CVE-2026-46655