### PR TITLE
viosock: Fix timer implementation and select timeout handling

### DIFF
--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -930,7 +930,7 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
     }
     else
     {
-        Select.Timeout = (LONGLONG)-1;
+        Select.Timeout = VSOCK_TIMEOUT_INFINITE;
     }
 
     hFile = VIOSockCreateFile(NULL, lpErrno);

--- a/viosock/lib/viosocklib.c
+++ b/viosock/lib/viosocklib.c
@@ -945,18 +945,12 @@ int WSPAPI VIOSockSelect(_In_ int nfds,
                                   &dwBytesReturned,
                                   lpErrno))
         {
-            if (*lpErrno == WSAETIMEDOUT)
-            {
-                TraceEvents(TRACE_LEVEL_INFORMATION, DBG_SOCKET, "VIOSockDeviceControl timed out\n");
-            }
-            else
-            {
-                iRes = SOCKET_ERROR;
-                TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
-            }
+            iRes = SOCKET_ERROR;
+            TraceEvents(TRACE_LEVEL_ERROR, DBG_SOCKET, "VIOSockDeviceControl failed: %d\n", *lpErrno);
         }
         else if (dwBytesReturned == sizeof(Select))
         {
+            // iRes == 0 if timed out
             iRes = CopyToFdSet(readfds, &Select.Fdss[FDSET_READ]) + CopyToFdSet(writefds, &Select.Fdss[FDSET_WRITE]) +
                    CopyToFdSet(exceptfds, &Select.Fdss[FDSET_EXCPT]);
         }

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -67,7 +67,7 @@ typedef struct _VIOSOCK_SELECT_HANDLE
 typedef struct _VIOSOCK_SELECT_PKT
 {
     LIST_ENTRY ListEntry;
-    LONGLONG Timeout;
+    VIOSOCK_TIMER_ENTRY TimerEntry;
     PVIRTIO_VSOCK_SELECT pSelect;
     ULONG FdCount[FDSET_MAX];
     NTSTATUS Status;
@@ -785,7 +785,7 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
     {
         LIST_ENTRY CompletionList;
         WDFREQUEST Request;
-        LONGLONG TimePassed, Timeout = MAXLONGLONG;
+        LONGLONG MinRemainingTicks = MAXLONGLONG;
         PLIST_ENTRY CurrentItem;
         BOOLEAN bRemove;
 
@@ -794,8 +794,6 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
         InitializeListHead(&CompletionList);
 
         WdfWaitLockAcquire(pContext->SelectLock, NULL);
-
-        TimePassed = VIOSockTimerPassed(&pContext->SelectTimer);
 
         for (CurrentItem = pContext->SelectList.Flink; CurrentItem != &pContext->SelectList;
              CurrentItem = CurrentItem->Flink)
@@ -818,22 +816,19 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
                 bRemove = TRUE;
                 pPkt->Status = STATUS_SUCCESS;
             }
-            else if (pPkt->Timeout)
+            else if (VIOSockTimerEntryIsSet(&pPkt->TimerEntry))
             {
-                if (pPkt->Timeout <= TimePassed + VIOSOCK_TIMER_TOLERANCE)
+                LONGLONG llRemainingTicks = VIOSockTimerEntryRemainingTicks(&pPkt->TimerEntry);
+
+                if (llRemainingTicks <= VIOSOCK_TIMER_TOLERANCE_TICKS)
                 {
                     bRemove = TRUE;
                     // It is a success value, just return empty fd sets
                     pPkt->Status = STATUS_TIMEOUT;
                 }
-                else
+                else if (llRemainingTicks < MinRemainingTicks)
                 {
-                    pPkt->Timeout -= TimePassed;
-
-                    if (pPkt->Timeout < Timeout)
-                    {
-                        Timeout = pPkt->Timeout;
-                    }
+                    MinRemainingTicks = llRemainingTicks;
                 }
             }
 
@@ -855,16 +850,16 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
                 CurrentItem = pPkt->ListEntry.Blink;
                 RemoveEntryList(&pPkt->ListEntry);
                 InsertTailList(&CompletionList, &pPkt->ListEntry);
-                if (pPkt->Timeout)
+                if (VIOSockTimerEntryIsSet(&pPkt->TimerEntry))
                 {
                     VIOSockTimerDeref(&pContext->SelectTimer, TRUE);
                 }
             }
         }
 
-        if (Timeout != MAXLONGLONG)
+        if (MinRemainingTicks != MAXLONGLONG)
         {
-            VIOSockTimerSet(&pContext->SelectTimer, Timeout);
+            VIOSockTimerSetDeadline(&pContext->SelectTimer, VIOSockTimerTicksToDeadline(MinRemainingTicks));
         }
 
         WdfWaitLockRelease(pContext->SelectLock);
@@ -1048,6 +1043,7 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
         return status;
     }
 
+    VIOSockTimerEntryInit(&pPkt->TimerEntry);
     pPkt->pSelect = pSelect;
 
     if (!VIOSockSelectCopyFds(pContext, bIs32BitProcess, pSelect, pPkt, FDSET_READ, VIOSockSelectGetFdsReadSet(pPkt)) ||
@@ -1085,28 +1081,20 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
         if (status == STATUS_PENDING)
         {
-            if (pSelect->Timeout)
+            status = WdfRequestMarkCancelableEx(Request, VIOSockSelectCancel);
+
+            ASSERT(NT_SUCCESS(status) || status == STATUS_CANCELLED);
+
+            if (NT_SUCCESS(status))
             {
-                status = WdfRequestMarkCancelableEx(Request, VIOSockSelectCancel);
+                pPkt->Status = status = STATUS_PENDING;
 
-                ASSERT(NT_SUCCESS(status) || status == STATUS_CANCELLED);
-
-                if (NT_SUCCESS(status))
+                if (pSelect->Timeout != VSOCK_TIMEOUT_INFINITE)
                 {
-                    pPkt->Status = status = STATUS_PENDING;
-                    pPkt->Timeout = (pSelect->Timeout == VSOCK_TIMEOUT_INFINITE) ? 0 : pSelect->Timeout;
-
-                    InsertTailList(&pContext->SelectList, &pPkt->ListEntry);
-
-                    if (pPkt->Timeout)
-                    {
-                        VIOSockTimerStart(&pContext->SelectTimer, pPkt->Timeout);
-                    }
+                    VIOSockTimerStart(&pContext->SelectTimer, &pPkt->TimerEntry, pSelect->Timeout);
                 }
-            }
-            else
-            {
-                status = STATUS_TIMEOUT;
+
+                InsertTailList(&pContext->SelectList, &pPkt->ListEntry);
             }
         }
         else

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -823,7 +823,8 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
                 if (pPkt->Timeout <= TimePassed + VIOSOCK_TIMER_TOLERANCE)
                 {
                     bRemove = TRUE;
-                    pPkt->Status = STATUS_IO_TIMEOUT;
+                    // It is a success value, just return empty fd sets
+                    pPkt->Status = STATUS_TIMEOUT;
                 }
                 else
                 {
@@ -877,7 +878,7 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
             VIOSockSelectCleanupPkt(pPkt);
             WdfRequestCompleteWithInformation(WdfObjectContextGetObject(pPkt),
                                               pPkt->Status,
-                                              pPkt->Status == STATUS_SUCCESS ? sizeof(VIRTIO_VSOCK_SELECT) : 0);
+                                              NT_SUCCESS(pPkt->Status) ? sizeof(VIRTIO_VSOCK_SELECT) : 0);
         }
 
     } while (InterlockedCompareExchange(&pContext->SelectInProgress, 0, 1) != 1);

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -1091,7 +1091,7 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
                 if (pSelect->Timeout != VSOCK_TIMEOUT_INFINITE)
                 {
-                    VIOSockTimerStart(&pContext->SelectTimer, &pPkt->TimerEntry, pSelect->Timeout);
+                    VIOSockTimerStartTimeout(&pContext->SelectTimer, &pPkt->TimerEntry, pSelect->Timeout);
                 }
 
                 InsertTailList(&pContext->SelectList, &pPkt->ListEntry);

--- a/viosock/sys/Device.c
+++ b/viosock/sys/Device.c
@@ -785,7 +785,7 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
     {
         LIST_ENTRY CompletionList;
         WDFREQUEST Request;
-        LONGLONG TimePassed, Timeout = LONGLONG_MAX;
+        LONGLONG TimePassed, Timeout = MAXLONGLONG;
         PLIST_ENTRY CurrentItem;
         BOOLEAN bRemove;
 
@@ -862,7 +862,7 @@ static VOID VIOSockSelectWorkitem(IN WDFWORKITEM Workitem)
             }
         }
 
-        if (Timeout != LONGLONG_MAX)
+        if (Timeout != MAXLONGLONG)
         {
             VIOSockTimerSet(&pContext->SelectTimer, Timeout);
         }
@@ -1030,6 +1030,11 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
         return STATUS_INVALID_PARAMETER;
     }
 
+    if (pSelect->Timeout < 0)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
+
 #ifdef _WIN64
     bIs32BitProcess = WdfRequestIsFrom32BitProcess(Request);
 #endif //_WIN64
@@ -1064,7 +1069,19 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
         WdfWaitLockAcquire(pContext->SelectLock, NULL);
 
