### PR TITLE
netkvm: fix RX buffer shortage flag being overwritten in RSS path

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -1834,12 +1834,15 @@ static BOOLEAN RxDPCWorkBody(PARANDIS_ADAPTER *pContext, CPUPathBundle *pathBund
 #ifdef PARANDIS_SUPPORT_RSS
     if (CurrCpuReceiveQueue != PARANDIS_RECEIVE_NO_QUEUE)
     {
-        isRxBufferShortage = ProcessReceiveQueue(pContext,
-                                                 &nPacketsToIndicate,
-                                                 &pContext->ReceiveQueues[CurrCpuReceiveQueue],
-                                                 &indicate,
-                                                 &indicateTail,
-                                                 &nIndicate);
+        if (ProcessReceiveQueue(pContext,
+                                &nPacketsToIndicate,
+                                &pContext->ReceiveQueues[CurrCpuReceiveQueue],
+                                &indicate,
+                                &indicateTail,
+                                &nIndicate))
+        {
+            isRxBufferShortage = TRUE;
+        }
         res |= ReceiveQueueHasBuffers(&pContext->ReceiveQueues[CurrCpuReceiveQueue]);
     }
 #endif


### PR DESCRIPTION
In `RxDPCWorkBody()`, packets are processed from two queues sequentially:
1. The **UnclassifiedPacketsQueue** — for packets not classified by RSS (e.g., ARP, broadcast)
2. The **per-CPU RSS receive queue** — for RSS-classified packets (e.g., TCP, UDP)

The `isRxBufferShortage` flag returned by the first `ProcessReceiveQueue()` call was being unconditionally overwritten by the second call using plain assignment (`=`). This means if the first call detected a buffer shortage but the second did not, the shortage condition was silently lost.

As a result, `NdisMIndicateReceiveNetBufferLists()` could be called without the `NDIS_RECEIVE_FLAGS_RESOURCES` flag when it should have been set, preventing immediate RX buffer reclamation under memory pressure.

### When can this happen?

This is a logical bug that has not been observed in production, but can theoretically occur when RSS is enabled and the unclassified queue detects a buffer shortage (e.g., while processing ARP packets), while the RSS per-CPU queue either:
- has no RSS-classified packets for the current CPU at this moment (the while-loop in `ProcessReceiveQueue` does not execute, so it returns the default value FALSE which overwrites the TRUE from the first call), or
- processes packets from a different virtqueue that is not in a shortage state.

### Fix

Change the second assignment from `=` to `|=` so that the shortage status from both queues is properly accumulated.