### PR TITLE
netkvm: Fix extra page leak on Enqueue failure causing TX hang

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -1496,6 +1496,13 @@ void CNB::ReturnPages()
 
 NBMappingStatus CNB::AllocateAndFillCopySGL(ULONG ParsedHeadersLength)
 {
+    // If we have already borrowed extra pages,
+    // just return SUCCESS otherwise we will leak these pages.
+    if (m_ExtraNBStorage)
+    {
+        return NBMappingStatus::SUCCESS;
+    }
+
     // Calculate the number of pages needed for data, excluding protocol header length.
     ULONG DataLength = GetDataLength() - ParsedHeadersLength;
     ULONG Pages = (DataLength + PAGE_SIZE - 1) / PAGE_SIZE;


### PR DESCRIPTION
### Summary

In `CTXVirtQueue::SubmitPacket`, when `BindToDescriptor` succeeds via the copy path (borrowing DMA pages from `m_ExtraPages` pool) but the subsequent `Enqueue` fails with `SUBMIT_NO_PLACE_IN_QUEUE`, the borrowed pages are never returned. This causes a progressive depletion of the `m_ExtraPages` pool, ultimately leading to an unrecoverable TX hang.

### Root Cause

When `m_SGL->NumberOfElements > m_VirtioSGLSize` (the NB's scatter-gather list exceeds the descriptor's direct capacity), the driver takes the copy path in `FillDescriptorSGList`:

1. `AllocateAndFillCopySGL` allocates a `CExtendedNBStorage`, borrows N pages from `m_ExtraPages`, and copies packet data into them.
2. `MapCopyDataToVirtioSGL` fills the VirtIO SGL with borrowed page physical addresses.
3. `BindToDescriptor` returns `SUCCESS`.

If `TXDescriptor->Enqueue` then fails (e.g., `FreeDescriptors < m_UsedBuffersNum`), the enqueue failure branch in `SubmitPacket` only pushes the descriptor back and reports failure — **without returning borrowed extra pages**.

The NB (with `m_ExtraNBStorage` still holding borrowed pages) is returned to the caller. In `SendMapped`, the `SUBMIT_NO_PLACE_IN_QUEUE` result causes the NB to be pushed back to the mapped queue for retry. On the next attempt, `AllocateAndFillCopySGL` overwrites `m_ExtraNBStorage` with a new allocation, permanently **leaking the old storage and its borrowed pages**.

Once enough pages leak to make `m_ExtraPages.GetCount() < NeedPages`, every subsequent `BorrowPages` call fails, returning `NO_RESOURCE`. This maps to `SUBMIT_NO_PLACE_IN_QUEUE` in the `BindToDescriptor`-failure branch (which does NOT call `KickQueueOnOverflow`), creating a permanent head-of-line blocking loop:

```
retry same NB → BorrowPages fails → NO_RESOURCE → push NB back → Kick (empty notify) → retry → ...
```

### Steps to Reproduce

1. Use a virtio-net device that does **not** negotiate VIRTIO_RING_F_INDIRECT_DESC (i.e., `bUseIndirect = false`) and does negotiate VIRTIO_NET_F_HOST_TSO4/VIRTIO_NET_F_HOST_TSO6.
2. Make sure that `Offload.Tx.LSO` property of the netkvm driver is enabled.
3. Run a TCP stress test with small application writes to trigger LSO aggregation:
   ```
   iperf3 -c <server_ip> -P 4 -i 1 -l 100 -t 60
   ```
4. The TCP stack aggregates small writes into large LSO segments, producing NBs whose `m_SGL->NumberOfElements` exceeds `m_VirtioSGLSize`, forcing the copy path.
5. Under load, `m_FreeHWBuffers` drops below the required `m_CurrVirtioSGLEntry` for a copy-path packet, triggering `Enqueue → SUBMIT_NO_PLACE_IN_QUEUE`.
6. TX hangs within a few seconds. Network connectivity is permanently lost.

### What was expected

TX queue should never hang.

### What actually happens

- `m_ExtraPages` pool progressively depletes.
- All subsequent copy-path packets fail permanently with `NO_RESOURCE`.
- The queue-head NB is retried infinitely, blocking all other NBs behind it.
- Device-side observes continuous notify signals but no descriptors in the ring.

### Fix

Add guard in `CNB::AllocateAndFillCopySGL` to prevent duplicate allocation of `m_ExtraNBStorage`.

### Notes
- The `~CNB()` destructor contains a safety-net `ReturnPages()` call, but it never triggers in this scenario because the NB is pushed back for retry (not destroyed) on `SUBMIT_NO_PLACE_IN_QUEUE`.
- The page leak via `SUBMIT_NO_PLACE_IN_QUEUE` is easily reproducible in a virtqueue using direct descriptor, where `m_UsedBuffersNum = m_CurrVirtioSGLEntry` can be greater than 1. In indirect mode, `m_UsedBuffersNum` is always 1, making the `FreeDescriptors < m_UsedBuffersNum` condition in `Enqueue` extremely unlikely (would require `m_FreeHWBuffers == 0`, which is prevented by the earlier `m_Descriptors.GetCount()` check in `SubmitPacket`), so the bug is much harder to trigger.