### PR TITLE
Support IOMMU in viostor driver viostor

### DIFF
--- a/viostor/viostor.inx
+++ b/viostor/viostor.inx
@@ -91,7 +91,7 @@ HKR,,TypesSupported,%REG_DWORD%,7
 [pnpsafe_pci_addreg]
 HKR, "Parameters\PnpInterface", "5", %REG_DWORD%, 0x00000001
 HKR, "Parameters", "BusType", %REG_DWORD%, 0x00000001
-HKR, "Parameters", DmaRemappingCompatible,0x00010001,0
+HKR, "Parameters", DmaRemappingCompatible,0x00010001,3
 
 [pnpsafe_pci_addreg_msix]
 HKR, "Interrupt Management",, 0x00000010

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -410,6 +410,11 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
     ConfigInfo->CachesData = CHECKBIT(adaptExt->features, VIRTIO_BLK_F_FLUSH);
     adaptExt->writeback_cache = HasWritebackCache(adaptExt);
 
+    if (CHECKBIT(adaptExt->features, VIRTIO_F_ACCESS_PLATFORM))
+    {
+        ConfigInfo->FeatureSupport |= STOR_ADAPTER_DMA_V3_PREFERRED;
+    }
+
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Writeback cache enabled = %d\n", adaptExt->writeback_cache);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Writeback cache supported = %d\n", ConfigInfo->CachesData);
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " VIRTIO_BLK_F_MQ = %d\n", CHECKBIT(adaptExt->features, VIRTIO_BLK_F_MQ));
@@ -1482,7 +1487,7 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
 {
     PCDB cdb;
     ULONG i;
-    ULONG dummy;
+    ULONG fragLen;
     ULONG sgElement;
     ULONG sgMaxElements;
     ULONG sgLength;
@@ -1492,10 +1497,17 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
     PSTOR_SCATTER_GATHER_LIST sgList;
     ULONGLONG lba;
     ULONG blocks;
+    STOR_PHYSICAL_ADDRESS extPA;
 
     cdb = SRB_CDB(Srb);
     srbExt = SRB_EXTENSION(Srb);
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
+    extPA = StorPortGetPhysicalAddress(DeviceExtension, Srb, srbExt, &fragLen);
+    if (extPA.QuadPart == 0 || fragLen < sizeof(SRB_EXTENSION))
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Srb = 0x%p\n", Srb);
 
@@ -1650,10 +1662,9 @@ VirtIoBuildIo(IN PVOID DeviceExtension, IN PSCSI_REQUEST_BLOCK Srb)
         srbExt->in = sgElement;
     }
 
-    srbExt->sg[0].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.out_hdr, &dummy);
+    srbExt->sg[0].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.out_hdr);
     srbExt->sg[0].length = sizeof(srbExt->vbr.out_hdr);
-
-    srbExt->sg[sgElement].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.status, &dummy);
+    srbExt->sg[sgElement].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.status);
     srbExt->sg[sgElement].length = sizeof(srbExt->vbr.status);
 
     return TRUE;
@@ -2373,6 +2384,7 @@ VOID VioStorCompleteRequest(IN PVOID DeviceExtension, IN ULONG MessageID, IN BOO
 
             if (bFound && srbExt->vbr.out_hdr.type == VIRTIO_BLK_T_GET_ID)
             {
+                StorPortCopyMemory(&adaptExt->sn, &srbExt->serial, BLOCK_SERIAL_STRLEN);
                 adaptExt->sn_ok = TRUE;
                 if (Srb)
                 {

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -286,7 +286,10 @@ typedef struct _SRB_EXTENSION
     BOOLEAN fua;
     VIO_SG sg[VIRTIO_MAX_SG];
     VRING_DESC_ALIAS desc[VIRTIO_MAX_SG];
-    blk_discard_write_zeroes blk_discard[MAX_DISCARD_SEGMENTS];
+    union {
+        blk_discard_write_zeroes blk_discard[MAX_DISCARD_SEGMENTS];
+        CHAR serial[BLOCK_SERIAL_STRLEN];
+    };
 } SRB_EXTENSION, *PSRB_EXTENSION;
 
 BOOLEAN

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -39,9 +39,13 @@
 
 #define SET_VA_PA()                                                                                                    \
     {                                                                                                                  \
-        ULONG len;                                                                                                     \
-        va = adaptExt->indirect ? srbExt->desc : NULL;                                                                 \
-        pa = va ? StorPortGetPhysicalAddress(DeviceExtension, NULL, va, &len).QuadPart : 0;                            \
+        va = NULL;                                                                                                     \
+        pa = 0;                                                                                                        \
+        if (adaptExt->indirect)                                                                                        \
+        {                                                                                                              \
+            va = srbExt->desc;                                                                                         \
+            pa = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, desc);                                                   \
+        }                                                                                                              \
     }
 
 static ULONG GetSrbQueueNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
@@ -99,8 +103,21 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     STOR_LOCK_HANDLE LockHandle = {0};
     struct virtqueue *vq = NULL;
     PREQUEST_LIST element;
+    STOR_PHYSICAL_ADDRESS extPA;
+
+    extPA = StorPortGetPhysicalAddress(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, srbExt, &fragLen);
+    if (extPA.QuadPart == 0 || fragLen < sizeof(SRB_EXTENSION))
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     SET_VA_PA();
+    if (adaptExt->indirect && pa == 0)
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     QueueNumber = resend ? srbExt->queue_number : GetSrbQueueNumber(DeviceExtension, Srb);
     MessageId = QueueToMessageId(DeviceExtension, QueueNumber);
@@ -115,9 +132,9 @@ RhelDoFlush(PVOID DeviceExtension, PSRB_TYPE Srb, BOOLEAN resend, BOOLEAN bIsr)
     srbExt->out = 1;
     srbExt->in = 1;
 
-    srbExt->sg[0].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.out_hdr, &fragLen);
+    srbExt->sg[0].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.out_hdr);
     srbExt->sg[0].length = sizeof(srbExt->vbr.out_hdr);
