### PR TITLE
viosock: Fix select correctness, event notification, and socket handle type

### DIFF
--- a/viosock/lib/install.c
+++ b/viosock/lib/install.c
@@ -50,7 +50,7 @@ static WSAPROTOCOL_INFO g_ProtocolInfo = {.dwServiceFlags1 = XP1_GRACEFUL_CLOSE 
                                           .dwCatalogEntryId = 0,
                                           .ProtocolChain.ChainLen = BASE_PROTOCOL,
                                           .ProtocolChain.ChainEntries = {0},
-                                          .iVersion = 0,
+                                          .iVersion = 2,
                                           .iAddressFamily = AF_VSOCK,
                                           .iMaxSockAddr = sizeof(struct sockaddr_in),
                                           .iMinSockAddr = sizeof(struct sockaddr_vm),

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -532,6 +532,18 @@ int WSPAPI VIOSockGetSockOpt(_In_ SOCKET s,
         return WSP_ERROR(WSAEFAULT);
     }
 
+    if (level == SOL_SOCKET && optname == SO_PROTOCOL_INFOW)
+    {
+        if (*optlen < (int)sizeof(WSAPROTOCOL_INFOW))
+        {
+            *optlen = sizeof(WSAPROTOCOL_INFOW);
+            return WSP_ERROR(WSAEFAULT);
+        }
+        memcpy(optval, &g_ProtocolInfo, sizeof(WSAPROTOCOL_INFOW));
+        *optlen = sizeof(WSAPROTOCOL_INFOW);
+        return ERROR_SUCCESS;
+    }
+
     Opt.level = level;
     Opt.optname = optname;
     Opt.optval = (ULONGLONG)optval;

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -247,6 +247,8 @@ VIOSockEvtDeviceAdd(IN WDFDRIVER Driver, IN PWDFDEVICE_INIT DeviceInit)
 
     // Set DirectIO mode
     WdfDeviceInitSetIoType(DeviceInit, WdfDeviceIoDirect);
+    // Valid file type is required for _open_osfhandle
+    WdfDeviceInitSetDeviceType(DeviceInit, FILE_DEVICE_NAMED_PIPE);
 
     // Set device name (for kernel mode clients)
     status = WdfDeviceInitAssignName(DeviceInit, &usDeviceName);

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -708,7 +708,7 @@ static VOID VIOSockSelectTimerFunc(IN WDFTIMER Timer)
 
 static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
 {
-    ULONG i;
+    ULONG i, uTotalFds = 0;
     PVIOSOCK_SELECT_HANDLE pHandleSet;
     PVIRTIO_VSOCK_FD_SET pFds;
 
@@ -728,6 +728,7 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
             pFds->fd_array[pFds->fd_count++] = pHandleSet[i].hSocket;
         }
     }
+    uTotalFds += pFds->fd_count;
 
     pFds = &pPkt->pSelect->Fdss[FDSET_WRITE];
     pHandleSet = VIOSockSelectGetFdsWriteSet(pPkt);
@@ -742,6 +743,7 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
             pFds->fd_array[pFds->fd_count++] = pHandleSet[i].hSocket;
         }
     }
+    uTotalFds += pFds->fd_count;
 
     pFds = &pPkt->pSelect->Fdss[FDSET_EXCPT];
     pHandleSet = VIOSockSelectGetFdsExcptSet(pPkt);
@@ -755,9 +757,9 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
             pFds->fd_array[pFds->fd_count++] = pHandleSet[i].hSocket;
         }
     }
+    uTotalFds += pFds->fd_count;
 
-    return pPkt->pSelect->Fdss[FDSET_READ].fd_count || pPkt->pSelect->Fdss[FDSET_WRITE].fd_count ||
-           pPkt->pSelect->Fdss[FDSET_EXCPT].fd_count;
+    return !!uTotalFds;
 }
 
 static VOID VIOSockSelectCancel(IN WDFREQUEST Request)
@@ -961,6 +963,16 @@ static BOOLEAN VIOSockSelectCopyFds(IN PDEVICE_CONTEXT pContext,
     return i == pSelect->Fdss[iFdSet].fd_count;
 }
 