-        pPkt->Status = status = VIOSockSelectCheckPkt(pPkt) ? STATUS_SUCCESS : STATUS_PENDING;
+        if (VIOSockSelectCheckPkt(pPkt))
+        {
+            status = STATUS_SUCCESS;
+        }
+        else if (!pSelect->Timeout)
+        {
+            // zero timeout specified, return immediately with zero fd sets
+            status = STATUS_TIMEOUT;
+        }
+        else
+        {
+            status = STATUS_PENDING;
+        }
 
         if (status == STATUS_PENDING)
         {
@@ -1076,16 +1093,12 @@ static NTSTATUS VIOSockSelect(IN WDFREQUEST Request, IN OUT size_t *pLength)
 
                 if (NT_SUCCESS(status))
                 {
-                    status = STATUS_PENDING;
+                    pPkt->Status = status = STATUS_PENDING;
+                    pPkt->Timeout = (pSelect->Timeout == VSOCK_TIMEOUT_INFINITE) ? 0 : pSelect->Timeout;
 
                     InsertTailList(&pContext->SelectList, &pPkt->ListEntry);
-                    pPkt->Timeout = pSelect->Timeout;
 
-                    if (pPkt->Timeout == (LONGLONG)-1)
-                    {
-                        pPkt->Timeout = 0;
-                    }
-                    else
+                    if (pPkt->Timeout)
                     {
                         VIOSockTimerStart(&pContext->SelectTimer, pPkt->Timeout);
                     }

--- a/viosock/sys/Driver.c
+++ b/viosock/sys/Driver.c
@@ -123,32 +123,25 @@ NTSTATUS VIOSockTimerCreate(IN PVIOSOCK_TIMER pTimer, IN WDFOBJECT ParentObject,
     return WdfTimerCreate(&timerConfig, &Attributes, &pTimer->Timer);
 }
 
-VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Timeout)
+VOID VIOSockTimerStartDeadline(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Deadline)
 {
-    LONGLONG Deadline;
     BOOLEAN bSetTimer = FALSE;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    ASSERT(Timeout > 0 && Timeout != MAXLONGLONG);
-    if (!Timeout || Timeout == MAXLONGLONG)
+    ASSERT(Deadline > 0 && Deadline != MAXLONGLONG);
+    if (!Deadline || Deadline == MAXLONGLONG)
     {
         return;
     }
 
-    ASSERT(Timeout > VIOSOCK_TIMER_TOLERANCE);
-    if (Timeout <= VIOSOCK_TIMER_TOLERANCE)
-    {
-        Timeout = VIOSOCK_TIMER_TOLERANCE + 1;
-    }
-
     ++pTimer->StartRefs;
-    Deadline = VIOSockTimerTimeoutToDeadline(Timeout);
     if (pEntry)
     {
         pEntry->Deadline = Deadline;
     }
 
+    ASSERT(!VIOSockTimerDeadlineIsExpired(Deadline));
     // pTimer->Deadline is MAXLONGLONG when the timer is not running (after Create or Cancel).
     // The else branch for 0 is unreachable: VIOSockTimerCreate initializes to MAXLONGLONG.
     if (pTimer->Deadline != MAXLONGLONG)
@@ -166,6 +159,6 @@ VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry 
     if (bSetTimer)
     {
         pTimer->Deadline = Deadline;
-        WdfTimerStart(pTimer->Timer, -Timeout);
+        WdfTimerStart(pTimer->Timer, -VIOSockTimerDeadlineToTimeout(Deadline));
     }
 }

--- a/viosock/sys/Driver.c
+++ b/viosock/sys/Driver.c
@@ -35,6 +35,7 @@
 #endif
 
 DRIVER_INITIALIZE DriverEntry;
+VOID VIOSockTimerInit();
 
 // Context cleanup callbacks generally run at IRQL <= DISPATCH_LEVEL but
 // WDFDRIVER context cleanup is guaranteed to run at PASSIVE_LEVEL.
@@ -44,7 +45,12 @@ EVT_WDF_OBJECT_CONTEXT_CLEANUP _IRQL_requires_(PASSIVE_LEVEL) VIOSockEvtDriverCo
 #ifdef ALLOC_PRAGMA
 #pragma alloc_text(INIT, DriverEntry)
 #pragma alloc_text(PAGE, VIOSockEvtDriverContextCleanup)
+#pragma alloc_text(INIT, VIOSockTimerInit)
+#pragma alloc_text(PAGE, VIOSockTimerCreate)
 #endif
+
+ULONG ulTimeIncrement;
+LONGLONG llTimerToleranceTicks;
 
 NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING RegistryPath)
 {
@@ -78,6 +84,8 @@ NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING Registry
         return status;
     }
 
+    VIOSockTimerInit();
+
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_INIT, "<-- %s\n", __FUNCTION__);
     return status;
 }
@@ -91,13 +99,38 @@ VOID VIOSockEvtDriverContextCleanup(IN WDFOBJECT Driver)
     WPP_CLEANUP(WdfDriverWdmGetDriverObject((WDFDRIVER)Driver));
 }
 
-VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
+VOID VIOSockTimerInit()
 {
-    LARGE_INTEGER liTicks;
+    ulTimeIncrement = KeQueryTimeIncrement();
+    llTimerToleranceTicks = VIOSOCK_TIMER_TOLERANCE / ulTimeIncrement;
+}
+
+NTSTATUS VIOSockTimerCreate(IN PVIOSOCK_TIMER pTimer, IN WDFOBJECT ParentObject, IN PFN_WDF_TIMER EvtTimerFunc)
+{
+    WDF_OBJECT_ATTRIBUTES Attributes;
+    WDF_TIMER_CONFIG timerConfig;
+
+    PAGED_CODE();
+
+    pTimer->Deadline = MAXLONGLONG;
+    pTimer->StartRefs = 0;
+
+    WDF_TIMER_CONFIG_INIT(&timerConfig, EvtTimerFunc);
+
+    WDF_OBJECT_ATTRIBUTES_INIT(&Attributes);
+    Attributes.ParentObject = ParentObject;
+
+    return WdfTimerCreate(&timerConfig, &Attributes, &pTimer->Timer);
+}
+
+VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Timeout)
+{
+    LONGLONG Deadline;
     BOOLEAN bSetTimer = FALSE;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
+    ASSERT(Timeout > 0 && Timeout != MAXLONGLONG);
     if (!Timeout || Timeout == MAXLONGLONG)
     {
         return;
@@ -109,18 +142,18 @@ VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
         Timeout = VIOSOCK_TIMER_TOLERANCE + 1;
     }
 
-    KeQueryTickCount(&liTicks);
-
     ++pTimer->StartRefs;
-
-    if (pTimer->StartTime)
+    Deadline = VIOSockTimerTimeoutToDeadline(Timeout);
+    if (pEntry)
     {
-        LONGLONG Remaining;
+        pEntry->Deadline = Deadline;
+    }
 
-        ASSERT(pTimer->Timeout);
-
-        Remaining = pTimer->Timeout - (liTicks.QuadPart - pTimer->StartTime) * KeQueryTimeIncrement();
-        if (Remaining > Timeout + VIOSOCK_TIMER_TOLERANCE)
+    // pTimer->Deadline is MAXLONGLONG when the timer is not running (after Create or Cancel).
+    // The else branch for 0 is unreachable: VIOSockTimerCreate initializes to MAXLONGLONG.
+    if (pTimer->Deadline != MAXLONGLONG)
+    {
+        if (Deadline + VIOSOCK_TIMER_TOLERANCE_TICKS < pTimer->Deadline)
         {
             bSetTimer = TRUE;
         }
@@ -132,8 +165,7 @@ VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
 
     if (bSetTimer)
     {
-        pTimer->StartTime = liTicks.QuadPart;
-        pTimer->Timeout = Timeout;
+        pTimer->Deadline = Deadline;
         WdfTimerStart(pTimer->Timer, -Timeout);
     }
 }

--- a/viosock/sys/Driver.c
+++ b/viosock/sys/Driver.c
@@ -141,7 +141,6 @@ VOID VIOSockTimerStartDeadline(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY
         pEntry->Deadline = Deadline;
     }
 
-    ASSERT(!VIOSockTimerDeadlineIsExpired(Deadline));
     // pTimer->Deadline is MAXLONGLONG when the timer is not running (after Create or Cancel).
     // The else branch for 0 is unreachable: VIOSockTimerCreate initializes to MAXLONGLONG.
     if (pTimer->Deadline != MAXLONGLONG)

--- a/viosock/sys/Driver.c
+++ b/viosock/sys/Driver.c
@@ -127,7 +127,7 @@ VOID VIOSockTimerStartDeadline(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY
 {
     BOOLEAN bSetTimer = FALSE;
 
-    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
+    TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, Deadline: %lld\n", __FUNCTION__, Deadline);
 
     ASSERT(Deadline > 0 && Deadline != MAXLONGLONG);
     if (!Deadline || Deadline == MAXLONGLONG)

--- a/viosock/sys/Driver.c
+++ b/viosock/sys/Driver.c
@@ -98,7 +98,7 @@ VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s\n", __FUNCTION__);
 
-    if (!Timeout || Timeout == LONGLONG_MAX)
+    if (!Timeout || Timeout == MAXLONGLONG)
     {
         return;
     }

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -79,7 +79,7 @@ typedef struct _VIOSOCK_RX_CONTEXT
     union {
         struct
         {
-            LONGLONG Timeout; // 100ns
+            VIOSOCK_TIMER_ENTRY TimerEntry;
             LONG Counter;
             ULONG Flags;
             PCHAR FreePtr;
@@ -1014,7 +1014,6 @@ _Requires_lock_not_held_(pSocket->RxLock) static NTSTATUS VIOSockReadForward(IN 
     PVIOSOCK_RX_CONTEXT pRequest;
     WDF_OBJECT_ATTRIBUTES attributes;
     NTSTATUS status;
-    BOOLEAN bTimer = FALSE;
     SIZE_T Length;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_HW_ACCESS, "--> %s\n", __FUNCTION__);
@@ -1036,17 +1035,15 @@ _Requires_lock_not_held_(pSocket->RxLock) static NTSTATUS VIOSockReadForward(IN 
 
     pRequest->BufferLen = pRequest->FreeBytes = (ULONG)Length;
     pRequest->Flags = Flags;
+    VIOSockTimerEntryInit(&pRequest->TimerEntry);
 
-    if (!VIOSockIsNonBlocking(pSocket) && pSocket->RecvTimeout != LONG_MAX)
+    if (!VIOSockIsNonBlocking(pSocket) && pSocket->RecvTimeout != MAXLONGLONG)
     {
-        pRequest->Timeout = WDF_ABS_TIMEOUT_IN_MS(pSocket->RecvTimeout);
         pRequest->Counter = 0;
 
         WdfSpinLockAcquire(pSocket->RxLock);
-        VIOSockTimerStart(&pSocket->ReadTimer, pRequest->Timeout);
+        VIOSockTimerStart(&pSocket->ReadTimer, &pRequest->TimerEntry, pSocket->RecvTimeout);
         WdfSpinLockRelease(pSocket->RxLock);
-
-        bTimer = TRUE;
     }
 
     VIOSockEventClearBitLocked(pSocket, FD_READ_BIT);
@@ -1056,7 +1053,7 @@ _Requires_lock_not_held_(pSocket->RxLock) static NTSTATUS VIOSockReadForward(IN 
     {
 
         TraceEvents(TRACE_LEVEL_ERROR, DBG_READ, "WdfRequestForwardToIoQueue failed: 0x%x\n", status);
-        if (bTimer)
+        if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
         {
             WdfSpinLockAcquire(pSocket->RxLock);
             VIOSockTimerDeref(&pSocket->ReadTimer, TRUE);
@@ -1208,7 +1205,6 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
     ULONG FreeSpace;
     BOOLEAN bSetBit, bStop = FALSE, bRequeue = FALSE, bRestart = TRUE, bAlwaysTrue = TRUE, bProcessRxPktList = FALSE;
     PVIOSOCK_RX_CONTEXT pRequest = NULL;
-    LONGLONG llTimeout = 0;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_READ, "--> %s\n", __FUNCTION__);
 
@@ -1233,18 +1229,9 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
 
     WdfSpinLockAcquire(pSocket->RxLock);
 
-    if (pRequest->Timeout)
+    if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
     {
-        llTimeout = VIOSockTimerPassed(&pSocket->ReadTimer);
         VIOSockTimerDeref(&pSocket->ReadTimer, TRUE);
-        if (llTimeout < pRequest->Timeout)
-        {
-            llTimeout = pRequest->Timeout - llTimeout;
-        }
-        else
-        {
-            llTimeout = VIOSOCK_TIMER_TOLERANCE;
-        }
     }
 
     if (!VIOSockRxHasData(pSocket))
@@ -1302,7 +1289,7 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
     if (bRequeue)
     {
         bStop = TRUE;
-        if (llTimeout && llTimeout <= VIOSOCK_TIMER_TOLERANCE)
+        if (VIOSockTimerEntryIsExpired(&pRequest->TimerEntry))
         {
             status = STATUS_IO_TIMEOUT;
         }
@@ -1314,9 +1301,11 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
             if (NT_SUCCESS(status))
             {
                 // continue timer
-                if (llTimeout)
+                if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
                 {
-                    VIOSockTimerStart(&pSocket->ReadTimer, llTimeout);
+                    VIOSockTimerStart(&pSocket->ReadTimer,
+                                      NULL,
+                                      VIOSockTimerDeadlineToTimeout(pRequest->TimerEntry.Deadline));
                 }
                 ReadRequest = WDF_NO_HANDLE;
                 status = STATUS_SUCCESS;
@@ -1416,7 +1405,7 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
     }
     else if (pRequest->BufferLen == pRequest->FreeBytes || pRequest->Flags & MSG_WAITALL)
     {
-        if (llTimeout && llTimeout <= VIOSOCK_TIMER_TOLERANCE)
+        if (VIOSockTimerEntryIsExpired(&pRequest->TimerEntry))
         {
             status = STATUS_IO_TIMEOUT;
         }
@@ -1429,9 +1418,11 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
             if (NT_SUCCESS(status))
             {
                 // continue timer
-                if (llTimeout)
+                if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
                 {
-                    VIOSockTimerStart(&pSocket->ReadTimer, llTimeout);
+                    VIOSockTimerStart(&pSocket->ReadTimer,
+                                      NULL,
+                                      VIOSockTimerDeadlineToTimeout(pRequest->TimerEntry.Deadline));
                 }
                 ReadRequest = WDF_NO_HANDLE;
                 status = STATUS_SUCCESS;
@@ -1631,7 +1622,7 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
 {
     static LONG lCounter;
     PSOCKET_CONTEXT pSocket = GetSocketContext(WdfTimerGetParentObject(Timer));
-    LONGLONG Timeout = MAXLONGLONG;
+    LONGLONG MinRemainingTicks = MAXLONGLONG;
     WDFREQUEST PrevTagRequest = WDF_NO_HANDLE, TagRequest = WDF_NO_HANDLE, Request;
     NTSTATUS status;
     LIST_ENTRY CompletionList;
@@ -1657,9 +1648,10 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
 
             WdfSpinLockAcquire(pSocket->RxLock);
 
-            if (pRequest->Timeout && pRequest->Counter < lCounter)
+            if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry) && pRequest->Counter < lCounter)
             {
-                if (pRequest->Timeout <= pSocket->ReadTimer.Timeout + VIOSOCK_TIMER_TOLERANCE)
+                LONGLONG llRemainingTicks = VIOSockTimerEntryRemainingTicks(&pRequest->TimerEntry);
+                if (llRemainingTicks <= VIOSOCK_TIMER_TOLERANCE_TICKS)
                 {
                     status = WdfIoQueueRetrieveFoundRequest(pSocket->ReadQueue, TagRequest, &Request);
 
@@ -1690,14 +1682,12 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
                 }
                 else
                 {
-                    pRequest->Counter = lCounter;
-                    pRequest->Timeout -= pSocket->ReadTimer.Timeout;
-
-                    if (pRequest->Timeout < Timeout)
+                    if (llRemainingTicks < MinRemainingTicks)
                     {
-                        Timeout = pRequest->Timeout;
+                        MinRemainingTicks = llRemainingTicks;
                     }
 
+                    pRequest->Counter = lCounter;
                     PrevTagRequest = TagRequest;
                 }
             }
@@ -1715,10 +1705,10 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
         }
     } while (NT_SUCCESS(status));
 
-    if (Timeout != MAXLONGLONG)
+    if (MinRemainingTicks != MAXLONGLONG)
     {
         WdfSpinLockAcquire(pSocket->RxLock);
-        VIOSockTimerSet(&pSocket->ReadTimer, Timeout);
+        VIOSockTimerSetDeadline(&pSocket->ReadTimer, VIOSockTimerTicksToDeadline(MinRemainingTicks));
         WdfSpinLockRelease(pSocket->RxLock);
     }
 

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1042,7 +1042,7 @@ _Requires_lock_not_held_(pSocket->RxLock) static NTSTATUS VIOSockReadForward(IN 
         pRequest->Counter = 0;
 
         WdfSpinLockAcquire(pSocket->RxLock);
-        VIOSockTimerStart(&pSocket->ReadTimer, &pRequest->TimerEntry, pSocket->RecvTimeout);
+        VIOSockTimerStartTimeout(&pSocket->ReadTimer, &pRequest->TimerEntry, pSocket->RecvTimeout);
         WdfSpinLockRelease(pSocket->RxLock);
     }
 
@@ -1303,9 +1303,7 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
                 // continue timer
                 if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
                 {
-                    VIOSockTimerStart(&pSocket->ReadTimer,
-                                      NULL,
-                                      VIOSockTimerDeadlineToTimeout(pRequest->TimerEntry.Deadline));
+                    VIOSockTimerStartDeadline(&pSocket->ReadTimer, NULL, pRequest->TimerEntry.Deadline);
                 }
                 ReadRequest = WDF_NO_HANDLE;
                 status = STATUS_SUCCESS;
@@ -1420,9 +1418,7 @@ _Requires_lock_not_held_(pSocket->RxLock) BOOLEAN VIOSockReadDequeueCb(IN PSOCKE
                 // continue timer
                 if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
                 {
-                    VIOSockTimerStart(&pSocket->ReadTimer,
-                                      NULL,
-                                      VIOSockTimerDeadlineToTimeout(pRequest->TimerEntry.Deadline));
+                    VIOSockTimerStartDeadline(&pSocket->ReadTimer, NULL, pRequest->TimerEntry.Deadline);
                 }
                 ReadRequest = WDF_NO_HANDLE;
                 status = STATUS_SUCCESS;

--- a/viosock/sys/Rx.c
+++ b/viosock/sys/Rx.c
@@ -1631,7 +1631,7 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
 {
     static LONG lCounter;
     PSOCKET_CONTEXT pSocket = GetSocketContext(WdfTimerGetParentObject(Timer));
-    LONGLONG Timeout = LONGLONG_MAX;
+    LONGLONG Timeout = MAXLONGLONG;
     WDFREQUEST PrevTagRequest = WDF_NO_HANDLE, TagRequest = WDF_NO_HANDLE, Request;
     NTSTATUS status;
     LIST_ENTRY CompletionList;
@@ -1715,7 +1715,7 @@ VOID VIOSockReadTimerFunc(WDFTIMER Timer)
         }
     } while (NT_SUCCESS(status));
 
-    if (Timeout != LONGLONG_MAX)
+    if (Timeout != MAXLONGLONG)
     {
         WdfSpinLockAcquire(pSocket->RxLock);
         VIOSockTimerSet(&pSocket->ReadTimer, Timeout);

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -812,6 +812,8 @@ _Requires_lock_not_held_(pListenSocket->StateLock) NTSTATUS VIOSockAcceptInitSoc
     pAcceptSocket->ConnectTimeout = pListenSocket->ConnectTimeout;
     pAcceptSocket->BufferMinSize = pListenSocket->BufferMinSize;
     pAcceptSocket->BufferMaxSize = pListenSocket->BufferMaxSize;
+    pAcceptSocket->SendTimeout = MAXLONGLONG;
+    pAcceptSocket->RecvTimeout = MAXLONGLONG;
 
     pAcceptSocket->buf_alloc = pListenSocket->buf_alloc;
 

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -653,7 +653,7 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOC
     }
     else if (Timeout)
     {
-        VIOSockTimerSet(&pSocket->PendedTimer, Timeout);
+        VIOSockTimerSetTimeout(&pSocket->PendedTimer, Timeout);
     }
 
     return status;
@@ -1115,8 +1115,8 @@ static NTSTATUS VIOSockCreate(IN WDFDEVICE WdfDevice, IN WDFREQUEST Request, IN 
                     pSocket->ConnectTimeout = VSOCK_DEFAULT_CONNECT_TIMEOUT;
                     pSocket->BufferMinSize = VSOCK_DEFAULT_BUFFER_MIN_SIZE;
                     pSocket->BufferMaxSize = VSOCK_DEFAULT_BUFFER_MAX_SIZE;
-                    pSocket->SendTimeout = LONG_MAX;
-                    pSocket->RecvTimeout = LONG_MAX;
+                    pSocket->SendTimeout = MAXLONGLONG;
+                    pSocket->RecvTimeout = MAXLONGLONG;
 
                     pSocket->buf_alloc = VSOCK_DEFAULT_BUFFER_SIZE;
                 }
@@ -2109,7 +2109,8 @@ static NTSTATUS VIOSockGetSockOpt(IN WDFREQUEST Request, OUT size_t *pLength)
                 break;
             }
 
-            *(PULONG)pOptVal = pSocket->SendTimeout;
+            *(PULONG)pOptVal = pSocket->SendTimeout == MAXULONGLONG ? 0
+                                                                    : (ULONG)(pSocket->SendTimeout / WDF_TIMEOUT_TO_MS);
             pOpt->optlen = sizeof(ULONG);
             break;
 
@@ -2120,7 +2121,8 @@ static NTSTATUS VIOSockGetSockOpt(IN WDFREQUEST Request, OUT size_t *pLength)
                 break;
             }
 
-            *(PULONG)pOptVal = pSocket->RecvTimeout;
+            *(PULONG)pOptVal = pSocket->RecvTimeout == MAXULONGLONG ? 0
+                                                                    : (ULONG)(pSocket->RecvTimeout / WDF_TIMEOUT_TO_MS);
             pOpt->optlen = sizeof(ULONG);
             break;
 
@@ -2295,7 +2297,7 @@ static NTSTATUS VIOSockSetSockOpt(IN WDFREQUEST Request)
                 break;
             }
 
-            pSocket->SendTimeout = *(PULONG)pOptVal;
+            pSocket->SendTimeout = *(PULONG)pOptVal ? WDF_ABS_TIMEOUT_IN_MS(*(PULONG)pOptVal) : MAXLONGLONG;
             break;
 
         case SO_RCVTIMEO:
@@ -2305,7 +2307,7 @@ static NTSTATUS VIOSockSetSockOpt(IN WDFREQUEST Request)
                 break;
             }
 
-            pSocket->RecvTimeout = *(PULONG)pOptVal;
+            pSocket->RecvTimeout = *(PULONG)pOptVal ? WDF_ABS_TIMEOUT_IN_MS(*(PULONG)pOptVal) : MAXLONGLONG;
             break;
 
         case SO_VM_SOCKETS_BUFFER_SIZE:

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -656,7 +656,7 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSet(IN PSOCKE
 
         if (Deadline != MAXLONGLONG)
         {
-            VIOSockTimerStart(&pSocket->PendedTimer, &pRequest->TimerEntry, VIOSockTimerDeadlineToTimeout(Deadline));
+            VIOSockTimerStartDeadline(&pSocket->PendedTimer, &pRequest->TimerEntry, Deadline);
         }
     }
     return status;
@@ -2117,8 +2117,8 @@ static NTSTATUS VIOSockGetSockOpt(IN WDFREQUEST Request, OUT size_t *pLength)
                 break;
             }
 
-            *(PULONG)pOptVal = pSocket->SendTimeout == MAXULONGLONG ? 0
-                                                                    : (ULONG)(pSocket->SendTimeout / WDF_TIMEOUT_TO_MS);
+            *(PULONG)pOptVal = pSocket->SendTimeout == MAXLONGLONG ? 0
+                                                                   : (ULONG)(pSocket->SendTimeout / WDF_TIMEOUT_TO_MS);
             pOpt->optlen = sizeof(ULONG);
             break;
 
@@ -2129,8 +2129,8 @@ static NTSTATUS VIOSockGetSockOpt(IN WDFREQUEST Request, OUT size_t *pLength)
                 break;
             }
 
-            *(PULONG)pOptVal = pSocket->RecvTimeout == MAXULONGLONG ? 0
-                                                                    : (ULONG)(pSocket->RecvTimeout / WDF_TIMEOUT_TO_MS);
+            *(PULONG)pOptVal = pSocket->RecvTimeout == MAXLONGLONG ? 0
+                                                                   : (ULONG)(pSocket->RecvTimeout / WDF_TIMEOUT_TO_MS);
             pOpt->optlen = sizeof(ULONG);
             break;
 

--- a/viosock/sys/Socket.c
+++ b/viosock/sys/Socket.c
@@ -67,8 +67,10 @@ VIOSockSetSockOpt(IN WDFREQUEST Request);
 NTSTATUS
 VIOSockIoctl(IN WDFREQUEST Request, OUT size_t *pLength);
 
-typedef union _VIOSOCK_PENDED_CONTEXT {
+typedef struct _VIOSOCK_PENDED_CONTEXT
+{
     WDFFILEOBJECT ParentSocket;
+    VIOSOCK_TIMER_ENTRY TimerEntry;
 } VIOSOCK_PENDED_CONTEXT, *PVIOSOCK_PENDED_CONTEXT;
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VIOSOCK_PENDED_CONTEXT, GetRequestPendedContext);
@@ -123,12 +125,12 @@ _Requires_lock_not_held_(pSocket->RxLock) __declspec(noinline) NTSTATUS VIOSockP
 
 _Requires_lock_not_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetLocked(IN PSOCKET_CONTEXT pSocket,
                                                                                  IN WDFREQUEST Request,
-                                                                                 IN LONGLONG Timeout)
+                                                                                 IN LONGLONG Deadline)
 {
     NTSTATUS status;
 
     WdfSpinLockAcquire(pSocket->RxLock);
-    status = VIOSockPendedRequestSet(pSocket, Request, Timeout);
+    status = VIOSockPendedRequestSet(pSocket, Request, Deadline);
     WdfSpinLockRelease(pSocket->RxLock);
 
     return status;
@@ -536,30 +538,26 @@ __inline BOOLEAN VIOSockIsBound(IN PSOCKET_CONTEXT pSocket)
 //////////////////////////////////////////////////////////////////////////
 static VOID VIOSockPendedRequestCancel(IN WDFREQUEST Request)
 {
-    PSOCKET_CONTEXT pSocket = GetSocketContextFromRequest(Request);
-    WDFFILEOBJECT ParentSocket = WDF_NO_HANDLE;
+    PSOCKET_CONTEXT pSocket;
     PVIOSOCK_PENDED_CONTEXT pRequest = GetRequestPendedContext(Request);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, Request: %p\n", __FUNCTION__, Request);
 
-    if (pRequest)
-    {
-        ParentSocket = pRequest->ParentSocket;
-    }
-    if (ParentSocket != WDF_NO_HANDLE)
-    {
-        pSocket = GetSocketContext(ParentSocket);
-    }
-
-    ASSERT(pSocket && pSocket->PendedRequest == Request);
+    ASSERT(pRequest->ParentSocket);
+    pSocket = GetSocketContext(pRequest->ParentSocket);
+    ASSERT(pSocket->PendedRequest == Request);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "Socket %d\n", pSocket->SocketId);
 
     WdfSpinLockAcquire(pSocket->RxLock);
-    VIOSockTimerCancel(&pSocket->PendedTimer);
-    WdfObjectDereference(Request);
+    if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
+    {
+        VIOSockTimerDeref(&pSocket->PendedTimer, TRUE);
+    }
     pSocket->PendedRequest = WDF_NO_HANDLE;
     WdfSpinLockRelease(pSocket->RxLock);
+
+    WdfObjectDereference(pRequest->ParentSocket);
 
     WdfRequestComplete(Request, STATUS_CANCELLED);
 }
@@ -581,14 +579,13 @@ VOID VIOSockPendedTimerFunc(WDFTIMER Timer)
     }
 }
 
