### PR TITLE
RHEL-216681: viogpu: serialize the pointer DDIs and honor pointer visibility

### DIFF
--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -2315,6 +2315,7 @@ VioGpuAdapter::VioGpuAdapter(_In_ VioGpuDod *pVioGpuDod)
     m_Id = g_InstanceId++;
     m_pFrameBuf = NULL;
     m_pCursorBuf = NULL;
+    KeInitializeGuardedMutex(&m_CursorMutex);
     m_PendingWorks = 0;
     m_bStopWorkThread = FALSE;
     m_pWorkThread = NULL;
@@ -2973,6 +2974,11 @@ NTSTATUS VioGpuAdapter::SetPointerShape(_In_ CONST DXGKARG_SETPOINTERSHAPE *pSet
         return STATUS_UNSUCCESSFUL;
     }
 
+    // The image upload and the UPDATE_CURSOR below must not interleave with a concurrent MOVE_CURSOR
+    // issued by SetPointerPosition on another thread (see m_CursorMutex).
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    KeAcquireGuardedMutex(&m_CursorMutex);
+
     if (UpdateCursor(pSetPointerShape, pModeCur))
     {
         PGPU_UPDATE_CURSOR crsr;
@@ -2991,18 +2997,29 @@ NTSTATUS VioGpuAdapter::SetPointerShape(_In_ CONST DXGKARG_SETPOINTERSHAPE *pSet
         DbgPrint(TRACE_LEVEL_INFORMATION, ("<--- %s vbuf = %p, ret = %d\n", __FUNCTION__, vbuf, ret));
         if (ret == 0)
         {
-            return STATUS_SUCCESS;
+            status = STATUS_SUCCESS;
         }
-        VioGpuDbgBreak();
+        else
+        {
+            VioGpuDbgBreak();
+        }
     }
-    DbgPrint(TRACE_LEVEL_ERROR, ("<--- %s Failed to create cursor\n", __FUNCTION__));
-    return STATUS_UNSUCCESSFUL;
+    else
+    {
+        DbgPrint(TRACE_LEVEL_ERROR, ("<--- %s Failed to create cursor\n", __FUNCTION__));
+    }
+
+    KeReleaseGuardedMutex(&m_CursorMutex);
+    return status;
 }
 
 NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION *pSetPointerPosition,
                                            _In_ CONST CURRENT_MODE *pModeCur)
 {
     PAGED_CODE();
+    // Serialize against SetPointerShape (see m_CursorMutex).
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    KeAcquireGuardedMutex(&m_CursorMutex);
     if (m_pCursorBuf != NULL)
     {
         PGPU_UPDATE_CURSOR crsr;
@@ -3048,11 +3065,15 @@ NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION
         DbgPrint(TRACE_LEVEL_VERBOSE, ("<--- %s vbuf = %p, ret = %d\n", __FUNCTION__, vbuf, ret));
         if (ret == 0)
         {
-            return STATUS_SUCCESS;
+            status = STATUS_SUCCESS;
         }
-        VioGpuDbgBreak();
+        else
+        {
+            VioGpuDbgBreak();
+        }
     }
-    return STATUS_UNSUCCESSFUL;
+    KeReleaseGuardedMutex(&m_CursorMutex);
+    return status;
 }
 
 NTSTATUS VioGpuAdapter::Escape(_In_ CONST DXGKARG_ESCAPE *pEscape)

--- a/viogpu/viogpudo/viogpudo.cpp
+++ b/viogpu/viogpudo/viogpudo.cpp
@@ -2316,6 +2316,10 @@ VioGpuAdapter::VioGpuAdapter(_In_ VioGpuDod *pVioGpuDod)
     m_pFrameBuf = NULL;
     m_pCursorBuf = NULL;
     KeInitializeGuardedMutex(&m_CursorMutex);
+    // No sprite is attached until the first shape is set.
+    m_bCursorHidden = TRUE;
+    m_CursorHotX = 0;
+    m_CursorHotY = 0;
     m_PendingWorks = 0;
     m_bStopWorkThread = FALSE;
     m_pWorkThread = NULL;
