### PR TITLE
RHEL-212375: viostor: Fix queue depth throttling

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -484,6 +484,7 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
         adaptExt->num_queues = min(adaptExt->num_queues, num_cpus);
     }
     adaptExt->reset_in_progress_count = 0;
+    adaptExt->rr_queue_index = -1;
 
     RhelDbgPrint(TRACE_LEVEL_INFORMATION, " Queues %d CPUs %d\n", adaptExt->num_queues, num_cpus);
 

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -517,6 +517,10 @@ VirtIoFindAdapter(IN PVOID DeviceExtension,
         adaptExt->poolAllocationSize += ROUND_TO_CACHE_LINES((ULONGLONG)(max_queues)*virtio_get_queue_descriptor_size());
     }
 
+    ConfigInfo->MaxIOsPerLun = adaptExt->queue_depth * adaptExt->num_queues;
+    ConfigInfo->InitialLunQueueDepth = ConfigInfo->MaxIOsPerLun;
+    ConfigInfo->MaxNumberOfIO = ConfigInfo->MaxIOsPerLun;
+
     RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                  " breaks_number = %x  queue_depth = %x\n",
                  ConfigInfo->NumberOfPhysicalBreaks,

--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1856,7 +1856,7 @@ RhelScsiGetInquiryData(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
                                 SRB_PATH_ID(Srb),
                                 SRB_TARGET_ID(Srb),
                                 SRB_LUN(Srb),
-                                adaptExt->queue_depth);
+                                adaptExt->queue_depth * adaptExt->num_queues);
     attributes.DeviceAttentionSupported = 1;
     attributes.AsyncNotificationSupported = 1;
     attributes.D3ColdNotSupported = 1;

--- a/viostor/virtio_stor.h
+++ b/viostor/virtio_stor.h
@@ -261,6 +261,7 @@ typedef struct _ADAPTER_EXTENSION
     STOR_ADDR_BTL8 device_address;
     REQUEST_LIST processing_srbs[MAX_CPU];
     ULONG reset_in_progress_count;
+    volatile LONG rr_queue_index;
     ULONGLONG fw_ver;
 #ifdef DBG
     LONG srb_cnt;

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -61,17 +61,18 @@ static ULONG GetSrbQueueNumber(IN PVOID DeviceExtension, IN PSRB_TYPE Srb)
     if (status != STOR_STATUS_SUCCESS)
     {
         RhelDbgPrint(TRACE_LEVEL_ERROR, " StorPortGetStartIoPerfParams failed. srb %p status 0x%x.\n", Srb, status);
-        return 0;
+        return (ULONG)InterlockedIncrement(&adaptExt->rr_queue_index) % adaptExt->num_queues;
     }
 
     if (param.MessageNumber == 0)
     {
-        QueueNumber = 0;
+        QueueNumber = (ULONG)InterlockedIncrement(&adaptExt->rr_queue_index) % adaptExt->num_queues;
     }
     else
     {
         QueueNumber = (param.MessageNumber - 1) % adaptExt->num_queues;
     }
+
     RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                  " srb %p, MessageNumber %lu, ChannelNumber %lu -> QueueNumber %lu\n",
                  Srb,

--- a/viostor/virtio_stor_hw_helper.c
+++ b/viostor/virtio_stor_hw_helper.c
@@ -210,53 +210,62 @@ RhelDoReadWrite(PVOID DeviceExtension, PSRB_TYPE Srb)
     SET_VA_PA();
 
     QueueNumber = GetSrbQueueNumber(DeviceExtension, Srb);
-    MessageId = QueueToMessageId(DeviceExtension, QueueNumber);
 
-    srbExt->queue_number = QueueNumber;
-    vq = adaptExt->vq[QueueNumber];
-    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " QueueNumber 0x%x vq = %p\n", QueueNumber, vq);
-
-    VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
-
-    if (adaptExt->reset_in_progress_count)
+    for (ULONG i = 0; i < adaptExt->num_queues; ++i)
     {
-        VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+        MessageId = QueueToMessageId(DeviceExtension, QueueNumber);
+        vq = adaptExt->vq[QueueNumber];
+        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " QueueNumber 0x%x vq = %p\n", QueueNumber, vq);
 
-        SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
-        CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
-        return TRUE;
-    }
+        VioStorVQLock(DeviceExtension, MessageId, &LockHandle, FALSE);
 
