### PR TITLE
RHEL-192319: Switch build environment to EWDK 26H1 and CodeQL 2.24.1 (WHCP_25H2)

### DIFF
--- a/Tools/clang-format-helper.sh
+++ b/Tools/clang-format-helper.sh
@@ -19,9 +19,9 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     clang_format="$(which clang-format-16)"
 else
     # Windows
-    # Load clang-format from the EWDK 24H2
-    EWDK11_24H2_DIR="${EWDK11_24H2_DIR:-c:\\ewdk11_24h2}"
-    clang_format_ewdk="${EWDK11_24H2_DIR}\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\Llvm\\x64\\bin\\clang-format.exe"
+    # Load clang-format from the EWDK 26H1
+    EWDK11_26H1_DIR="${EWDK11_26H1_DIR:-c:\\ewdk11_26h1}"
+    clang_format_ewdk="${EWDK11_26H1_DIR}\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\Llvm\\x64\\bin\\clang-format.exe"
     clang_format="$(cygpath "${clang_format_ewdk}")"
     # Convert the path to OS specific format
     CLANG_FORMAT_STYLE="$(cygpath -w "${CLANG_FORMAT_STYLE}")"

--- a/build/Driver.Platform.props
+++ b/build/Driver.Platform.props
@@ -27,6 +27,10 @@ Common PlatformTools definitions used by all projects:
   <VisualStudioToolset>v143</VisualStudioToolset>
   <CETCompatSupported>true</CETCompatSupported>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(VisualStudioVersionMajor)'>='18'">
+  <VisualStudioToolset>v145</VisualStudioToolset>
+  <CETCompatSupported>true</CETCompatSupported>
+  </PropertyGroup>
 
   <PropertyGroup Condition= "'$(PlatformToolset)'=='' OR '$(PlatformToolset)'=='AutoVSToolset'">
   <PlatformToolset>$(VisualStudioToolset)</PlatformToolset>

--- a/build/SetVsEnv.bat
+++ b/build/SetVsEnv.bat
@@ -5,8 +5,8 @@ set CODEQL_DRIVER_SUITES=%CODEQL_HOME%\Windows-Driver-Developer-Supplemental-Too
 
 if not "%EnterpriseWDK%"=="" goto ready
 if "%1"=="Win11" (
-    if "%EWDK11_24H2_DIR%"=="" set EWDK11_24H2_DIR=c:\ewdk11_24h2
-    call %EWDK11_24H2_DIR%\BuildEnv\SetupBuildEnv.cmd
+    if "%EWDK11_26H1_DIR%"=="" set EWDK11_26H1_DIR=c:\ewdk11_26h1
+    call "%EWDK11_26H1_DIR%\BuildEnv\SetupBuildEnv.cmd"
     @echo off
     goto :eof
 ) else (

--- a/build/build.bat
+++ b/build/build.bat
@@ -19,7 +19,7 @@ rem
 rem To do a Static Driver Verifier build, append the _SDV tag to the target OS version,
 rem for example Win10_SDV. Where SDV is deprecated, we rely on CodeQL, defaulting to
 rem the WHCP_24H2 configuration. To use an earlier configuration specify WHCP_LEGACY.
-rem We also continue to run Code Analysis (CA) and Driver Verifier Log (DVL) builds 
+rem We also continue to run Code Analysis (CA) and Driver Verifier Log (DVL) builds
 rem for use with HCK / WHCP.
 rem ================================================================================
 
@@ -191,7 +191,7 @@ if /I "!TAG!"=="SDV" (
   echo.
   rem SDV is deprecated from Windows 11 24H2, both in the EWDK and WHCP. Making some allowances...
   rem We only do SDV for Win10 targets.
-  if "%TARGET%"=="Win10" (  
+  if "%TARGET%"=="Win10" (
     echo Running SDV for %BUILD_FILE%, configuration %TARGET_VS_CONFIG%
     call :run_sdv "%TARGET_PROJ_CONFIG% %BUILD_FLAVOR%" %BUILD_ARCH%
     if "%BUILD_FAILED%" EQU "1" (
@@ -318,7 +318,7 @@ if ERRORLEVEL 1 (
 )
 
 IF "%CODEQL_FAILED%" NEQ "1" (
-  call %CODEQL_BIN% database analyze %~dp1codeql_db %CODEQL_DRIVER_SUITES%\windows_driver_recommended.qls --format=sarifv2.1.0 --output=%~dp1%BUILD_NAME%.sarif -j 0
+  call %CODEQL_BIN% database analyze %~dp1codeql_db microsoft/windows-drivers:windows-driver-suites/recommended.qls --format=sarifv2.1.0 --output=%~dp1%BUILD_NAME%.sarif -j 0
   if ERRORLEVEL 1 (
     set CODEQL_FAILED=1
   )


### PR DESCRIPTION
Static Tools Logo Test from the latest HLK for Windows 11 25H2 / Windows Server 2025 updated May 2026, requires DVL.XML version 1.2.0.0. There is no WDK/EWDK that can generate proper DVL.XML. MSFT published Errata/Filter #320241 that allows the use of DVL.XML version 1.1.0.0. So, switch the build environment to EWDK 26H1 and CodeQL 2.24.1 (WHCP_25H2) to generate DVL.XML version 1.1.0.0. 

for now until the update build machine 