### PR TITLE
﻿netkvm: limit header copy size for UDP and IP checksum offload

### DIFF
--- a/NetKVM/Common/ParaNdis_TX.cpp
+++ b/NetKVM/Common/ParaNdis_TX.cpp
@@ -1291,13 +1291,16 @@ bool CNB::CopyHeaders(PVOID Destination, ULONG MaxSize, ULONG &HeadersLength, UL
     }
     else if (m_ParentNBL->IsUdpCSO())
     {
-        HeadersLength = Copy(Destination, MaxSize);
+        // UDP CSO: need L4HeaderOffset, may be IPv6 with extension headers
+        ULONG MaxNeeded = min(MaxSize, MAX_HEADERS_SIZE_FOR_CSO);
+        HeadersLength = Copy(Destination, MaxNeeded);
         L4HeaderOffset = QueryL4HeaderOffset(Destination, m_Context->Offload.ipHeaderOffset);
     }
     else if (m_ParentNBL->IsIPHdrCSO())
     {
-        HeadersLength = Copy(Destination, MaxSize);
-        L4HeaderOffset = QueryL4HeaderOffset(Destination, m_Context->Offload.ipHeaderOffset);
+        // IP header CSO only: IPv4 only, no L4HeaderOffset needed
+        HeadersLength = min(MaxSize, ETH_HEADER_SIZE + MAX_IPV4_HEADER_SIZE);
+        HeadersLength = Copy(Destination, HeadersLength);
     }
     else
     {

--- a/NetKVM/Common/ethernetutils.h
+++ b/NetKVM/Common/ethernetutils.h
@@ -232,11 +232,16 @@ typedef struct _EthernetNSMFrame
 
 #include <poppack.h>
 
-#define TCP_CHECKSUM_OFFSET   16
-#define UDP_CHECKSUM_OFFSET   6
-#define MAX_IPV4_HEADER_SIZE  60
-#define MAX_TCP_HEADER_SIZE   60
-#define MAX_IP4_DATAGRAM_SIZE 65535
+#define TCP_CHECKSUM_OFFSET        16
+#define UDP_CHECKSUM_OFFSET        6
+#define MAX_IPV4_HEADER_SIZE       60
+#define MAX_TCP_HEADER_SIZE        60
+#define MAX_IP4_DATAGRAM_SIZE      65535
+// till IP header size is 8 bit
+#define MAX_SUPPORTED_IPV6_HEADERS (256 - 4)
+// ETH_HEADER_SIZE(14) + MAX_SUPPORTED_IPV6_HEADERS(252) + sizeof(UDPHeader)(8) = 274
+// Use 288 for 32-byte alignment
+#define MAX_HEADERS_SIZE_FOR_CSO   288
 
 static __inline USHORT swap_short(USHORT us)
 {

--- a/NetKVM/Common/sw_offload.cpp
+++ b/NetKVM/Common/sw_offload.cpp
@@ -33,9 +33,6 @@
 #include "sw_offload.tmh"
 #endif
 
-// till IP header size is 8 bit
-#define MAX_SUPPORTED_IPV6_HEADERS (256 - 4)
-
 // IPv6 Header RFC 2460 (n*8 bytes)
 typedef struct _tagIPv6ExtHeader
 {


### PR DESCRIPTION
For UDP CSO and IP header CSO, `CopyHeaders()` copies the entire packet (up to MaxSize, typically 4KB) just to parse the L4 header offset. This is wasteful since only protocol headers are needed.

**Changes:**

- **UDP CSO path:** Limit the copy size to 288 bytes (ETH header + max IPv6 extension headers + UDP header = 274, rounded to 32-byte alignment). This covers the worst case of IPv6 with extension headers while avoiding a full 4KB copy.

- **IP header CSO path:** Limit the copy size to 74 bytes (ETH header + max IPv4 header = 14 + 60). Also skip the `QueryL4HeaderOffset()` call entirely since `DoIPHdrCSO()` does not need L4 header offset. IPv6 never enters this path because IPv6 has no IP header checksum.

- **New macro:** Add `MAX_HEADERS_SIZE_FOR_CSO` (288) in `ethernetutils.h`.

**Background:**

This is a follow-up optimization noted in commit 1f72e397 ("netkvm: reduce double copy for UDP and IP packets in TX path"), which mentioned: "we actually need from 40 to ~300 bytes to populate IP checksum, so the size of copied data can be reduced."