### PR TITLE
RHEL-183408 viostor: fix overflow in bump allocator bounds checks

### DIFF
--- a/viostor/virtio_pci.c
+++ b/viostor/virtio_pci.c
@@ -124,9 +124,9 @@ static void *mem_alloc_contiguous_pages(void *context, size_t size)
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)context;
     PVOID ptr = (PVOID)((ULONG_PTR)adaptExt->pageAllocationVa + adaptExt->pageOffset);
 
-    if ((adaptExt->pageOffset + size) <= adaptExt->pageAllocationSize)
+    size = ROUND_TO_PAGES(size);
+    if (size && size <= adaptExt->pageAllocationSize - adaptExt->pageOffset)
     {
-        size = ROUND_TO_PAGES(size);
         adaptExt->pageOffset += size;
         RtlZeroMemory(ptr, size);
         return ptr;

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -2466,9 +2466,9 @@ VioStorPoolAlloc(IN PVOID DeviceExtension, IN SIZE_T size)
     PADAPTER_EXTENSION adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     PVOID ptr = (PVOID)((ULONG_PTR)adaptExt->poolAllocationVa + adaptExt->poolOffset);
 
-    if ((adaptExt->poolOffset + size) <= adaptExt->poolAllocationSize)
+    size = ROUND_TO_CACHE_LINES(size);
+    if (size && size <= adaptExt->poolAllocationSize - adaptExt->poolOffset)
     {
-        size = ROUND_TO_CACHE_LINES(size);
         adaptExt->poolOffset += (ULONG)size;
         RtlZeroMemory(ptr, size);
         return ptr;


### PR DESCRIPTION
**Issue**
`VioStorPoolAlloc` (and the related page bump allocator in `virtio_pci.c`) checked whether a request fit in the pre-allocated pool using:

`(offset + size) <= totalSize`

With 32-bit unsigned math, offset + size can wrap around when both values are large. The result can look small, so the check incorrectly passes and the code writes past the end of the buffer via `RtlZeroMemory`.

The code checked the raw request size but allocated a cache-line- or page-rounded size. A small request near the end of the pool could pass the check yet still overrun when the rounded size was applied.

**Fix**
Updated both bump allocators to use an overflow-safe bounds check:

- Round first — compute the actual allocation size (`ROUND_TO_CACHE_LINES` for the pool, `ROUND_TO_PAGES` for pages) before checking.

- Check fit safely — instead of `offset + size`, use `offset > totalSize - alignedSize` (with a prior check that `alignedSize <= totalSize`). This avoids addition wraparound and correctly answers “is there enough space left?”
- Reject invalid sizes — fail if rounding overflows (`alignedSize < size`) or the request does not fit.