-_Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOCKET_CONTEXT pSocket,
-                                                                         IN WDFREQUEST Request,
-                                                                         IN LONGLONG Timeout,
-                                                                         IN BOOLEAN Resume)
+_Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSet(IN PSOCKET_CONTEXT pSocket,
+                                                                       IN WDFREQUEST Request,
+                                                                       IN LONGLONG Deadline)
 {
     NTSTATUS status;
     PSOCKET_CONTEXT pRequestSocket = GetSocketContextFromRequest(Request);
-    PVIOSOCK_PENDED_CONTEXT pRequest = NULL;
+    PVIOSOCK_PENDED_CONTEXT pRequest = GetRequestPendedContext(Request);
 
     TraceEvents(TRACE_LEVEL_VERBOSE,
                 DBG_SOCKET,
@@ -600,15 +597,11 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOC
     ASSERT(pSocket && pRequestSocket);
     ASSERT(pSocket->PendedRequest == WDF_NO_HANDLE);
 
-    // store parent socket handle
-    if (pRequestSocket != pSocket)
+    if (!pRequest)
     {
         WDF_OBJECT_ATTRIBUTES attributes;
 
         WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, VIOSOCK_PENDED_CONTEXT);
-
-        TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "Linking pended request to parent socket\n");
-
         status = WdfObjectAllocateContext(Request, &attributes, &pRequest);
 
         if (!NT_SUCCESS(status))
@@ -617,11 +610,12 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOC
             return status;
         }
 
