### PR TITLE
RHEL-183405: [viostor] Validate blk_size to prevent divide-by-zero

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -395,7 +395,11 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
         return res;
     }
 
-    RhelGetDiskGeometry(DeviceExtension);
+    if (!RhelGetDiskGeometry(DeviceExtension))
+    {
+        return SP_RETURN_ERROR;
+    }
+
     RhelSetGuestFeatures(DeviceExtension);
 
     ConfigInfo->NumberOfBuses = 1;
@@ -1280,7 +1284,11 @@ static VOID VirtIoConfigUpdated(PADAPTER_EXTENSION adaptExt)
 {
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Device Config Interrupt\n");
 
-    RhelGetDiskGeometry(adaptExt);
+    if (!RhelGetDiskGeometry(adaptExt))
+    {
+        return;
+    }
+
     adaptExt->sense_info.senseKey = SCSI_SENSE_UNIT_ATTENTION;
     adaptExt->sense_info.additionalSenseCode = SCSI_ADSENSE_PARAMETERS_CHANGED;
     adaptExt->sense_info.additionalSenseCodeQualifier = SCSI_SENSEQ_CAPACITY_DATA_CHANGED;
@@ -1460,7 +1468,12 @@ VirtIoHwReinitialize(IN PVOID DeviceExtension)
     {
         return FALSE;
     }
-    RhelGetDiskGeometry(DeviceExtension);
+
+    if (!RhelGetDiskGeometry(DeviceExtension))
+    {
+        return FALSE;
+    }
+
     RhelSetGuestFeatures(DeviceExtension);
 
     if (!VirtIoHwInitialize(DeviceExtension))

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -625,7 +625,7 @@ RhelGetSectors(IN PVOID DeviceExtension, IN PCDB Cdb)
     return (sector.AsULong * (adaptExt->info.blk_size / SECTOR_SIZE));
 }
 
-VOID RhelGetDiskGeometry(IN PVOID DeviceExtension)
+BOOLEAN RhelGetDiskGeometry(IN PVOID DeviceExtension)
 {
     u64 cap;
     u32 v;
@@ -664,6 +664,11 @@ VOID RhelGetDiskGeometry(IN PVOID DeviceExtension)
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_BLK_SIZE))
     {
         virtio_get_config(&adaptExt->vdev, FIELD_OFFSET(blk_config, blk_size), &v, sizeof(v));
+        if (v == 0)
+        {
+            RhelDbgPrint(TRACE_LEVEL_ERROR, "Invalid blk_size %u from device config\n", v);
+            return FALSE;
+        }
         adaptExt->info.blk_size = v;
     }
     else
@@ -737,6 +742,7 @@ VOID RhelGetDiskGeometry(IN PVOID DeviceExtension)
         adaptExt->info.max_discard_seg = min(v, MAX_DISCARD_SEGMENTS);
         RhelDbgPrint(TRACE_LEVEL_INFORMATION, " max_discard_seg = %d\n", adaptExt->info.max_discard_seg);
     }
+    return TRUE;
 }
 
 VOID VioStorVQLock(IN PVOID DeviceExtension, IN ULONG MessageID, IN OUT PSTOR_LOCK_HANDLE LockHandle, IN BOOLEAN isr)

--- a/viostor/virtio_stor_hw_helper.h
+++ b/viostor/virtio_stor_hw_helper.h
@@ -148,7 +148,7 @@ RhelGetSectors(IN PVOID DeviceExtension, IN PCDB Cdb);
 BOOLEAN
 RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb);
 
-VOID RhelGetDiskGeometry(IN PVOID DeviceExtension);
+BOOLEAN RhelGetDiskGeometry(IN PVOID DeviceExtension);
 
 VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOOLEAN bIsr);
 


### PR DESCRIPTION
…de-by-zero