### PR TITLE
RHEL-185213: [Balloon] Remove dead ASSERT

### DIFF
--- a/Balloon/sys/balloon.c
+++ b/Balloon/sys/balloon.c
@@ -281,7 +281,6 @@ BalloonTellHost(IN WDFOBJECT WdfDevice, IN PVIOQUEUE vq)
 
     timeout.QuadPart = Int32x32To64(1000, -10000);
     status = KeWaitForSingleObject(&devCtx->HostAckEvent, Executive, KernelMode, FALSE, &timeout);
-    ASSERT(NT_SUCCESS(status));
     if (STATUS_TIMEOUT == status)
     {
         TraceEvents(TRACE_LEVEL_WARNING, DBG_HW_ACCESS, "<--> TimeOut\n");


### PR DESCRIPTION
KeWaitForSingleObject returns 4 possible statuses:
STATUS_SUCCESS - possible
STATUS_TIMEOUT - possible
STATUS_ALERTED - Alertable is set to FALSE so not possible
STATUS_USER_APC - Alertable is set to FALSE and the parameter is KernelMode instead of UserMode so again not possible

The ASSERT is defined in ntifs.h, balloon code does not redefine it. So in release builds it is harmless anyway. But in debug builds, NT_SUCCESS(STATUS_TIMEOUT) and NT_SUCCESS(STATUS_SUCCESS) both will be true. So ASSERT seems to be dead code here, we can remove it entirely.

Reference: [KeWaitForSingleObject function (wdm.h) - Windows drivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kewaitforsingleobject)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of host acknowledgment events without triggering an unnecessary assertion.
  * Preserved existing timeout and status-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->