-        ASSERT(pRequest->ParentSocket == WDF_NO_HANDLE || pRequest->ParentSocket == pSocket->ThisSocket);
-        pRequest->ParentSocket = pSocket->ThisSocket;
+        // store parent socket handle
+        VIOSockTimerEntryInit(&pRequest->TimerEntry);
     }
 
-    WdfObjectReference(Request);
+    WdfObjectReference(pSocket->ThisSocket);
+    pRequest->ParentSocket = pSocket->ThisSocket;
     pSocket->PendedRequest = Request;
 
     status = WdfRequestMarkCancelableEx(pSocket->PendedRequest, VIOSockPendedRequestCancel);
@@ -629,33 +623,42 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOC
     {
         ASSERT(status == STATUS_CANCELLED);
         pSocket->PendedRequest = WDF_NO_HANDLE;
-        WdfObjectDereference(Request);
+        WdfObjectDereference(pSocket->ThisSocket);
 
         TraceEvents(TRACE_LEVEL_WARNING, DBG_SOCKET, "Pended request canceled: 0x%x\n", status);
     }
-    else if (Resume)
+    else
     {
-        if (!VIOSockTimerResume(&pSocket->PendedTimer))
+        // Use pended request deadline (resume timer) if Deadline parameter is zero
+        if (!Deadline)
         {
-            // rollback request pending
-            if (!NT_SUCCESS(WdfRequestUnmarkCancelable(Request)))
-            {
-                status = STATUS_CANCELLED;
-            }
-            else
-            {
-                status = STATUS_IO_TIMEOUT;
-            }
+            ASSERT(VIOSockTimerEntryIsSet(&pRequest->TimerEntry));
+            Deadline = pRequest->TimerEntry.Deadline;
 
-            pSocket->PendedRequest = WDF_NO_HANDLE;
-            WdfObjectDereference(Request);
+            if (VIOSockTimerDeadlineIsExpired(Deadline))
+            {
+                // rollback request pending
+                if (!NT_SUCCESS(WdfRequestUnmarkCancelable(Request)))
+                {
+                    status = STATUS_CANCELLED;
+                }
+                else
+                {
+                    status = STATUS_IO_TIMEOUT;
+                }
+
+                pSocket->PendedRequest = WDF_NO_HANDLE;
+                WdfObjectDereference(pSocket->ThisSocket);
+
+                return status;
+            }
+        }
+
+        if (Deadline != MAXLONGLONG)
+        {
+            VIOSockTimerStart(&pSocket->PendedTimer, &pRequest->TimerEntry, VIOSockTimerDeadlineToTimeout(Deadline));
         }
     }
-    else if (Timeout)
-    {
-        VIOSockTimerSetTimeout(&pSocket->PendedTimer, Timeout);
-    }
-
     return status;
 }
 
@@ -663,11 +666,8 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestGet(IN PSOCKE
                                                                        OUT WDFREQUEST *Request)
 {
     NTSTATUS status = STATUS_SUCCESS;
-    ;
 
     TraceEvents(TRACE_LEVEL_VERBOSE, DBG_SOCKET, "--> %s, Socket %d\n", __FUNCTION__, pSocket->SocketId);
-
-    VIOSockTimerSuspend(&pSocket->PendedTimer);
 
     *Request = pSocket->PendedRequest;
     if (*Request != WDF_NO_HANDLE)
@@ -683,9 +683,14 @@ _Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestGet(IN PSOCKE
         }
         else
         {
-            ASSERT(GetRequestPendedContext(*Request) == NULL || GetRequestPendedContext(*Request)->ParentSocket);
+            PVIOSOCK_PENDED_CONTEXT pRequest = GetRequestPendedContext(*Request);
 
-            WdfObjectDereference(*Request);
+            ASSERT(pRequest->ParentSocket == pSocket->ThisSocket);
+            if (VIOSockTimerEntryIsSet(&pRequest->TimerEntry))
+            {
+                VIOSockTimerDeref(&pSocket->PendedTimer, TRUE);
+            }
+            WdfObjectDereference(pSocket->ThisSocket);
             pSocket->PendedRequest = WDF_NO_HANDLE;
         }
     }
