### PR TITLE
RHEL-216649: viofs: add optional polling-based file change notifications

### DIFF
--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -50,6 +50,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include "virtiofs.h"
 #include "fusereq.h"
@@ -163,6 +164,9 @@ struct VIRTFS
     // Maps NodeId to its Nlookup counter.
     std::map<UINT64, UINT64> LookupMap{};
 
+    // Directory buffers are shared by WinFsp dispatcher threads and the
+    // periodic refresh thread. This lock also keeps a file context alive while
+    // the refresh thread is using its FUSE handle.
     SRWLOCK RefreshLock = SRWLOCK_INIT;
     std::map<VIRTFS_FILE_CONTEXT *, VIRTFS_REFRESH_ENTRY> RefreshEntries{};
     HANDLE RefreshStopEvent{NULL};
@@ -200,6 +204,12 @@ struct VIRTFS
 
     VOID LookupMapNewOrIncNode(UINT64 NodeId);
     UINT64 LookupMapPopNode(UINT64 NodeId);
+
+    NTSTATUS StartRefreshThread();
+    VOID StopRefreshThread();
+    VOID RegisterRefresh(VIRTFS_FILE_CONTEXT *FileContext, PCWSTR FileName);
+    VOID UnregisterRefresh(VIRTFS_FILE_CONTEXT *FileContext);
+    VOID RefreshWatchedHandles();
 
     NTSTATUS ReadDirAndIgnoreCaseSearch(const VIRTFS_FILE_CONTEXT *ParentContext,
                                         const char *filename,
@@ -239,6 +249,8 @@ struct VIRTFS
                                   uint32_t flags);
     NTSTATUS SubmitDestroyRequest();
 };
+
+static DWORD WINAPI RefreshThreadProc(PVOID Context);
 
 static NTSTATUS SetBasicInfo(FSP_FILE_SYSTEM *FileSystem,
                              PVOID FileContext0,
@@ -332,6 +344,7 @@ VOID VIRTFS::Stop()
         return;
     }
 
+    StopRefreshThread();
     FspFileSystemStopDispatcher(FileSystem);
     FspFileSystemDelete(FileSystem);
     FileSystem = NULL;
@@ -474,6 +487,182 @@ static NTSTATUS GetChangeToken(HANDLE Device, const VIRTFS_FILE_CONTEXT *FileCon
     }
 
     return Status;