+static VOID VIOSockSelectClearFdss(IN PVIRTIO_VSOCK_SELECT pSelect)
+{
+    VIRTIO_VSOCK_FDSET_TYPE i;
+    for (i = FDSET_READ; i < FDSET_MAX; i++)
+    {
+        RtlZeroMemory(pSelect->Fdss[i].fd_array, pSelect->Fdss[i].fd_count * sizeof(pSelect->Fdss[i].fd_array[0]));
+        pSelect->Fdss[i].fd_count = 0;
+    }
+}
+
 static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 {
     PDEVICE_CONTEXT pContext = GetDeviceContextFromRequest(Request);
@@ -1045,6 +1057,8 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
     if (NT_SUCCESS(status))
     {
+        VIOSockSelectClearFdss(pSelect);
+
         WdfWaitLockAcquire(pContext->SelectLock, NULL);
 
         pPkt->Status = status = VIOSockSelectCheckPkt(pPkt) ? STATUS_SUCCESS : STATUS_PENDING;

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -98,6 +98,8 @@ VIOSockSelectCopyFds(IN PDEVICE_CONTEXT pContext,
                      IN VIRTIO_VSOCK_FDSET_TYPE iFdSet,
                      IN PVIOSOCK_SELECT_HANDLE pHandleSet);
 
+_IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockSelectEnqueueWorkItem(IN PDEVICE_CONTEXT pContext);
+
 NTSTATUS
 VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength);
 
@@ -701,10 +703,7 @@ static VOID VIOSockSelectTimerFunc(IN WDFTIMER Timer)
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "--> %s\n", __FUNCTION__);
 
-    if (InterlockedIncrement(&pContext->SelectInProgress) == 1)
-    {
-        WdfWorkItemEnqueue(pContext->SelectWorkitem);
-    }
+    VIOSockSelectEnqueueWorkItem(pContext);
 }
 
 static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
@@ -767,10 +766,7 @@ static VOID VIOSockSelectCancel(IN WDFREQUEST Request)
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "--> %s\n", __FUNCTION__);
 
-    if (InterlockedIncrement(&pContext->SelectInProgress) == 1)
-    {
-        WdfWorkItemEnqueue(pContext->SelectWorkitem);
-    }
+    VIOSockSelectEnqueueWorkItem(pContext);
 }
 
 static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
@@ -885,6 +881,15 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "<-- %s\n", __FUNCTION__);
 }
 
+_IRQL_requires_max_(DISPATCH_LEVEL) static VOID VIOSockSelectEnqueueWorkItem(IN PDEVICE_CONTEXT pContext)
+{
+    if (InterlockedIncrement(&pContext->SelectInProgress) == 1)
+    {
+        TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "Enqueue workitem\n");
+        WdfWorkItemEnqueue(pContext->SelectWorkitem);
+    }
+}
+
 _IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockSelectRun(IN PSOCKET_CONTEXT pSocket)
 {
     BOOLEAN bRun = FALSE;
@@ -908,10 +913,9 @@ _IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockSelectRun(IN PSOCKET_CONTEXT pSo
         bRun |= (pSocket->Events & FD_CONNECT) && !NT_SUCCESS(pSocket->EventsStatus[FD_CONNECT_BIT]);
     }
 
-    if (bRun && InterlockedIncrement(&pContext->SelectInProgress) == 1)
+    if (bRun)
     {
-        TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "Enqueue workitem\n");
-        WdfWorkItemEnqueue(pContext->SelectWorkitem);
+        VIOSockSelectEnqueueWorkItem(pContext);
     }
 }
 

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -76,10 +76,16 @@ typedef struct _VIOSOCK_SELECT_PKT
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VIOSOCK_SELECT_PKT, GetSelectContext);
 
+#define VIOSockSelectGetFdsReadSet(p)  ((p)->Fds)
+#define VIOSockSelectGetFdsWriteSet(p) ((p)->Fds + (p)->FdCount[FDSET_READ])
+#define VIOSockSelectGetFdsExcptSet(p) ((p)->Fds + (p)->FdCount[FDSET_READ] + (p)->FdCount[FDSET_WRITE])
+
 NTSTATUS
 VIOSockSelectInit(IN PDEVICE_CONTEXT pContext);
 
-VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt, IN VIRTIO_VSOCK_FDSET_TYPE iFdSet, IN ULONG uStartIndex);
+VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt,
+                             IN VIRTIO_VSOCK_FDSET_TYPE iFdSet,
+                             IN PVIOSOCK_SELECT_HANDLE pHandleSet);
 
 BOOLEAN
 VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt);
@@ -90,7 +96,7 @@ VIOSockSelectCopyFds(IN PDEVICE_CONTEXT pContext,
                      IN PVIRTIO_VSOCK_SELECT pSelect,
                      IN PVIOSOCK_SELECT_PKT pPkt,
                      IN VIRTIO_VSOCK_FDSET_TYPE iFdSet,
-                     IN ULONG uStartIndex);
+                     IN PVIOSOCK_SELECT_HANDLE pHandleSet);
 
 NTSTATUS
 VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength);
@@ -660,12 +666,11 @@ static NTSTATUS VIOSockSelectInit(IN PDEVICE_CONTEXT pContext)
     return status;
 }
 
-static VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt, IN VIRTIO_VSOCK_FDSET_TYPE iFdSet, IN ULONG uStartIndex
-
-)
+static VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt,
+                                    IN VIRTIO_VSOCK_FDSET_TYPE iFdSet,
+                                    IN PVIOSOCK_SELECT_HANDLE pHandleSet)
 {
     ULONG i;
-    PVIOSOCK_SELECT_HANDLE pHandleSet = &pPkt->Fds[uStartIndex];
 
     PAGED_CODE();
 
@@ -675,6 +680,7 @@ static VOID VIOSockSelectCleanupFds(IN PVIOSOCK_SELECT_PKT pPkt, IN VIRTIO_VSOCK
 
         InterlockedDecrement(&GetSocketContext(pHandleSet[i].Socket)->SelectRefs[iFdSet]); // dereference socket
         WdfObjectDereference(pHandleSet[i].Socket);
+        pHandleSet[i].Socket = NULL;
     }
 
     pPkt->FdCount[iFdSet] = 0;
@@ -684,9 +690,9 @@ __inline VOID VIOSockSelectCleanupPkt(IN PVIOSOCK_SELECT_PKT pPkt)
 {
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "--> %s, status: 0x%08x\n", __FUNCTION__, pPkt->Status);
 
-    VIOSockSelectCleanupFds(pPkt, FDSET_READ, 0);
-    VIOSockSelectCleanupFds(pPkt, FDSET_WRITE, pPkt->FdCount[FDSET_READ]);
-    VIOSockSelectCleanupFds(pPkt, FDSET_EXCPT, pPkt->FdCount[FDSET_READ] + pPkt->FdCount[FDSET_WRITE]);
+    VIOSockSelectCleanupFds(pPkt, FDSET_READ, VIOSockSelectGetFdsReadSet(pPkt));
+    VIOSockSelectCleanupFds(pPkt, FDSET_WRITE, VIOSockSelectGetFdsWriteSet(pPkt));
+    VIOSockSelectCleanupFds(pPkt, FDSET_EXCPT, VIOSockSelectGetFdsExcptSet(pPkt));
 }
 
 static VOID VIOSockSelectTimerFunc(IN WDFTIMER Timer)
@@ -712,7 +718,7 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SELECT, "--> %s\n", __FUNCTION__);
 
     pFds = &pPkt->pSelect->Fdss[FDSET_READ];
-    pHandleSet = pPkt->Fds;
+    pHandleSet = VIOSockSelectGetFdsReadSet(pPkt);
 
     pFds->fd_count = 0;
     for (i = 0; i < pPkt->FdCount[FDSET_READ]; ++i)
@@ -725,7 +731,7 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
     }
 
     pFds = &pPkt->pSelect->Fdss[FDSET_WRITE];
-    pHandleSet = &pPkt->Fds[pPkt->FdCount[FDSET_READ]];
+    pHandleSet = VIOSockSelectGetFdsWriteSet(pPkt);
 
     pFds->fd_count = 0;
     for (i = 0; i < pPkt->FdCount[FDSET_WRITE]; ++i)
@@ -739,7 +745,7 @@ static BOOLEAN VIOSockSelectCheckPkt(IN PVIOSOCK_SELECT_PKT pPkt)
     }
 
     pFds = &pPkt->pSelect->Fdss[FDSET_EXCPT];