@@ -2993,6 +2997,11 @@ NTSTATUS VioGpuAdapter::SetPointerShape(_In_ CONST DXGKARG_SETPOINTERSHAPE *pSet
         crsr->pos.y = 0;
         crsr->hot_x = pSetPointerShape->XHot;
         crsr->hot_y = pSetPointerShape->YHot;
+        // This UPDATE_CURSOR attaches the resource and shows the sprite, so any pending hide is over.
+        // Remember the hot spot for the UPDATE_CURSOR that re-attaches the sprite after a later hide.
+        m_CursorHotX = pSetPointerShape->XHot;
+        m_CursorHotY = pSetPointerShape->YHot;
+        m_bCursorHidden = FALSE;
         ret = m_CursorQueue.QueueCursor(vbuf);
         DbgPrint(TRACE_LEVEL_INFORMATION, ("<--- %s vbuf = %p, ret = %d\n", __FUNCTION__, vbuf, ret));
         if (ret == 0)
@@ -3022,54 +3031,73 @@ NTSTATUS VioGpuAdapter::SetPointerPosition(_In_ CONST DXGKARG_SETPOINTERPOSITION
     KeAcquireGuardedMutex(&m_CursorMutex);
     if (m_pCursorBuf != NULL)
     {
-        PGPU_UPDATE_CURSOR crsr;
-        PGPU_VBUFFER vbuf;
-        UINT ret = 0;
-        crsr = (PGPU_UPDATE_CURSOR)m_CursorQueue.AllocCursor(&vbuf);
-        RtlZeroMemory(crsr, sizeof(*crsr));
+        // Out-of-range coordinates are treated as invisible, as before.
+        BOOLEAN visible = pSetPointerPosition->Flags.Visible && pSetPointerPosition->X >= 0 &&
+                          pSetPointerPosition->Y >= 0 && (UINT)pSetPointerPosition->X <= pModeCur->SrcModeWidth &&
+                          (UINT)pSetPointerPosition->Y <= pModeCur->SrcModeHeight;
 
-        crsr->hdr.type = VIRTIO_GPU_CMD_MOVE_CURSOR;
-        crsr->resource_id = m_pCursorBuf->GetId();
+        DbgPrint(TRACE_LEVEL_VERBOSE,
+                 ("---> %s (%d - %d) Visible = %d Value = %x VidPnSourceId = %d hidden = %d\n",
+                  __FUNCTION__,
+                  pSetPointerPosition->X,
+                  pSetPointerPosition->Y,
+                  pSetPointerPosition->Flags.Visible,
+                  pSetPointerPosition->Flags.Value,
+                  pSetPointerPosition->VidPnSourceId,
+                  m_bCursorHidden));
 
-        if (!pSetPointerPosition->Flags.Visible || (UINT)pSetPointerPosition->X > pModeCur->SrcModeWidth ||
-            (UINT)pSetPointerPosition->Y > pModeCur->SrcModeHeight || pSetPointerPosition->X < 0 ||
-            pSetPointerPosition->Y < 0)
+        if (!visible && m_bCursorHidden)
         {
-            DbgPrint(TRACE_LEVEL_VERBOSE,
-                     ("---> %s (%d - %d) Visiable = %d Value = %x VidPnSourceId = %d\n",
-                      __FUNCTION__,
-                      pSetPointerPosition->X,
-                      pSetPointerPosition->Y,
-                      pSetPointerPosition->Flags.Visible,
-                      pSetPointerPosition->Flags.Value,
-                      pSetPointerPosition->VidPnSourceId));
-            crsr->pos.x = 0;
-            crsr->pos.y = 0;
-        }
-        else
-        {
-            DbgPrint(TRACE_LEVEL_VERBOSE,
-                     ("---> %s (%d - %d) Visiable = %d Value = %x VidPnSourceId = %d posX = %d, psY = %d\n",
-                      __FUNCTION__,
-                      pSetPointerPosition->X,
-                      pSetPointerPosition->Y,
-                      pSetPointerPosition->Flags.Visible,
-                      pSetPointerPosition->Flags.Value,
-                      pSetPointerPosition->VidPnSourceId,
-                      pSetPointerPosition->X,
-                      pSetPointerPosition->Y));
-            crsr->pos.x = pSetPointerPosition->X;
-            crsr->pos.y = pSetPointerPosition->Y;
-        }
-        ret = m_CursorQueue.QueueCursor(vbuf);
-        DbgPrint(TRACE_LEVEL_VERBOSE, ("<--- %s vbuf = %p, ret = %d\n", __FUNCTION__, vbuf, ret));
-        if (ret == 0)
-        {
+            // Already hidden, nothing to send.
             status = STATUS_SUCCESS;
         }
         else
         {
-            VioGpuDbgBreak();
+            PGPU_UPDATE_CURSOR crsr;
+            PGPU_VBUFFER vbuf;
+            UINT ret = 0;
+            crsr = (PGPU_UPDATE_CURSOR)m_CursorQueue.AllocCursor(&vbuf);
+            RtlZeroMemory(crsr, sizeof(*crsr));
+
+            if (!visible)
+            {
+                // Hide the sprite for real instead of parking it at (0, 0) with the resource still
+                // attached: a parked sprite stays visible in the top left corner of the display.
+                crsr->hdr.type = VIRTIO_GPU_CMD_UPDATE_CURSOR;
+                crsr->resource_id = 0;
+                m_bCursorHidden = TRUE;
+            }
+            else if (m_bCursorHidden)
+            {
+                // Coming back from a hide: MOVE_CURSOR does not re-associate a detached resource, so the
+                // sprite must be re-attached with a full UPDATE_CURSOR. The image itself is still
+                // uploaded, only the association has to be recreated.
+                crsr->hdr.type = VIRTIO_GPU_CMD_UPDATE_CURSOR;
+                crsr->resource_id = m_pCursorBuf->GetId();
+                crsr->pos.x = pSetPointerPosition->X;
+                crsr->pos.y = pSetPointerPosition->Y;
+                crsr->hot_x = m_CursorHotX;
+                crsr->hot_y = m_CursorHotY;
+                m_bCursorHidden = FALSE;
+            }
+            else
+            {
+                crsr->hdr.type = VIRTIO_GPU_CMD_MOVE_CURSOR;
+                crsr->resource_id = m_pCursorBuf->GetId();
+                crsr->pos.x = pSetPointerPosition->X;
+                crsr->pos.y = pSetPointerPosition->Y;
+            }
+
+            ret = m_CursorQueue.QueueCursor(vbuf);
+            DbgPrint(TRACE_LEVEL_VERBOSE, ("<--- %s vbuf = %p, ret = %d\n", __FUNCTION__, vbuf, ret));
+            if (ret == 0)
+            {
+                status = STATUS_SUCCESS;
+            }
+            else
+            {
+                VioGpuDbgBreak();
+            }
         }
     }
     KeReleaseGuardedMutex(&m_CursorMutex);

--- a/viogpu/viogpudo/viogpudo.h
+++ b/viogpu/viogpudo/viogpudo.h
@@ -203,6 +203,12 @@ class VioGpuAdapter : IVioGpuPCI
     VioGpuIdr m_Idr;
     VioGpuObj *m_pFrameBuf;
     VioGpuObj *m_pCursorBuf;
+    // Serializes SetPointerShape against SetPointerPosition: dxgkrnl calls the two pointer DDIs from
+    // different threads without synchronizing them. A concurrent MOVE_CURSOR can then interleave with the
+    // two-step shape update (control-queue image upload followed by the cursor-queue UPDATE_CURSOR) and the
+    // commands reach the device out of order, leaving a stale or stuck cursor. Both DDIs run at
+    // PASSIVE_LEVEL, so a guarded mutex is legal here and may be held across the upload.
+    KGUARDED_MUTEX m_CursorMutex;
     VioGpuMemSegment m_CursorSegment;
     VioGpuMemSegment m_FrameSegment;
     volatile ULONG m_PendingWorks;

--- a/viogpu/viogpudo/viogpudo.h
+++ b/viogpu/viogpudo/viogpudo.h
@@ -209,6 +209,13 @@ class VioGpuAdapter : IVioGpuPCI
     // commands reach the device out of order, leaving a stale or stuck cursor. Both DDIs run at
     // PASSIVE_LEVEL, so a guarded mutex is legal here and may be held across the upload.
     KGUARDED_MUTEX m_CursorMutex;
+    // Pointer visibility, guarded by m_CursorMutex. Windows hides the hardware cursor (Flags.Visible = 0)
+    // whenever it draws the pointer itself, for instance while DWM composes it into the primary during a
+    // window move or resize loop, and shows it again afterwards.
+    BOOLEAN m_bCursorHidden;
+    // Hot spot of the current shape, replayed by the UPDATE_CURSOR that re-attaches the sprite after a hide.
+    UINT m_CursorHotX;
+    UINT m_CursorHotY;
     VioGpuMemSegment m_CursorSegment;
     VioGpuMemSegment m_FrameSegment;
     volatile ULONG m_PendingWorks;


### PR DESCRIPTION
Two small patches around the hardware cursor, following the discussion in #977
(RHELMISC-34288). This is my first contribution here, so please tell me if the
split, the style, or anything about the process should be different -- I am
happy to redo them.

`HWCursor` stays opt-in and its default is unchanged, so nothing moves for users
who do not set it. The two patches are independent and can be taken separately.

### Context

With the hardware cursor disabled, Windows composes the pointer into the primary
surface itself, so a backend that captures or streams that surface gets the
pointer baked into every frame and cannot separate it from the content. That is
what led me to look at the two issues below.

### 1. Serialize the pointer DDIs

As noted in #977, SetPointerShape and SetPointerPosition are not synchronised
and are called from different threads. Updating the shape is not atomic -- the
new image is copied into the shared cursor buffer and queued for transfer, then
UPDATE_CURSOR is queued on the cursor queue -- so a second SetPointerShape can
overwrite that buffer while the first is still queueing, and a MOVE_CURSOR
issued concurrently by SetPointerPosition can land in the middle of the pair.
The cursor commands then reach the device in an order Windows never asked for.

This patch makes the two DDIs mutually exclusive with a guarded mutex. Both run
at PASSIVE_LEVEL, so they are allowed to block, and the mutex is only held
across the image copy and the queueing of the commands (`TransferToHost2D` does
not wait for the device), so it does not add a blocking point on the pointer
path.

You mentioned a queue and a kernel thread for this. I started with the mutex
because it was the smallest change I could find that removes the interleaving,
but I have no attachment to it: if you prefer the queue and thread design, or if
there is a reason the DDIs should stay non-blocking that I am missing, I will
gladly rework it.

Both functions now have a single exit so the mutex is always released; nothing
else changes here.

### 2. Hide the sprite instead of parking it at (0, 0)

This one is independent of the above.

`SetPointerPosition` treats `Flags.Visible = 0` as "move the sprite to the top
left corner": it keeps sending MOVE_CURSOR with the resource still attached and
only forces the coordinates to (0, 0), so the sprite stays visible, parked over
the top left corner of the display.

Windows clears `Flags.Visible` when it draws the pointer itself instead of
letting the adapter do it, typically when DWM composites it into the primary
during a window move or resize loop. The guest then paints its own pointer while
the parked sprite is still shown, which appears as a second, stationary cursor.
It is most visible for a remote viewer, where the sprite is drawn by the host
while the composed pointer arrives in the video stream.

The patch sends a real hide (UPDATE_CURSOR with `resource_id = 0`) and tracks
the hidden state so repeated hides are not resent. Coming back from a hide needs
a full UPDATE_CURSOR, since MOVE_CURSOR does not re-associate a detached
resource; the hot spot of the current shape is kept for that. The image itself
stays uploaded, so no new transfer is involved.

### Not addressed here

The cursor image transfer goes on the control queue, while UPDATE_CURSOR goes on
the cursor queue. Because those are independent, the device can apply
UPDATE_CURSOR before the transfer has landed and briefly show the previous
image. That is separate from the serialization above and is not fixed in this
PR: it means waiting for the transfer to complete before queueing UPDATE_CURSOR,
which touches the synchronous-wait path in `viogpu_queue.cpp` and seems better
as its own patch. I would rather send it separately, unless you prefer it here.

Sorry for not calling that out from the start: the commit message of the first
patch mentions a cursor keeping its previous image, which really belongs to this
queue asynchrony rather than to the missing serialization. I will tighten that
wording the next time I update the branch, together with anything that comes out
of review.

### Testing

Validated on a Windows 11 guest running virtio-gpu, in a downstream build
carrying these same two changes, with `HWCursor` enabled: dragging a window no
longer leaves a second stationary cursor, and cursor tracking, shape changes
(arrow, I-beam, resize arrows) and mode changes behave as before. DDI traces
showed the expected sequence -- one `Visible = 0` when the move loop starts,
silence while DWM composes, `Visible = 1` on release.

The branch as posted builds clean, but I could not deploy it to a guest as-is,
since it does not carry the rest of that downstream tree.

* Win11 EWDK (x64, `Win11 Release`): 0 errors, 0 warnings.
* `clang-format` clean on the changed lines, per `Tools/clang-format-helper.sh`.

Thanks for looking, and for the notes in #977 -- they are what made it clear
where to start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor visibility handling so hiding the pointer no longer moves it to the top-left corner.
  * Restored hidden cursors at their correct position and hotspot when shown again.
  * Improved reliability when changing cursor shape and position simultaneously.
  * Cursor updates now report their operation status more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->