+}
+
+NTSTATUS VIRTFS::StartRefreshThread()
+{
+    DBG("Starting change notifier with interval %u second(s)", RefreshIntervalSec);
+
+    RefreshStopEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (RefreshStopEvent == NULL)
+    {
+        return FspNtStatusFromWin32(GetLastError());
+    }
+
+    RefreshThread = CreateThread(NULL, 0, RefreshThreadProc, this, 0, NULL);
+    if (RefreshThread == NULL)
+    {
+        NTSTATUS Status = FspNtStatusFromWin32(GetLastError());
+        CloseHandle(RefreshStopEvent);
+        RefreshStopEvent = NULL;
+        return Status;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+VOID VIRTFS::StopRefreshThread()
+{
+    if (RefreshThread != NULL)
+    {
+        SetEvent(RefreshStopEvent);
+        WaitForSingleObject(RefreshThread, INFINITE);
+        CloseHandle(RefreshThread);
+        RefreshThread = NULL;
+    }
+    if (RefreshStopEvent != NULL)
+    {
+        CloseHandle(RefreshStopEvent);
+        RefreshStopEvent = NULL;
+    }
+
+    AcquireSRWLockExclusive(&RefreshLock);
+    RefreshEntries.clear();
+    ReleaseSRWLockExclusive(&RefreshLock);
+}
+
+VOID VIRTFS::RegisterRefresh(VIRTFS_FILE_CONTEXT *FileContext, PCWSTR FileName)
+{
+    if (!RefreshEnabled)
+    {
+        return;
+    }
+
+    bool LockHeld = false;
+    try
+    {
+        VIRTFS_REFRESH_ENTRY Entry;
+        Entry.FileName = FileName;
+        Entry.ChangeTokenValid = NT_SUCCESS(GetChangeToken(Device, FileContext, &Entry.ChangeToken));
+
+        AcquireSRWLockExclusive(&RefreshLock);
+        LockHeld = true;
+        auto [Iterator, Inserted] = RefreshEntries.emplace(FileContext, std::move(Entry));
+        if (Inserted)
+        {
+            DBG("%s added to refresh watcher: path='%S' nodeid=%I64u fh=%I64u",
+                FileContext->IsDirectory ? "Directory" : "File",
+                Iterator->second.FileName.c_str(),
+                FileContext->NodeId,
+                FileContext->FileHandle);
+        }
+        ReleaseSRWLockExclusive(&RefreshLock);
+        LockHeld = false;
+    }
+    catch (std::bad_alloc &)
+    {
+        if (LockHeld)
+        {
+            ReleaseSRWLockExclusive(&RefreshLock);
+        }
+        DBG("Unable to register directory refresh for '%S'", FileName);
+    }
+}
+
+VOID VIRTFS::UnregisterRefresh(VIRTFS_FILE_CONTEXT *FileContext)
+{
+    if (!RefreshEnabled)
+    {
+        return;
+    }
+
+    AcquireSRWLockExclusive(&RefreshLock);
+    auto Iterator = RefreshEntries.find(FileContext);
+    if (Iterator != RefreshEntries.end())
+    {
+        DBG("%s removed from refresh watcher: path='%S' nodeid=%I64u fh=%I64u",
+            FileContext->IsDirectory ? "Directory" : "File",
+            Iterator->second.FileName.c_str(),
+            FileContext->NodeId,
+            FileContext->FileHandle);
+        RefreshEntries.erase(Iterator);
+    }
+    ReleaseSRWLockExclusive(&RefreshLock);
+}
+
+VOID VIRTFS::RefreshWatchedHandles()
+{
+    AcquireSRWLockExclusive(&RefreshLock);
+
+    for (auto &[FileContext, Entry] : RefreshEntries)
+    {
+        VIRTFS_CHANGE_TOKEN ChangeToken;
+        NTSTATUS Status = GetChangeToken(Device, FileContext, &ChangeToken);
+        if (!NT_SUCCESS(Status))
+        {
+            continue;
+        }
+
+        bool Changed = Entry.ChangeTokenValid &&
+                       !(FileContext->IsDirectory ? DirChangeTokenEqual(Entry.ChangeToken, ChangeToken)
+                                                  : FileChangeTokenEqual(Entry.ChangeToken, ChangeToken));
+
+        if (Changed)
+        {
+            DBG("%s change detected: path='%S' nodeid=%I64u fh=%I64u",
+                FileContext->IsDirectory ? "Directory" : "File",
+                Entry.FileName.c_str(),
+                FileContext->NodeId,
+                FileContext->FileHandle);
+            if (FileContext->IsDirectory)
+            {
+                FspFileSystemDeleteDirectoryBuffer(&FileContext->DirBuffer);
+            }
+
+            alignas(FSP_FSCTL_NOTIFY_INFO) BYTE NotifyInfoBuffer[FIELD_OFFSET(FSP_FSCTL_NOTIFY_INFO, FileNameBuf) +
+                                                                 MAX_PATH * sizeof(WCHAR)];
+            FSP_FSCTL_NOTIFY_INFO *NotifyInfo = reinterpret_cast<FSP_FSCTL_NOTIFY_INFO *>(NotifyInfoBuffer);
+            SIZE_T FileNameLength = min(Entry.FileName.length(), (SIZE_T)MAX_PATH - 1);
+
+            ZeroMemory(NotifyInfoBuffer, sizeof(NotifyInfoBuffer));
+            CopyMemory(NotifyInfo->FileNameBuf, Entry.FileName.c_str(), FileNameLength * sizeof(WCHAR));
+            NotifyInfo->Size = (UINT16)(sizeof(*NotifyInfo) + FileNameLength * sizeof(WCHAR));
+            NotifyInfo->Action = FILE_ACTION_MODIFIED;
+            NotifyInfo->Filter = FileContext->IsDirectory ? FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_FILE_NAME
+                                                          : FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SIZE;
+
+            if (STATUS_SUCCESS == FspFileSystemNotifyBegin(FileSystem, 500))
+            {
+                FspFileSystemNotify(FileSystem, NotifyInfo, NotifyInfo->Size);
+                FspFileSystemNotifyEnd(FileSystem);
+            }
+        }
+        else
+        {
+            DBG("No %s change detected: path='%S' nodeid=%I64u fh=%I64u",
+                FileContext->IsDirectory ? "directory" : "file",
+                Entry.FileName.c_str(),
+                FileContext->NodeId,
+                FileContext->FileHandle);
+        }
+
+        Entry.ChangeToken = ChangeToken;
+        Entry.ChangeTokenValid = true;
+    }
+
+    ReleaseSRWLockExclusive(&RefreshLock);
+}
+
+static DWORD WINAPI RefreshThreadProc(PVOID Context)
+{
+    VIRTFS *VirtFs = static_cast<VIRTFS *>(Context);
+
+    while (WAIT_TIMEOUT == WaitForSingleObject(VirtFs->RefreshStopEvent, VirtFs->RefreshIntervalSec * 1000))
+    {
+        VirtFs->RefreshWatchedHandles();
+    }
+
+    return 0;
 }
 
 static UINT32 PosixUnixModeToAttributes(VIRTFS *VirtFs, uint64_t nodeid, uint32_t mode)
@@ -1523,6 +1712,8 @@ static NTSTATUS Create(FSP_FILE_SYSTEM *FileSystem,
 
     *PFileContext = FileContext;
 
+    VirtFs->RegisterRefresh(FileContext, FileName);
+
     return Status;
 }
 
@@ -1547,6 +1738,8 @@ static NTSTATUS Open(FSP_FILE_SYSTEM *FileSystem,
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
+    FileContext->FileHandle = INVALID_FILE_HANDLE;
+
     Status = VirtFsLookupFileName(VirtFs, FileName, &lookup_out);
     if (!NT_SUCCESS(Status))
     {
@@ -1569,6 +1762,11 @@ static NTSTATUS Open(FSP_FILE_SYSTEM *FileSystem,
 
     SetFileInfo(VirtFs, &lookup_out.entry, FileInfo);
     *PFileContext = FileContext;
+
+    if (FileContext->FileHandle != INVALID_FILE_HANDLE)
+    {
+        VirtFs->RegisterRefresh(FileContext, FileName);
+    }
 
     return Status;
 }
@@ -1642,7 +1840,12 @@ static VOID Close(FSP_FILE_SYSTEM *FileSystem, PVOID FileContext0)
 
     DBG("fh: %I64u nodeid: %I64u", FileContext->FileHandle, FileContext->NodeId);
 
-    (VOID) VirtFs->SubmitReleaseRequest(FileContext);
+    VirtFs->UnregisterRefresh(FileContext);
+
+    if (FileContext->FileHandle != INVALID_FILE_HANDLE)
+    {
+        (VOID) VirtFs->SubmitReleaseRequest(FileContext);
+    }
 
     FspFileSystemDeleteDirectoryBuffer(&FileContext->DirBuffer);
 
@@ -2397,6 +2600,18 @@ static NTSTATUS ReadDirectory(FSP_FILE_SYSTEM *FileSystem,
     int FileNameLength;
     FUSE_READ_OUT *read_out;
 
+    bool RefreshLockHeld = VirtFs->RefreshEnabled;
+    if (RefreshLockHeld)
+    {
+        AcquireSRWLockExclusive(&VirtFs->RefreshLock);
+    }
+    scope_exit RefreshLockGuard([VirtFs, RefreshLockHeld] {
+        if (RefreshLockHeld)
+        {
+            ReleaseSRWLockExclusive(&VirtFs->RefreshLock);
+        }
+    });
+
     DBG("Pattern: %S Marker: %S BufferLength: %u",
         Pattern ? Pattern : TEXT("(null)"),
         Marker ? Marker : TEXT("(null)"),
@@ -2414,11 +2629,11 @@ static NTSTATUS ReadDirectory(FSP_FILE_SYSTEM *FileSystem,
         {
             for (;;)
             {
-                VirtFs->SubmitReadDirRequest(FileContext,
-                                             Offset,
-                                             TRUE,
-                                             read_out,
-                                             sizeof(struct fuse_out_header) + (ULONG64)BufferLength * 2);
+                Status = VirtFs->SubmitReadDirRequest(FileContext,
+                                                      Offset,
+                                                      TRUE,
+                                                      read_out,
+                                                      sizeof(struct fuse_out_header) + (ULONG64)BufferLength * 2);
 
                 if (!NT_SUCCESS(Status))
                 {
@@ -2798,6 +3013,16 @@ NTSTATUS VIRTFS::Start()
     {
         FspServiceLog(EVENTLOG_ERROR_TYPE, (PWSTR)L"Failed to mount virtio-fs file system.");
         goto out_del_fs;
+    }
+
+    if (RefreshEnabled)
+    {
+        Status = StartRefreshThread();
+        if (!NT_SUCCESS(Status))
+        {
+            FspFileSystemStopDispatcher(FileSystem);
+            goto out_del_fs;
+        }
     }
 
     return STATUS_SUCCESS;

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -60,6 +60,8 @@
 #define ALLOCATION_UNIT                4096
 #define PAGE_SZ_4K                     4096
 #define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32
+#define DEFAULT_REFRESH_INTERVAL_SEC   3
+#define MAX_REFRESH_INTERVAL_SEC       60
 
 #define INVALID_FILE_HANDLE            ((uint64_t)(-1))
 
@@ -103,6 +105,24 @@ typedef struct
 
 } VIRTFS_FILE_CONTEXT, *PVIRTFS_FILE_CONTEXT;
 
+typedef struct VIRTFS_CHANGE_TOKEN
+{
+    UINT64 Atime;
+    UINT64 Mtime;
+    UINT64 Ctime;
+    UINT32 AtimeNsec;
+    UINT32 MtimeNsec;
+    UINT32 CtimeNsec;
+    UINT32 Nlink;
+} VIRTFS_CHANGE_TOKEN;
+
+typedef struct VIRTFS_REFRESH_ENTRY
+{
+    std::wstring FileName;
+    VIRTFS_CHANGE_TOKEN ChangeToken{};
+    bool ChangeTokenValid{false};
+} VIRTFS_REFRESH_ENTRY;
+
 struct VIRTFS
 {
     FSP_FILE_SYSTEM *FileSystem{NULL};
@@ -117,6 +137,8 @@ struct VIRTFS
     DeviceHandleNotification DevHandleNotification{};
 
     bool CaseInsensitive{false};
+    bool RefreshEnabled{false};
+    ULONG RefreshIntervalSec{DEFAULT_REFRESH_INTERVAL_SEC};
     std::wstring FileSystemName{};
     std::wstring MountPoint{L"*"};
     std::wstring Tag{};
@@ -141,16 +163,24 @@ struct VIRTFS
     // Maps NodeId to its Nlookup counter.
     std::map<UINT64, UINT64> LookupMap{};
 
+    SRWLOCK RefreshLock = SRWLOCK_INIT;
+    std::map<VIRTFS_FILE_CONTEXT *, VIRTFS_REFRESH_ENTRY> RefreshEntries{};
+    HANDLE RefreshStopEvent{NULL};
+    HANDLE RefreshThread{NULL};
+
     VIRTFS(ULONG DebugFlags,
            bool CaseInsensitive,
            const std::wstring &FileSystemName,
            const std::wstring &MountPoint,
            const std::wstring &Tag,
+           bool RefreshEnabled,
+           ULONG RefreshIntervalSec,
            bool AutoOwnerIds,
            uint32_t OwnerUid,
            uint32_t OwnerGid)
-        : DebugFlags{DebugFlags}, CaseInsensitive{CaseInsensitive}, FileSystemName{FileSystemName},
-          MountPoint{MountPoint}, Tag{Tag}, AutoOwnerIds{AutoOwnerIds}
+        : DebugFlags{DebugFlags}, CaseInsensitive{CaseInsensitive}, RefreshEnabled{RefreshEnabled},
+          RefreshIntervalSec{RefreshIntervalSec}, FileSystemName{FileSystemName}, MountPoint{MountPoint}, Tag{Tag},
+          AutoOwnerIds{AutoOwnerIds}
     {
         if (!AutoOwnerIds)
         {
@@ -230,6 +260,13 @@ static VOID FixReparsePointAttributes(VIRTFS *VirtFs, uint64_t nodeid, UINT32 *P
 static VOID GetVolumeName(HANDLE Device, PWSTR VolumeName, DWORD VolumeNameSize);
 
 static NTSTATUS VirtFsLookupFileName(VIRTFS *VirtFs, PWSTR FileName, FUSE_LOOKUP_OUT *LookupOut);
+
+static NTSTATUS VirtFsFuseRequest(HANDLE Device,
+                                  LPVOID InBuffer,
+                                  DWORD InBufferSize,
+                                  LPVOID OutBuffer,
+                                  DWORD OutBufferSize,
+                                  DWORD Code = IOCTL_VIRTFS_FUSE_REQUEST);
 
 static DWORD WINAPI DeviceNotificationCallback(HCMNOTIFICATION Notify,
                                                PVOID Context,
@@ -402,6 +439,43 @@ DWORD WINAPI DeviceNotificationCallback(HCMNOTIFICATION Notify,
     return ERROR_SUCCESS;
 }
 
+static bool DirChangeTokenEqual(const VIRTFS_CHANGE_TOKEN &Left, const VIRTFS_CHANGE_TOKEN &Right)
+{
+    return Left.Atime == Right.Atime && Left.Mtime == Right.Mtime && Left.Ctime == Right.Ctime &&
+           Left.AtimeNsec == Right.AtimeNsec && Left.MtimeNsec == Right.MtimeNsec &&
+           Left.CtimeNsec == Right.CtimeNsec && Left.Nlink == Right.Nlink;
+}
+
+static bool FileChangeTokenEqual(const VIRTFS_CHANGE_TOKEN &Left, const VIRTFS_CHANGE_TOKEN &Right)
+{
+    return Left.Mtime == Right.Mtime && Left.MtimeNsec == Right.MtimeNsec;
+}
+
+static NTSTATUS GetChangeToken(HANDLE Device, const VIRTFS_FILE_CONTEXT *FileContext, VIRTFS_CHANGE_TOKEN *ChangeToken)
+{
+    FUSE_GETATTR_IN getattr_in;
+    FUSE_GETATTR_OUT getattr_out;
+
+    FUSE_HEADER_INIT(&getattr_in.hdr, FUSE_GETATTR, FileContext->NodeId, sizeof(getattr_in.getattr));
+    ZeroMemory(&getattr_in.getattr, sizeof(getattr_in.getattr));
+    getattr_in.getattr.fh = FileContext->FileHandle;
+    getattr_in.getattr.getattr_flags = FUSE_GETATTR_FH;
+
+    NTSTATUS Status = VirtFsFuseRequest(Device, &getattr_in, sizeof(getattr_in), &getattr_out, sizeof(getattr_out));
+    if (NT_SUCCESS(Status))
+    {
+        ChangeToken->Atime = getattr_out.attr.attr.atime;
+        ChangeToken->Mtime = getattr_out.attr.attr.mtime;
+        ChangeToken->Ctime = getattr_out.attr.attr.ctime;
+        ChangeToken->AtimeNsec = getattr_out.attr.attr.atimensec;
+        ChangeToken->MtimeNsec = getattr_out.attr.attr.mtimensec;
+        ChangeToken->CtimeNsec = getattr_out.attr.attr.ctimensec;
+        ChangeToken->Nlink = getattr_out.attr.attr.nlink;
+    }
+
+    return Status;
+}
+
 static UINT32 PosixUnixModeToAttributes(VIRTFS *VirtFs, uint64_t nodeid, uint32_t mode)
 {
     UINT32 Attributes;
@@ -525,7 +599,7 @@ static NTSTATUS VirtFsFuseRequest(HANDLE Device,
                                   DWORD InBufferSize,
                                   LPVOID OutBuffer,
                                   DWORD OutBufferSize,
-                                  DWORD Code = IOCTL_VIRTFS_FUSE_REQUEST)
+                                  DWORD Code)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     DWORD BytesReturned = 0;
@@ -2885,6 +2959,8 @@ static NTSTATUS SvcStart(FSP_SERVICE *Service, ULONG argc, PWSTR *argv)
     std::wstring DebugLogFile{};
     ULONG DebugFlags{0};
     bool CaseInsensitive{false};
+    bool RefreshEnabled{false};
+    ULONG RefreshIntervalSec{DEFAULT_REFRESH_INTERVAL_SEC};
     std::wstring MountPoint{L"*"};
     std::wstring FileSystemName{};
     std::wstring Tag{};
@@ -2960,6 +3036,8 @@ static NTSTATUS SvcStart(FSP_SERVICE *Service, ULONG argc, PWSTR *argv)
                             FileSystemName,
                             MountPoint,
                             Tag,
+                            RefreshEnabled,
+                            RefreshIntervalSec,
                             AutoOwnerIds,
                             OwnerUid,
                             OwnerGid);

--- a/viofs/svc/virtiofs.cpp
+++ b/viofs/svc/virtiofs.cpp
@@ -2813,6 +2813,8 @@ static NTSTATUS ParseArgs(ULONG argc,
                           ULONG &DebugFlags,
                           std::wstring &DebugLogFile,
                           bool &CaseInsensitive,
+                          bool &RefreshEnabled,
+                          ULONG &RefreshIntervalSec,
                           std::wstring &FileSystemName,
                           std::wstring &MountPoint,
                           std::wstring &Tag,
@@ -2850,6 +2852,10 @@ static NTSTATUS ParseArgs(ULONG argc,
                 break;
             case L'i':
                 CaseInsensitive = true;
+                break;
+            case L'n':
+                argtol(RefreshIntervalSec);
+                RefreshEnabled = true;
                 break;
             case L'F':
                 argtos(FileSystemName);
@@ -2890,12 +2896,13 @@ usage:
                              "    -d DebugFlags       [-1: enable all debug logs]\n"
                              "    -D DebugLogFile     [file path; use - for stderr]\n"
                              "    -i                  [case insensitive file system]\n"
+                             "    -n Seconds          [enable notifier; 0 defaults to 3, maximum %u]\n"
                              "    -F FileSystemName   [file system name for OS]\n"
                              "    -m MountPoint       [X:|* (required if no UNC prefix)]\n"
                              "    -t Tag              [mount tag; max 36 symbols]\n"
                              "    -o UID:GID          [host owner UID:GID]\n";
 
-    FspServiceLog(EVENTLOG_ERROR_TYPE, usage, FS_SERVICE_NAME);
+    FspServiceLog(EVENTLOG_ERROR_TYPE, usage, FS_SERVICE_NAME, MAX_REFRESH_INTERVAL_SEC);
 
     return STATUS_UNSUCCESSFUL;
 }
@@ -2903,6 +2910,8 @@ usage:
 static VOID ParseRegistry(ULONG &DebugFlags,
                           std::wstring &DebugLogFile,
                           bool &CaseInsensitive,
+                          bool &RefreshEnabled,
+                          ULONG &RefreshIntervalSec,
                           std::wstring &FileSystemName,
                           std::wstring &MountPoint,
                           std::wstring &Owner)
@@ -2910,6 +2919,8 @@ static VOID ParseRegistry(ULONG &DebugFlags,
     RegistryGetVal(FS_SERVICE_REGKEY, L"DebugFlags", DebugFlags);
     RegistryGetVal(FS_SERVICE_REGKEY, L"DebugLogFile", DebugLogFile);
     RegistryGetVal(FS_SERVICE_REGKEY, L"CaseInsensitive", CaseInsensitive);
+    RegistryGetVal(FS_SERVICE_REGKEY, L"NotifierEnabled", RefreshEnabled);
+    RegistryGetVal(FS_SERVICE_REGKEY, L"NotifierIntervalSec", RefreshIntervalSec);
     RegistryGetVal(FS_SERVICE_REGKEY, L"FileSystemName", FileSystemName);
     RegistryGetVal(FS_SERVICE_REGKEY, L"MountPoint", MountPoint);
     RegistryGetVal(FS_SERVICE_REGKEY, L"Owner", Owner);
@@ -2996,6 +3007,8 @@ static NTSTATUS SvcStart(FSP_SERVICE *Service, ULONG argc, PWSTR *argv)
                            DebugFlags,
                            DebugLogFile,
                            CaseInsensitive,
+                           RefreshEnabled,
+                           RefreshIntervalSec,
                            FileSystemName,
                            MountPoint,
                            Tag,
@@ -3008,7 +3021,14 @@ static NTSTATUS SvcStart(FSP_SERVICE *Service, ULONG argc, PWSTR *argv)
     }
     else
     {
-        ParseRegistry(DebugFlags, DebugLogFile, CaseInsensitive, FileSystemName, MountPoint, Owner);
+        ParseRegistry(DebugFlags,
+                      DebugLogFile,
+                      CaseInsensitive,
+                      RefreshEnabled,
+                      RefreshIntervalSec,
+                      FileSystemName,
+                      MountPoint,
+                      Owner);
     }
 
     ParseRegistryCommon();
@@ -3018,6 +3038,15 @@ static NTSTATUS SvcStart(FSP_SERVICE *Service, ULONG argc, PWSTR *argv)
     if (!NT_SUCCESS(Status))
     {
         return Status;
+    }
+
+    if (RefreshEnabled && RefreshIntervalSec == 0)
+    {
+        RefreshIntervalSec = DEFAULT_REFRESH_INTERVAL_SEC;
+    }
+    else if (RefreshEnabled && RefreshIntervalSec > MAX_REFRESH_INTERVAL_SEC)
+    {
+        RefreshIntervalSec = MAX_REFRESH_INTERVAL_SEC;
     }
 
     if (!DebugLogFile.empty())


### PR DESCRIPTION
This PR adds partial change-notification support without requiring changes to virtiofsd or the virtio-fs protocol.
When enabled, viofs runs a shared periodic worker that queries attributes for open file and directory handles. If their timestamps change, viofs invalidates cached directory data where applicable and notifies WinFsp.
This allows:

- Directories currently displayed in Explorer to refresh when directory attributes change.
- Applications with open files to detect host-side content changes.

All watched handles to be polled by a single worker thread.
The feature is disabled by default. It can be enabled with:
-n <refresh_seconds> (Default is 3 sec when zero)

Known limitations
- only open handles are monitored. Changes to files that are not open will not be reported individually, so their updated metadata may not appear in Explorer until the containing directory is refreshed by the user or otherwise re-enumerated.