-    pHandleSet = &pPkt->Fds[pPkt->FdCount[FDSET_READ] + pPkt->FdCount[FDSET_WRITE]];
+    pHandleSet = VIOSockSelectGetFdsExcptSet(pPkt);
 
     pFds->fd_count = 0;
     for (i = 0; i < pPkt->FdCount[FDSET_EXCPT]; ++i)
@@ -914,10 +920,9 @@ static BOOLEAN VIOSockSelectCopyFds(IN PDEVICE_CONTEXT pContext,
                                     IN PVIRTIO_VSOCK_SELECT pSelect,
                                     IN PVIOSOCK_SELECT_PKT pPkt,
                                     IN VIRTIO_VSOCK_FDSET_TYPE iFdSet,
-                                    IN ULONG uStartIndex)
+                                    IN PVIOSOCK_SELECT_HANDLE pHandleSet)
 {
     ULONG i;
-    PVIOSOCK_SELECT_HANDLE pHandleSet = &pPkt->Fds[uStartIndex];
 
     PAGED_CODE();
 
@@ -1021,14 +1026,14 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
     pPkt->pSelect = pSelect;
 
-    if (!VIOSockSelectCopyFds(pContext, bIs32BitProcess, pSelect, pPkt, FDSET_READ, 0) ||
-        !VIOSockSelectCopyFds(pContext, bIs32BitProcess, pSelect, pPkt, FDSET_WRITE, pPkt->FdCount[FDSET_READ]) ||
+    if (!VIOSockSelectCopyFds(pContext, bIs32BitProcess, pSelect, pPkt, FDSET_READ, VIOSockSelectGetFdsReadSet(pPkt)) ||
         !VIOSockSelectCopyFds(pContext,
                               bIs32BitProcess,
                               pSelect,
                               pPkt,
-                              FDSET_EXCPT,
-                              pPkt->FdCount[FDSET_READ] + pPkt->FdCount[FDSET_WRITE]))
+                              FDSET_WRITE,
+                              VIOSockSelectGetFdsWriteSet(pPkt)) ||
+        !VIOSockSelectCopyFds(pContext, bIs32BitProcess, pSelect, pPkt, FDSET_EXCPT, VIOSockSelectGetFdsExcptSet(pPkt)))
     {
         TraceEvents(TRACE_LEVEL_WARNING, DBG_SELECT, "VIOSockSelectCopyFds failed\n");
         status = STATUS_INVALID_HANDLE;

--- a/viosock/sys/Loopback.c
+++ b/viosock/sys/Loopback.c
@@ -212,6 +212,8 @@ _Requires_lock_not_held_(pDestSocket->StateLock) static NTSTATUS VIOSockLoopback
         }
         else
         {
+            BOOLEAN bSetEvent = FALSE;
+
             switch (Op)
             {
                 case VIRTIO_VSOCK_OP_RESPONSE:
@@ -223,11 +225,12 @@ _Requires_lock_not_held_(pDestSocket->StateLock) static NTSTATUS VIOSockLoopback
                     ASSERT(bTxHasSpace);
                     WdfSpinLockAcquire(pDestSocket->StateLock);
                     VIOSockStateSet(pDestSocket, VIOSOCK_STATE_CONNECTED);
-                    VIOSockEventSetBit(pDestSocket, FD_CONNECT_BIT, STATUS_SUCCESS);
+                    bSetEvent = VIOSockEventMarkBit(pDestSocket, FD_CONNECT_BIT, STATUS_SUCCESS);
                     if (bTxHasSpace)
                     {
-                        VIOSockEventSetBit(pDestSocket, FD_WRITE_BIT, STATUS_SUCCESS);
+                        bSetEvent |= VIOSockEventMarkBit(pDestSocket, FD_WRITE_BIT, STATUS_SUCCESS);
                     }
+                    VIOSockEventNotify(pDestSocket, bSetEvent);
                     WdfSpinLockRelease(pDestSocket->StateLock);
                     status = STATUS_SUCCESS;
                     break;

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -594,16 +594,18 @@ _Requires_lock_not_held_(pSocket->StateLock) static VOID VIOSockRxPktHandleConne
         }
         else
         {
+            BOOLEAN bSetEvent = FALSE;
             switch (pPkt->Header.op)
             {
                 case VIRTIO_VSOCK_OP_RESPONSE:
                     WdfSpinLockAcquire(pSocket->StateLock);
                     VIOSockStateSet(pSocket, VIOSOCK_STATE_CONNECTED);
-                    VIOSockEventSetBit(pSocket, FD_CONNECT_BIT, STATUS_SUCCESS);
+                    bSetEvent = VIOSockEventMarkBit(pSocket, FD_CONNECT_BIT, STATUS_SUCCESS);
                     if (bTxHasSpace)
                     {
-                        VIOSockEventSetBit(pSocket, FD_WRITE_BIT, STATUS_SUCCESS);
+                        bSetEvent |= VIOSockEventMarkBit(pSocket, FD_WRITE_BIT, STATUS_SUCCESS);
                     }
+                    VIOSockEventNotify(pSocket, bSetEvent);
                     WdfSpinLockRelease(pSocket->StateLock);
                     status = STATUS_SUCCESS;
                     break;
@@ -1047,7 +1049,7 @@ _Requires_lock_not_held_(pSocket->RxLock) static NTSTATUS VIOSockReadForward(IN 
         bTimer = TRUE;
     }
 
-    VIOSockEventClearBit(pSocket, FD_READ_BIT);
+    VIOSockEventClearBitLocked(pSocket, FD_READ_BIT);
 
     status = WdfRequestForwardToIoQueue(Request, pSocket->ReadQueue);
     if (!NT_SUCCESS(status))
@@ -1445,11 +1447,11 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
 
     if (bSetBit)
     {
-        VIOSockEventSetBit(pSocket, FD_READ_BIT, STATUS_SUCCESS);
+        VIOSockEventSetBitLocked(pSocket, FD_READ_BIT, STATUS_SUCCESS);
     }
     else
     {
-        VIOSockEventClearBit(pSocket, FD_READ_BIT);
+        VIOSockEventClearBitLocked(pSocket, FD_READ_BIT);
     }
 
     if (FreeSpace < VIRTIO_VSOCK_MAX_PKT_BUF_SIZE)

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -946,7 +946,7 @@ static NTSTATUS VIOSockAccept(IN HANDLE hListenSocket, IN WDFREQUEST Request)
                 VIOSockSetFlag(pAcceptSocket, SOCK_NON_BLOCK);
             }
 
-            VIOSockEventClearBit(pListenSocket, FD_ACCEPT_BIT);
+            VIOSockEventClearBitLocked(pListenSocket, FD_ACCEPT_BIT);
 
             if (!VIOSockAcceptDequeue(pListenSocket, pAcceptSocket, &bSetBit))
             {
@@ -1413,7 +1413,7 @@ static NTSTATUS VIOSockConnect(IN WDFREQUEST Request)
         }
     }
 
-    VIOSockEventClearBit(pSocket, FD_CONNECT_BIT);
+    VIOSockEventClearBitLocked(pSocket, FD_CONNECT_BIT);
 
     pSocket->dst_cid = pAddr->svm_cid;
     pSocket->dst_port = pAddr->svm_port;
@@ -1843,9 +1843,7 @@ static NTSTATUS VIOSockEventSelect(IN WDFREQUEST Request)
     return STATUS_SUCCESS;
 }
 