-    srbExt->sg[1].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.status, &fragLen);
+    srbExt->sg[1].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.status);
     srbExt->sg[1].length = sizeof(srbExt->vbr.status);
 
     if (!resend)
@@ -205,8 +222,22 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
     STOR_LOCK_HANDLE LockHandle = {0};
     struct virtqueue *vq = NULL;
     PREQUEST_LIST element;
+    ULONG fragLen = 0UL;
+    STOR_PHYSICAL_ADDRESS extPA;
+
+    extPA = StorPortGetPhysicalAddress(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, srbExt, &fragLen);
+    if (extPA.QuadPart == 0 || fragLen < sizeof(SRB_EXTENSION))
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     SET_VA_PA();
+    if (adaptExt->indirect && pa == 0)
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
     MessageId = QueueToMessageId(DeviceExtension, QueueNumber);
@@ -299,8 +330,21 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     BOOLEAN notify = FALSE;
     STOR_LOCK_HANDLE LockHandle = {0};
     struct virtqueue *vq = NULL;
+    STOR_PHYSICAL_ADDRESS extPA;
+
+    extPA = StorPortGetPhysicalAddress(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, srbExt, &fragLen);
+    if (extPA.QuadPart == 0 || fragLen < sizeof(SRB_EXTENSION))
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     SET_VA_PA();
+    if (adaptExt->indirect && pa == 0)
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     unmapList = (PUNMAP_LIST_HEADER)srbDataBuffer;
     if (!(CHECKBIT(adaptExt->features, VIRTIO_BLK_F_DISCARD)) || (unmapList == NULL) ||
@@ -357,11 +401,11 @@ RhelDoUnMap(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     srbExt->out = 2;
     srbExt->in = 1;
 
-    srbExt->sg[0].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.out_hdr, &fragLen);
+    srbExt->sg[0].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.out_hdr);
     srbExt->sg[0].length = sizeof(srbExt->vbr.out_hdr);
-    srbExt->sg[1].physAddr = MmGetPhysicalAddress(&srbExt->blk_discard[0]);
+    srbExt->sg[1].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, blk_discard);
     srbExt->sg[1].length = sizeof(blk_discard_write_zeroes) * BlockDescrCount;
-    srbExt->sg[2].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.status, &fragLen);
+    srbExt->sg[2].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.status);
     srbExt->sg[2].length = sizeof(srbExt->vbr.status);
 
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
@@ -440,8 +484,21 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     BOOLEAN notify = FALSE;
     ULONG fragLen = 0UL;
     PREQUEST_LIST element;
+    STOR_PHYSICAL_ADDRESS extPA;
+
+    extPA = StorPortGetPhysicalAddress(DeviceExtension, (PSCSI_REQUEST_BLOCK)Srb, srbExt, &fragLen);
+    if (extPA.QuadPart == 0 || fragLen < sizeof(SRB_EXTENSION))
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     SET_VA_PA();
+    if (adaptExt->indirect && pa == 0)
+    {
+        Srb->SrbStatus = SRB_STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
 
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " srbExt %p.\n", srbExt);
 
@@ -458,11 +515,11 @@ RhelGetSerialNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     srbExt->out = 1;
     srbExt->in = 2;
 
-    srbExt->sg[0].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.out_hdr, &fragLen);
+    srbExt->sg[0].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.out_hdr);
     srbExt->sg[0].length = sizeof(srbExt->vbr.out_hdr);
-    srbExt->sg[1].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &adaptExt->sn[0], &fragLen);
-    srbExt->sg[1].length = sizeof(adaptExt->sn);
-    srbExt->sg[2].physAddr = StorPortGetPhysicalAddress(DeviceExtension, NULL, &srbExt->vbr.status, &fragLen);
+    srbExt->sg[1].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, serial);
+    srbExt->sg[1].length = BLOCK_SERIAL_STRLEN; //sizeof(srbExt->serial);
+    srbExt->sg[2].physAddr.QuadPart = extPA.QuadPart + FIELD_OFFSET(SRB_EXTENSION, vbr.status);
     srbExt->sg[2].length = sizeof(srbExt->vbr.status);
 
     VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);


### PR DESCRIPTION
Applying the second commit, "Enable IOMMU ...", can be postponed for downstream/WHQL-signed builds until Microsoft enforces DMAR support.