-    element = &adaptExt->processing_srbs[QueueNumber];
+        if (adaptExt->reset_in_progress_count)
+        {
+            VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
 
-    ULONG_PTR id = element->next_id;
+            SRB_SET_DATA_TRANSFER_LENGTH(Srb, 0);
+            CompleteRequestWithStatus(DeviceExtension, Srb, SRB_STATUS_BUS_RESET);
+            return TRUE;
+        }
 
-    if (id == 0)
-    {
-        id++;
-    }
+        element = &adaptExt->processing_srbs[QueueNumber];
 
-    srbExt->id = id;
-    element->next_id = ++id;
+        ULONG_PTR id = element->next_id;
 
-    if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
-        VQ_ADD_BUFFER_SUCCESS)
-    {
-        notify = virtqueue_kick_prepare(vq);
-        InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
-        element->srb_cnt++;
-        VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
+        if (id == 0)
+        {
+            id++;
+        }
+
+        srbExt->id = id;
+        element->next_id = ++id;
+
+        if (virtqueue_add_buf(vq, &srbExt->sg[0], srbExt->out, srbExt->in, (void *)srbExt->id, va, pa) ==
+            VQ_ADD_BUFFER_SUCCESS)
+        {
+            notify = virtqueue_kick_prepare(vq);
+            InsertTailList(&element->srb_list, &srbExt->vbr.list_entry);
+            element->srb_cnt++;
+            srbExt->queue_number = QueueNumber;
+            VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
 #ifdef DBG
-        InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
+            InterlockedIncrement((LONG volatile *)&adaptExt->inqueue_cnt);
 #endif
-        result = TRUE;
-    }
-    else
-    {
+            result = TRUE;
+            break;
+        }
+
         VioStorVQUnlock(DeviceExtension, MessageId, &LockHandle, FALSE);
-        RhelDbgPrint(TRACE_LEVEL_ERROR, " Can not add packet to queue %d.\n", QueueNumber);
+        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Can not add packet to queue %d.\n", QueueNumber);
+        QueueNumber = (QueueNumber + 1) % adaptExt->num_queues;
+    }
+
+    if (!result)
+    {
+        RhelDbgPrint(TRACE_LEVEL_ERROR, " All queues full, calling StorPortBusy.\n");
         StorPortBusy(DeviceExtension, 2);
     }
+
     if (notify)
     {
         virtqueue_notify(vq);


### PR DESCRIPTION
**Summary**
Fix viostor performance by correctly reporting queue capacity to StorPort and adding overflow iteration across virtqueues.

Problem: StorPort was never informed of the device's actual I/O capacity, defaulting to ~20 in-flight I/Os. This throttled both single-queue and multi-queue configurations far below their true capability.

**Commits:**
- Inform StorPort of full queue depth capacity - Set MaxIOsPerLun, InitialLunQueueDepth, MaxNumberOfIO to queue_depth * num_queues
- Fix StorPortSetDeviceQueueDepth - The INQUIRY-time call was overriding MaxIOsPerLun back to single-queue depth (256 vs 1024 with 4 queues)
- Add overflow iteration - Since we now report a device capacity of 1024 to StorPort, but each individual queue only holds 256, StorPort may send more I/Os than a single queue can accept. Without overflow, requests routed to an already-full queue would stall while other queues have free slots. This iterates through remaining queues to find available capacity before calling StorPortBusy.
- Add round-robin fallback - When StorPortGetStartIoPerfParams returns no CPU hint (MessageNumber == 0), distribute via round-robin instead of always targeting queue 0 (_nice to have_) 


**Test**
Tested with caches `none`, `directsync`, `writethrough` and with 2 disks (1 delayed by 100ms with device mapper, 1 raw  disk based on NVMe) [results](https://github.com/mnecas/kvm-guest-drivers-windows/blob/test-data/mnecas/results.md).
Data integrity: CRC32C write+verify passes under all configurations.

Fast Disk (NVMe backend)
Cache Mode | Avg IOPS Improvement | Best Case | Regressions
-- | -- | -- | --
none | +13% | +30% (verify) | -17% (mixed RW)
directsync | +34% | +85% (seq write) | -12% (burst)
writethrough | +168% | +378% (seq write) | -5% (burst)

Latent Disk (dm-delay 100ms)
Cache Mode | Avg IOPS Improvement | Best Case | Regressions
-- | -- | -- | --
none | +230% | +493% (seq write) | none
directsync | +447% | +977% (seq write) | none
writethrough | +2838% | +4967% (seq write) | none