-_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBit(IN PSOCKET_CONTEXT pSocket,
-                                                                     IN ULONG uSetBit,
-                                                                     IN NTSTATUS Status)
+BOOLEAN VIOSockEventMarkBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uSetBit, IN NTSTATUS Status)
 {
     ULONG uEvent = (1 << uSetBit);
     BOOLEAN bSetEvent;
@@ -1857,12 +1855,25 @@ _Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBit(IN PSOCKET_
     pSocket->Events |= uEvent;
     pSocket->EventsStatus[uSetBit] = Status;
 
+    return bSetEvent;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockEventNotify(IN PSOCKET_CONTEXT pSocket, IN BOOLEAN bSetEvent)
+{
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, bSetEvent: 0x%x\n", __FUNCTION__, bSetEvent);
+
     VIOSockSelectRun(pSocket);
 
     if (bSetEvent && pSocket->EventObject)
     {
         KeSetEvent(pSocket->EventObject, IO_NO_INCREMENT, FALSE);
     }
+}
+
+VOID VIOSockEventSetBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uSetBit, IN NTSTATUS Status)
+{
+    BOOLEAN bSetEvent = VIOSockEventMarkBit(pSocket, uSetBit, Status);
+    VIOSockEventNotify(pSocket, bSetEvent);
 }
 
 _Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBitLocked(IN PSOCKET_CONTEXT pSocket,
@@ -1874,7 +1885,8 @@ _Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBitLocked(IN PS
     WdfSpinLockRelease(pSocket->StateLock);
 }
 
-_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventClearBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uClearBit)
+_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventClearBitLocked(IN PSOCKET_CONTEXT pSocket,
+                                                                             IN ULONG uClearBit)
 {
     ULONG uEvent = (1 << uClearBit);
 

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -412,15 +412,18 @@ _IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockSelectRun(IN PSOCKET_CONTEXT pSo
 #define FD_ADDRESS_LIST_CHANGE_BIT      9
 #define FD_ADDRESS_LIST_CHANGE          (1 << FD_ADDRESS_LIST_CHANGE_BIT)
 
-_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBit(IN PSOCKET_CONTEXT pSocket,
-                                                                     IN ULONG uSetBit,
-                                                                     IN NTSTATUS Status);
+BOOLEAN VIOSockEventMarkBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uSetBit, IN NTSTATUS Status);
+
+_IRQL_requires_max_(DISPATCH_LEVEL) VOID VIOSockEventNotify(IN PSOCKET_CONTEXT pSocket, IN BOOLEAN bSetEvent);
+
+VOID VIOSockEventSetBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uSetBit, IN NTSTATUS Status);
 
 _Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventSetBitLocked(IN PSOCKET_CONTEXT pSocket,
                                                                            IN ULONG uSetBit,
                                                                            IN NTSTATUS Status);
 
-_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventClearBit(IN PSOCKET_CONTEXT pSocket, IN ULONG uClearBit);
+_Requires_lock_not_held_(pSocket->StateLock) VOID VIOSockEventClearBitLocked(IN PSOCKET_CONTEXT pSocket,
+                                                                             IN ULONG uClearBit);
 
 //////////////////////////////////////////////////////////////////////////
 // Tx functions

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -377,8 +377,8 @@ _Requires_lock_not_held_(pSocket->RxLock) __declspec(noinline) NTSTATUS VIOSockP
                                                                                                     IN PSOCKET_CONTEXT pSocket,
                                                                                                     OUT WDFREQUEST *Request);
 