@@ -958,7 +963,7 @@ static NTSTATUS VIOSockAccept(IN HANDLE hListenSocket, IN WDFREQUEST Request)
                 {
                     if (pListenSocket->PendedRequest == WDF_NO_HANDLE)
                     {
-                        status = VIOSockPendedRequestSetLocked(pListenSocket, Request, 0);
+                        status = VIOSockPendedRequestSetLocked(pListenSocket, Request, MAXLONGLONG);
                     }
                     else
                     {
@@ -1423,7 +1428,10 @@ static NTSTATUS VIOSockConnect(IN WDFREQUEST Request)
 
     if (!VIOSockIsNonBlocking(pSocket))
     {
-        status = VIOSockPendedRequestSetLocked(pSocket, Request, pSocket->ConnectTimeout);
+        ASSERT(pSocket->ConnectTimeout && pSocket->ConnectTimeout != MAXLONGLONG);
+        status = VIOSockPendedRequestSetLocked(pSocket,
+                                               Request,
+                                               VIOSockTimerTimeoutToDeadline(pSocket->ConnectTimeout));
         if (!NT_SUCCESS(status))
         {
             VIOSockStateSet(pSocket, VIOSOCK_STATE_CLOSE);

--- a/viosock/sys/Tx.c
+++ b/viosock/sys/Tx.c
@@ -1026,7 +1026,7 @@ VOID VIOSockTxTimerFunc(WDFTIMER Timer)
 {
     PDEVICE_CONTEXT pContext = GetDeviceContext(WdfTimerGetParentObject(Timer));
     PLIST_ENTRY CurrentEntry;
-    LONGLONG Timeout = LONGLONG_MAX;
+    LONGLONG Timeout = MAXLONGLONG;
     LIST_ENTRY CompletionList;
     BOOLEAN SetTimer = FALSE, bAlwaysTrue = TRUE;
 

--- a/viosock/sys/Tx.c
+++ b/viosock/sys/Tx.c
@@ -87,7 +87,7 @@ typedef struct _VIOSOCK_TX_ENTRY
     ULONG32 flags;
     USHORT type;
 
-    LONGLONG Timeout; // 100ns
+    VIOSOCK_TIMER_ENTRY TimerEntry; // 100ns
 } VIOSOCK_TX_ENTRY, *PVIOSOCK_TX_ENTRY;
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VIOSOCK_TX_ENTRY, GetRequestTxContext);
@@ -462,7 +462,7 @@ _Requires_lock_not_held_(pContext->TxLock) static VOID VIOSockTxDequeue(PDEVICE_
                 PSOCKET_CONTEXT pSocket = GetSocketContext(pTxEntry->Socket);
                 VIRTIO_DMA_TRANSACTION_PARAMS params = {0};
 
-                if (pTxEntry->Timeout)
+                if (VIOSockTimerEntryIsSet(&pTxEntry->TimerEntry))
                 {
                     VIOSockTimerDeref(&pContext->TxTimer, TRUE);
                 }
@@ -595,7 +595,7 @@ _Requires_lock_not_held_(pContext->TxLock) VOID VIOSockTxCleanup(PDEVICE_CONTEXT
 
             InsertTailList(&CompletionList, &pTxEntry->ListEntry); // complete later
 
-            if (pTxEntry->Timeout)
+            if (VIOSockTimerEntryIsSet(&pTxEntry->TimerEntry))
             {
                 VIOSockTimerDeref(&pContext->TxTimer, TRUE);
             }
@@ -663,7 +663,7 @@ static VOID VIOSockTxEnqueueCancel(IN WDFREQUEST Request)
     RemoveEntryList(&pTxEntry->ListEntry);
     VIOSockTxPutCredit(pSocket, pTxEntry->len);
 
-    if (pTxEntry->Timeout)
+    if (VIOSockTimerEntryIsSet(&pTxEntry->TimerEntry))
     {
         VIOSockTimerDeref(&pContext->TxTimer, TRUE);
     }
@@ -743,7 +743,6 @@ VIOSockTxEnqueue(IN PSOCKET_CONTEXT pSocket,
     pTxEntry->op = Op;
     pTxEntry->reply = Reply;
     pTxEntry->flags = Flags;
-    pTxEntry->Timeout = 0;
 
     uLen = VIOSockTxGetCredit(pSocket, pTxEntry->len);
     if (pTxEntry->len && !uLen)
@@ -753,6 +752,8 @@ VIOSockTxEnqueue(IN PSOCKET_CONTEXT pSocket,
 
         return STATUS_BUFFER_TOO_SMALL;
     }
+
+    VIOSockTimerEntryInit(&pTxEntry->TimerEntry);
 
     WdfSpinLockAcquire(pContext->TxLock);
 
@@ -776,10 +777,9 @@ VIOSockTxEnqueue(IN PSOCKET_CONTEXT pSocket,
             return status; // caller completes failed requests
         }
 
-        if (pSocket->SendTimeout != LONG_MAX)
+        if (pSocket->SendTimeout != MAXLONGLONG)
         {
-            pTxEntry->Timeout = WDF_ABS_TIMEOUT_IN_MS(pSocket->SendTimeout);
-            VIOSockTimerStart(&pContext->TxTimer, pTxEntry->Timeout);
+            VIOSockTimerStart(&pContext->TxTimer, &pTxEntry->TimerEntry, pSocket->SendTimeout);
         }
     }
 
@@ -1026,7 +1026,7 @@ VOID VIOSockTxTimerFunc(WDFTIMER Timer)
 {
     PDEVICE_CONTEXT pContext = GetDeviceContext(WdfTimerGetParentObject(Timer));
     PLIST_ENTRY CurrentEntry;
-    LONGLONG Timeout = MAXLONGLONG;
+    LONGLONG MinRemainingTicks = MAXLONGLONG;
     LIST_ENTRY CompletionList;
     BOOLEAN SetTimer = FALSE, bAlwaysTrue = TRUE;
 
@@ -1040,9 +1040,10 @@ VOID VIOSockTxTimerFunc(WDFTIMER Timer)
     {
         PVIOSOCK_TX_ENTRY pTxEntry = CONTAINING_RECORD(CurrentEntry, VIOSOCK_TX_ENTRY, ListEntry);
 
-        if (pTxEntry->Timeout)
+        if (VIOSockTimerEntryIsSet(&pTxEntry->TimerEntry))
         {
-            if (pTxEntry->Timeout <= pContext->TxTimer.Timeout + VIOSOCK_TIMER_TOLERANCE)
+            LONGLONG llRemainingTicks = VIOSockTimerEntryRemainingTicks(&pTxEntry->TimerEntry);
+            if (llRemainingTicks <= VIOSOCK_TIMER_TOLERANCE_TICKS)
             {
                 CurrentEntry = CurrentEntry->Blink;
                 RemoveEntryList(&pTxEntry->ListEntry);
@@ -1072,23 +1073,16 @@ VOID VIOSockTxTimerFunc(WDFTIMER Timer)
                     VIOSockTimerDeref(&pContext->TxTimer, FALSE);
                 }
             }
-            else
+            else if (llRemainingTicks < MinRemainingTicks)
             {
-                SetTimer = TRUE;
-
-                pTxEntry->Timeout -= pContext->TxTimer.Timeout;
-
-                if (pTxEntry->Timeout < Timeout)
-                {
-                    Timeout = pTxEntry->Timeout;
-                }
+                MinRemainingTicks = llRemainingTicks;
             }
         }
     }
 
-    if (SetTimer)
+    if (MinRemainingTicks != MAXLONGLONG)
     {
-        VIOSockTimerSet(&pContext->TxTimer, Timeout);
+        VIOSockTimerSetDeadline(&pContext->TxTimer, VIOSockTimerTicksToDeadline(MinRemainingTicks));
     }
 
     WdfSpinLockRelease(pContext->TxLock);

--- a/viosock/sys/Tx.c
+++ b/viosock/sys/Tx.c
@@ -779,7 +779,7 @@ VIOSockTxEnqueue(IN PSOCKET_CONTEXT pSocket,
 
         if (pSocket->SendTimeout != MAXLONGLONG)
         {
-            VIOSockTimerStart(&pContext->TxTimer, &pTxEntry->TimerEntry, pSocket->SendTimeout);
+            VIOSockTimerStartTimeout(&pContext->TxTimer, &pTxEntry->TimerEntry, pSocket->SendTimeout);
         }
     }
 

--- a/viosock/sys/public.h
+++ b/viosock/sys/public.h
@@ -157,6 +157,9 @@ typedef struct _VIRTIO_VSOCK_FD_SET
     ULONGLONG fd_array[FD_SETSIZE]; /* an array of SOCKETs */
 } VIRTIO_VSOCK_FD_SET, *PVIRTIO_VSOCK_FD_SET;
 
+// Sentinel value for VIRTIO_VSOCK_SELECT.Timeout: wait indefinitely (no timer).
+#define VSOCK_TIMEOUT_INFINITE MAXLONGLONG
+
 typedef struct _VIRTIO_VSOCK_SELECT
 {
     VIRTIO_VSOCK_FD_SET Fdss[FDSET_MAX];

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -645,13 +645,14 @@ __inline BOOLEAN VIOSockTimerDeadlineIsExpired(IN LONGLONG Deadline)
 
 __inline LONGLONG VIOSockTimerTimeoutToDeadline(IN LONGLONG Timeout)
 {
-    return VIOSockTimerTicksToDeadline(VIOSockTimerTimeoutToTicks(Timeout));
+    return Timeout == MAXLONGLONG ? MAXLONGLONG : VIOSockTimerTicksToDeadline(VIOSockTimerTimeoutToTicks(Timeout));
 }
 
 // Caller must ensure Deadline != MAXLONGLONG; passing MAXLONGLONG overflows on multiply.
 __inline LONGLONG VIOSockTimerDeadlineToTimeout(IN LONGLONG Deadline)
 {
-    return VIOSockTimerTicksToTimeout(VIOSockTimerDeadlineRemainingTicks(Deadline));
+    return Deadline == MAXLONGLONG ? MAXLONGLONG
+                                   : VIOSockTimerTicksToTimeout(VIOSockTimerDeadlineRemainingTicks(Deadline));
 }
 
 __inline BOOLEAN VIOSockTimerEntryIsSet(IN PVIOSOCK_TIMER_ENTRY pEntry)
@@ -683,7 +684,14 @@ __inline BOOLEAN VIOSockTimerEntryIsExpired(IN PVIOSOCK_TIMER_ENTRY pEntry)
 
 NTSTATUS VIOSockTimerCreate(IN PVIOSOCK_TIMER pTimer, IN WDFOBJECT ParentObject, IN PFN_WDF_TIMER EvtTimerFunc);
 
-VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Timeout);
+VOID VIOSockTimerStartDeadline(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Deadline);
+
+__inline VOID VIOSockTimerStartTimeout(IN PVIOSOCK_TIMER pTimer,
+                                       IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL,
+                                       IN LONGLONG Timeout)
+{
+    VIOSockTimerStartDeadline(pTimer, pEntry, VIOSockTimerTimeoutToDeadline(Timeout));
+}
 
 __inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Deadline)
 {
@@ -705,15 +713,7 @@ __inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Dead
 __inline VOID VIOSockTimerSetTimeout(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
 {
     ASSERT(Timeout > 0);
-    if (!Timeout || Timeout == MAXLONGLONG)
-    {
-        ASSERT(!pTimer->StartRefs);
-        pTimer->Deadline = MAXLONGLONG;
-        return;
-    }
-
-    pTimer->Deadline = VIOSockTimerTimeoutToDeadline(Timeout);
-    WdfTimerStart(pTimer->Timer, -Timeout);
+    VIOSockTimerSetDeadline(pTimer, VIOSockTimerTimeoutToDeadline(Timeout));
 }
 
 __inline VOID VIOSockTimerCancel(IN PVIOSOCK_TIMER pTimer)

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -688,7 +688,11 @@ __inline VOID VIOSockTimerStartTimeout(IN PVIOSOCK_TIMER pTimer,
                                        IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL,
                                        IN LONGLONG Timeout)
 {
-    VIOSockTimerStartDeadline(pTimer, pEntry, VIOSockTimerTimeoutToDeadline(Timeout));
+    ASSERT(Timeout > 0);
+    if (Timeout > 0)
+    {
+        VIOSockTimerStartDeadline(pTimer, pEntry, VIOSockTimerTimeoutToDeadline(Timeout));
+    }
 }
 
 __inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Deadline)

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -125,10 +125,8 @@ extern LONGLONG llTimerToleranceTicks;
 typedef struct _VIOSOCK_TIMER
 {
     WDFTIMER Timer;
-    LONGLONG Deadline;  // absolute tick count of expiry
-    LONGLONG StartTime; // ticks when timer started
-    LONGLONG Timeout;   // timeout in 100ns
-    ULONG StartRefs;    // stop timer if refs = 0
+    LONGLONG Deadline; // absolute tick count of expiry
+    ULONG StartRefs;   // stop timer if refs = 0
 } VIOSOCK_TIMER, *PVIOSOCK_TIMER;
 
 // Per-request deadline tracking; must be accessed under the same lock as VIOSOCK_TIMER.

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -114,13 +114,30 @@ typedef struct VirtIOBufferDescriptor VIOSOCK_SG_DESC, *PVIOSOCK_SG_DESC;
 #define INVALID_THREAD_ID                LONG64_ERROR
 //////////////////////////////////////////////////////////////////////////
 #define VIOSOCK_TIMER_TOLERANCE          MSEC_TO_NANO(50)
+#define VIOSOCK_TIMER_TOLERANCE_TICKS    llTimerToleranceTicks
+#define VIOSOCK_TIMER_TIME_INCREMENT     ulTimeIncrement
+
+extern ULONG ulTimeIncrement;
+extern LONGLONG llTimerToleranceTicks;
+
+// All fields of VIOSOCK_TIMER must be read and written under the caller's lock
+// (e.g. WdfWaitLock or WdfSpinLock that guards the associated request list).
 typedef struct _VIOSOCK_TIMER
 {
     WDFTIMER Timer;
+    LONGLONG Deadline;  // absolute tick count of expiry
     LONGLONG StartTime; // ticks when timer started
     LONGLONG Timeout;   // timeout in 100ns
-    ULONG StartRefs;
+    ULONG StartRefs;    // stop timer if refs = 0
 } VIOSOCK_TIMER, *PVIOSOCK_TIMER;
+
+// Per-request deadline tracking; must be accessed under the same lock as VIOSOCK_TIMER.
+// Deadline == MAXLONGLONG means no expiry. Always initialize with VIOSockTimerEntryInit
+// because WDF zero-initializes object contexts (Deadline=0 would look like tick 0 = expired).
+typedef struct _VIOSOCK_TIMER_ENTRY
+{
+    LONGLONG Deadline; // absolute tick count of expiry (MAXLONGLONG = no deadline, 0 = not initialized)
+} VIOSOCK_TIMER_ENTRY, *PVIOSOCK_TIMER_ENTRY;
 
 #define VIOSOCK_DEVICE_NAME L"\\Device\\Viosock"
 
@@ -232,8 +249,8 @@ typedef struct _SOCKET_CONTEXT
     WDFSPINLOCK StateLock;
     _Interlocked_ volatile VIOSOCK_STATE State;
     LONGLONG ConnectTimeout;
-    ULONG SendTimeout;
-    ULONG RecvTimeout;
+    LONGLONG SendTimeout;
+    LONGLONG RecvTimeout;
     ULONG32 BufferMinSize;
     ULONG32 BufferMaxSize;
     ULONG32 PeerShutdown;
@@ -596,34 +613,104 @@ VIOSockLoopbackTxEnqueue(IN PSOCKET_CONTEXT pSocket,
                          IN ULONG Length OPTIONAL);
 
 //////////////////////////////////////////////////////////////////////////
-__inline NTSTATUS VIOSockTimerCreate(IN PVIOSOCK_TIMER pTimer, IN WDFOBJECT ParentObject, IN PFN_WDF_TIMER EvtTimerFunc)
+__inline LONGLONG VIOSockTimerTimeoutToTicks(IN LONGLONG Timeout)
 {
-    WDF_OBJECT_ATTRIBUTES Attributes;
-    WDF_TIMER_CONFIG timerConfig;
-
-    pTimer->Timeout = 0;
-    pTimer->StartTime = 0;
-    pTimer->StartRefs = 0;
-
-    WDF_TIMER_CONFIG_INIT(&timerConfig, EvtTimerFunc);
-
-    WDF_OBJECT_ATTRIBUTES_INIT(&Attributes);
-    Attributes.ParentObject = ParentObject;
-
-    return WdfTimerCreate(&timerConfig, &Attributes, &pTimer->Timer);
+    return Timeout / VIOSOCK_TIMER_TIME_INCREMENT;
 }
 
-VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout);
+__inline LONGLONG VIOSockTimerTicksToTimeout(IN LONGLONG Ticks)
+{
+    return Ticks * VIOSOCK_TIMER_TIME_INCREMENT;
+}
 
-__inline VOID VIOSockTimerSet(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
+__inline LONGLONG VIOSockTimerTicksToDeadline(IN LONGLONG Ticks)
 {
     LARGE_INTEGER liTicks;
 
+    KeQueryTickCount(&liTicks);
+    return liTicks.QuadPart + Ticks;
+}
+
+__inline LONGLONG VIOSockTimerDeadlineRemainingTicks(IN LONGLONG Deadline)
+{
+    LARGE_INTEGER liNow;
+    LONGLONG llRemaining;
+
+    KeQueryTickCount(&liNow);
+    llRemaining = (Deadline - liNow.QuadPart);
+    return llRemaining > 0 ? llRemaining : 0;
+}
+
+__inline BOOLEAN VIOSockTimerDeadlineIsExpired(IN LONGLONG Deadline)
+{
+    return VIOSockTimerDeadlineRemainingTicks(Deadline) <= VIOSOCK_TIMER_TOLERANCE_TICKS;
+}
+
+__inline LONGLONG VIOSockTimerTimeoutToDeadline(IN LONGLONG Timeout)
+{
+    return VIOSockTimerTicksToDeadline(VIOSockTimerTimeoutToTicks(Timeout));
+}
+
+// Caller must ensure Deadline != MAXLONGLONG; passing MAXLONGLONG overflows on multiply.
+__inline LONGLONG VIOSockTimerDeadlineToTimeout(IN LONGLONG Deadline)
+{
+    return VIOSockTimerTicksToTimeout(VIOSockTimerDeadlineRemainingTicks(Deadline));
+}
+
+__inline BOOLEAN VIOSockTimerEntryIsSet(IN PVIOSOCK_TIMER_ENTRY pEntry)
+{
+    return pEntry->Deadline != MAXLONGLONG;
+}
+
+__inline VOID VIOSockTimerEntryInit(IN PVIOSOCK_TIMER_ENTRY pEntry)
+{
+    pEntry->Deadline = MAXLONGLONG;
+}
+
+__inline LONGLONG VIOSockTimerEntryRemainingTicks(IN PVIOSOCK_TIMER_ENTRY pEntry)
+{
+    if (!VIOSockTimerEntryIsSet(pEntry))
+    {
+        return MAXLONGLONG;
+    }
+
+    return VIOSockTimerDeadlineRemainingTicks(pEntry->Deadline);
+}
+
+// Safe to call without a prior IsSet check: MAXLONGLONG - now is always a large positive
+// value, so RemainingTicks > TOLERANCE_TICKS and the function returns FALSE for unset entries.
+__inline BOOLEAN VIOSockTimerEntryIsExpired(IN PVIOSOCK_TIMER_ENTRY pEntry)
+{
+    return VIOSockTimerDeadlineIsExpired(pEntry->Deadline);
+}
+
+NTSTATUS VIOSockTimerCreate(IN PVIOSOCK_TIMER pTimer, IN WDFOBJECT ParentObject, IN PFN_WDF_TIMER EvtTimerFunc);
+
+VOID VIOSockTimerStart(IN PVIOSOCK_TIMER pTimer, IN PVIOSOCK_TIMER_ENTRY pEntry OPTIONAL, IN LONGLONG Timeout);
+
+__inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Deadline)
+{
+    LONGLONG Timeout;
+
+    ASSERT(Deadline && Deadline > 0);
+    if (!Deadline || Deadline == MAXLONGLONG)
+    {
+        ASSERT(!pTimer->StartRefs);
+        pTimer->Deadline = MAXLONGLONG;
+        return;
+    }
+
+    pTimer->Deadline = Deadline;
+    Timeout = VIOSockTimerDeadlineToTimeout(Deadline);
+    WdfTimerStart(pTimer->Timer, -Timeout);
+}
+
+__inline VOID VIOSockTimerSetTimeout(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
+{
     if (!Timeout || Timeout == MAXLONGLONG)
     {
         ASSERT(!pTimer->StartRefs);
-        pTimer->StartTime = 0;
-        pTimer->Timeout = 0;
+        pTimer->Deadline = MAXLONGLONG;
         return;
     }
 
@@ -633,18 +720,14 @@ __inline VOID VIOSockTimerSet(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
         Timeout = VIOSOCK_TIMER_TOLERANCE + 1;
     }
 
-    KeQueryTickCount(&liTicks);
-
-    pTimer->StartTime = liTicks.QuadPart;
-    pTimer->Timeout = Timeout;
+    pTimer->Deadline = VIOSockTimerTimeoutToDeadline(Timeout);
     WdfTimerStart(pTimer->Timer, -Timeout);
 }
 
 __inline VOID VIOSockTimerCancel(IN PVIOSOCK_TIMER pTimer)
 {
     WdfTimerStop(pTimer->Timer, FALSE);
-    pTimer->Timeout = 0;
-    pTimer->StartTime = 0;
+    pTimer->Deadline = MAXLONGLONG;
 }
 
 __inline VOID VIOSockTimerDeref(IN PVIOSOCK_TIMER pTimer, IN BOOLEAN bStop)
@@ -656,31 +739,20 @@ __inline VOID VIOSockTimerDeref(IN PVIOSOCK_TIMER pTimer, IN BOOLEAN bStop)
     }
 }
 
-__inline LONGLONG VIOSockTimerPassed(IN PVIOSOCK_TIMER pTimer)
-{
-    LARGE_INTEGER liTicks;
-
-    KeQueryTickCount(&liTicks);
-
-    return (liTicks.QuadPart - pTimer->StartTime) * KeQueryTimeIncrement();
-}
-
 __inline BOOLEAN VIOSockTimerSuspend(IN PVIOSOCK_TIMER pTimer)
 {
     if (WdfTimerStop(pTimer->Timer, FALSE))
     {
-        return pTimer->Timeout > VIOSockTimerPassed(pTimer) + VIOSOCK_TIMER_TOLERANCE;
+        return !VIOSockTimerDeadlineIsExpired(pTimer->Deadline);
     }
     return TRUE;
 }
 
 __inline BOOLEAN VIOSockTimerResume(IN PVIOSOCK_TIMER pTimer)
 {
-    LONGLONG llTimeout = VIOSockTimerPassed(pTimer);
-
-    if (pTimer->Timeout > llTimeout + VIOSOCK_TIMER_TOLERANCE)
+    if (!VIOSockTimerDeadlineIsExpired(pTimer->Deadline))
     {
-        VIOSockTimerSet(pTimer, pTimer->Timeout - llTimeout);
+        VIOSockTimerSetDeadline(pTimer, pTimer->Deadline);
         return TRUE;
     }
     return FALSE;

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -273,7 +273,7 @@ typedef struct _SOCKET_CONTEXT
     _Guarded_by_(RxLock) VIOSOCK_TIMER ReadTimer;
 
     _Guarded_by_(RxLock) WDFREQUEST PendedRequest;
-    VIOSOCK_TIMER PendedTimer;
+    _Guarded_by_(RxLock) VIOSOCK_TIMER PendedTimer;
 
     _Guarded_by_(RxLock) LIST_ENTRY AcceptList;
     LONG Backlog;
@@ -371,18 +371,15 @@ __inline BOOLEAN VIOSockIsDone(PSOCKET_CONTEXT pSocket)
     return !!KeReadStateEvent(&pSocket->CloseEvent);
 }
 
-_Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetEx(IN PSOCKET_CONTEXT pSocket,
-                                                                         IN WDFREQUEST Request,
-                                                                         IN LONGLONG Timeout,
-                                                                         IN BOOLEAN Resume);
-
-#define VIOSockPendedRequestSet(s, r, t) VIOSockPendedRequestSetEx(s, r, t, FALSE)
+_Requires_lock_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSet(IN PSOCKET_CONTEXT pSocket,
+                                                                       IN WDFREQUEST Request,
+                                                                       IN LONGLONG Deadline);
 
 _Requires_lock_not_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetLocked(IN PSOCKET_CONTEXT pSocket,
                                                                                  IN WDFREQUEST Request,
-                                                                                 IN LONGLONG Timeout);
+                                                                                 IN LONGLONG Deadline);
 
-#define VIOSockPendedRequestSetResume(s, r) VIOSockPendedRequestSetEx(s, r, 0, TRUE)
+#define VIOSockPendedRequestSetResume(s, r) VIOSockPendedRequestSet(s, r, 0)
 
 _Requires_lock_not_held_(pSocket->RxLock) NTSTATUS VIOSockPendedRequestSetResumeLocked(IN PSOCKET_CONTEXT pSocket,
                                                                                        IN WDFREQUEST Request);
@@ -692,7 +689,7 @@ __inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Dead
 {
     LONGLONG Timeout;
 
-    ASSERT(Deadline && Deadline > 0);
+    ASSERT(Deadline > 0);
     if (!Deadline || Deadline == MAXLONGLONG)
     {
         ASSERT(!pTimer->StartRefs);
@@ -707,17 +704,12 @@ __inline VOID VIOSockTimerSetDeadline(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Dead
 
 __inline VOID VIOSockTimerSetTimeout(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
 {
+    ASSERT(Timeout > 0);
     if (!Timeout || Timeout == MAXLONGLONG)
     {
         ASSERT(!pTimer->StartRefs);
         pTimer->Deadline = MAXLONGLONG;
         return;
-    }
-
-    ASSERT(Timeout > VIOSOCK_TIMER_TOLERANCE);
-    if (Timeout <= VIOSOCK_TIMER_TOLERANCE)
-    {
-        Timeout = VIOSOCK_TIMER_TOLERANCE + 1;
     }
 
     pTimer->Deadline = VIOSockTimerTimeoutToDeadline(Timeout);
@@ -733,29 +725,14 @@ __inline VOID VIOSockTimerCancel(IN PVIOSOCK_TIMER pTimer)
 __inline VOID VIOSockTimerDeref(IN PVIOSOCK_TIMER pTimer, IN BOOLEAN bStop)
 {
     ASSERT(pTimer->StartRefs);
-    if (--pTimer->StartRefs == 0 && bStop)
+    if (--pTimer->StartRefs == 0)
     {
-        VIOSockTimerCancel(pTimer);
+        pTimer->Deadline = MAXLONGLONG;
+        if (bStop)
+        {
+            WdfTimerStop(pTimer->Timer, FALSE);
+        }
     }
-}
-
-__inline BOOLEAN VIOSockTimerSuspend(IN PVIOSOCK_TIMER pTimer)
-{
-    if (WdfTimerStop(pTimer->Timer, FALSE))
-    {
-        return !VIOSockTimerDeadlineIsExpired(pTimer->Deadline);
-    }
-    return TRUE;
-}
-
-__inline BOOLEAN VIOSockTimerResume(IN PVIOSOCK_TIMER pTimer)
-{
-    if (!VIOSockTimerDeadlineIsExpired(pTimer->Deadline))
-    {
-        VIOSockTimerSetDeadline(pTimer, pTimer->Deadline);
-        return TRUE;
-    }
-    return FALSE;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/viosock/sys/viosock.h
+++ b/viosock/sys/viosock.h
@@ -619,7 +619,7 @@ __inline VOID VIOSockTimerSet(IN PVIOSOCK_TIMER pTimer, IN LONGLONG Timeout)
 {
     LARGE_INTEGER liTicks;
 
-    if (!Timeout || Timeout == LONGLONG_MAX)
+    if (!Timeout || Timeout == MAXLONGLONG)
     {
         ASSERT(!pTimer->StartRefs);
         pTimer->StartTime = 0;


### PR DESCRIPTION
**Timer implementation fixes:**

- Replace the shared `StartTime`/`Timeout` fields in `VIOSOCK_TIMER` with an absolute `Deadline` (`MAXLONGLONG` = not running), eliminating a per-iteration `TimePassed` bias that caused later-queued requests to expire too late when the timer was restarted for an earlier deadline.
- Add `VIOSOCK_TIMER_ENTRY` with a per-request absolute `Deadline` so each pending request carries its own expiry independently.
- Convert `PendedTimer` to deadline-based tracking. Fix `WdfObjectReference` to reference the socket (not the request), and guard `VIOSockTimerDeref` against `StartRefs` underflow for infinite-wait requests.

**Select timeout fixes:**

- Fix `WSPSelect` to distinguish poll (`timeout={0,0}`) from infinite wait (`timeout=NULL`): the library now sends `MAXLONGLONG` for infinite wait; the driver treats `MAXLONGLONG` as "no timer" and zero as poll (completes immediately with empty fd sets).
- Fix select timeout completion: use `STATUS_TIMEOUT` (success) instead of `STATUS_IO_TIMEOUT` (error) so `DeviceIoControl` returns `TRUE` with empty fd sets, matching POSIX behavior. Remove the `WSAETIMEDOUT` special case in the library.