-NTSTATUS
-VIOSockAcceptInitSocket(PSOCKET_CONTEXT pAcceptSocket, PSOCKET_CONTEXT pListenSocket);
+_Requires_lock_not_held_(pListenSocket->StateLock) NTSTATUS VIOSockAcceptInitSocket(PSOCKET_CONTEXT pAcceptSocket,
+                                                                                    PSOCKET_CONTEXT pListenSocket);
 
 _Requires_lock_not_held_(pListenSocket->RxLock) NTSTATUS VIOSockAcceptEnqueuePkt(IN PSOCKET_CONTEXT pListenSocket,
                                                                                  IN PVIRTIO_VSOCK_HDR pPkt);


### PR DESCRIPTION
**Driver fixes:**

- Set the WDF device type to `FILE_DEVICE_NAMED_PIPE` so that `GetFileType()` returns `FILE_TYPE_PIPE` for viosock socket handles, matching real socket providers and making `_open_osfhandle()` succeed.
- Fix `WSPSelect`: clear the output fd sets before processing so that input fd handles don't leak into the output (the IOCTL uses a shared input/output buffer).
- Fix event notification to mark all event bits atomically under a single state lock hold and call `VIOSockEventNotify()` once, so the event object and select workitem are signaled only once per batch (e.g. FD_CONNECT + FD_WRITE on connection).
- Refactoring: `VIOSockSelectGetFds*` macros and `VIOSockSelectEnqueueWorkItem` helper to reduce code duplication.

**Library fixes:**

- Implement `SO_PROTOCOL_INFOW` for `WSPGetSockOpt`.
- Fix protocol registration info: set `iVersion` to 2.