### PR TITLE
netkvm: make the TX fragmentation limit configurable and lower the default to 63

### DIFF
--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -155,7 +155,7 @@ static const tConfigurationEntries defaultConfiguration =
     { "MinRxBufferPercent", PARANDIS_MIN_RX_BUFFER_PERCENT_DEFAULT, 0, 100},
     { "*NdisPoll", 0, 0, 1},
     { "MergeableBuffers", 0, 0, 1},
-    { "TxFragmentationLimit", 256, 20, 256},
+    { "TxFragmentationLimit", 63, 20, 256},
 };
 
 static void ParaNdis_ResetVirtIONetDevice(PARANDIS_ADAPTER *pContext)

--- a/NetKVM/Common/ParaNdis_Common.cpp
+++ b/NetKVM/Common/ParaNdis_Common.cpp
@@ -111,6 +111,7 @@ typedef struct _tagConfigurationEntries
     tConfigurationEntry MinRxBufferPercent;
     tConfigurationEntry PollMode;
     tConfigurationEntry MergeableBuffers;
+    tConfigurationEntry TxFragmentationLimit;
 } tConfigurationEntries;
 
 // clang-format off
@@ -154,6 +155,7 @@ static const tConfigurationEntries defaultConfiguration =
     { "MinRxBufferPercent", PARANDIS_MIN_RX_BUFFER_PERCENT_DEFAULT, 0, 100},
     { "*NdisPoll", 0, 0, 1},
     { "MergeableBuffers", 0, 0, 1},
+    { "TxFragmentationLimit", 256, 20, 256},
 };
 
 static void ParaNdis_ResetVirtIONetDevice(PARANDIS_ADAPTER *pContext)
@@ -291,6 +293,7 @@ static bool ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             GetConfigurationEntry(cfg, &pConfiguration->MinRxBufferPercent);
             GetConfigurationEntry(cfg, &pConfiguration->PollMode);
             GetConfigurationEntry(cfg, &pConfiguration->MergeableBuffers);
+            GetConfigurationEntry(cfg, &pConfiguration->TxFragmentationLimit);
 
             bDebugPrint = pConfiguration->isLogEnabled.ulValue;
             virtioDebugLevel = pConfiguration->debugLevel.ulValue;
@@ -393,7 +396,7 @@ static bool ReadNicConfiguration(PARANDIS_ADAPTER *pContext, PUCHAR pNewMACAddre
             pContext->RSC.bIPv4SupportedSW = (UCHAR)pConfiguration->RSCIPv4Supported.ulValue;
             pContext->RSC.bIPv6SupportedSW = (UCHAR)pConfiguration->RSCIPv6Supported.ulValue;
 #endif
-            pContext->uMaxFragmentsInOneNB = MAX_FRAGMENTS_IN_ONE_NB;
+            pContext->uMaxFragmentsInOneNB = pConfiguration->TxFragmentationLimit.ulValue;
 #if PARANDIS_SUPPORT_POLL
             // Win10 build: poll mode keyword is not in the INF, poll mode is disabled by compilation
             // Win11 build: poll mode keyword is in the INF

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -82,10 +82,6 @@ extern "C"
     }
 #endif
 
-#ifndef MAX_FRAGMENTS_IN_ONE_NB
-#define MAX_FRAGMENTS_IN_ONE_NB 256
-#endif
-
 #include "kdebugprint.h"
 #include "virtio_pci.h"
 #include "DebugData.h"
@@ -670,6 +666,12 @@ struct _PARANDIS_ADAPTER : public CNdisAllocatable<_PARANDIS_ADAPTER, 'DCTX'>
     } RSC = {};
 #endif
 
+    /* Maximal number of virtio SG entries the driver uses for a single NET_BUFFER,
+    counting both the header entries and the data fragments. Some hardware
+    implementations of virtio-net can't handle long chains of descriptors, so this
+    is configurable through the "Init.TxFragmentationLimit" parameter. NET_BUFFERs
+    with more fragments are coalesced into fewer pages by the TX path instead of
+    being dropped. The effective value is additionally limited by the TX queue size. */
     ULONG uMaxFragmentsInOneNB;
 
     VOID RaiseUnrecoverableError(PCSTR Message);

--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -230,6 +230,13 @@ HKR, Ndi\Params\MergeableBuffers,           type,       0,          "enum"
 HKR, Ndi\Params\MergeableBuffers\enum,      "1",        0,          %Enable%
 HKR, Ndi\Params\MergeableBuffers\enum,      "0",        0,          %Disable%
 
+HKR, Ndi\params\TxFragmentationLimit,       ParamDesc,  0,          %TxFragmentationLimit%
+HKR, Ndi\params\TxFragmentationLimit,       type,       0,          "int"
+HKR, Ndi\params\TxFragmentationLimit,       default,    0,          "256"
+HKR, Ndi\params\TxFragmentationLimit,       min,        0,          "20"
+HKR, Ndi\params\TxFragmentationLimit,       max,        0,          "256"
+HKR, Ndi\params\TxFragmentationLimit,       step,       0,          "1"
+
 HKR, Ndi\params\*RSS,             ParamDesc,           0, "Receive Side Scaling"
 HKR, Ndi\params\*RSS,             Type,                0, "enum"
 HKR, Ndi\params\*RSS,             Default,             0, "1"
@@ -353,6 +360,7 @@ IPv4 = "IPv4"
 Maximal = "Maximal"
 MinRxBufferPercent = "MinRxBufferPercent"
 MergeableBuffers = "Mergeable Rx Buffers"
+TxFragmentationLimit = "Init.TxFragmentationLimit"
 
 [kvmnet6.Reg] 
 HKR,    ,                         BusNumber,           0, "0"

--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -232,7 +232,7 @@ HKR, Ndi\Params\MergeableBuffers\enum,      "0",        0,          %Disable%
 
 HKR, Ndi\params\TxFragmentationLimit,       ParamDesc,  0,          %TxFragmentationLimit%
 HKR, Ndi\params\TxFragmentationLimit,       type,       0,          "int"
-HKR, Ndi\params\TxFragmentationLimit,       default,    0,          "256"
+HKR, Ndi\params\TxFragmentationLimit,       default,    0,          "63"
 HKR, Ndi\params\TxFragmentationLimit,       min,        0,          "20"
 HKR, Ndi\params\TxFragmentationLimit,       max,        0,          "256"
 HKR, Ndi\params\TxFragmentationLimit,       step,       0,          "1"


### PR DESCRIPTION
Fixes #1530

Implements the approach @ybendito proposed in that issue: expose the limit as a
visible configuration parameter with limits 20..256, and lower the default to 63.

- `netkvm: make the TX fragmentation limit configurable` — replaces the
  compile-time `MAX_FRAGMENTS_IN_ONE_NB` with `Init.TxFragmentationLimit`,
  keeping the default at 256, so there is no functional change
- `netkvm: lower the default TX fragmentation limit to 63`

Ordered this way so the mechanism change is behaviour-preserving and the default
change is a two-line commit that can be reverted on its own.

The mechanism change is a faithful 1:1 replacement: the macro bounded
`m_SGTableCapacity`, i.e. the total number of SG entries including the 1..4
header entries, which is exactly what the parameter now bounds. At the default of
256 the clamp is in fact inert on the indirect path, since
`virtio_get_indirect_page_capacity()` is itself 256.

Verified on Windows Server 2022 with WPP tracing that the driver really consumes
the parameter, not just that Windows stores it. Writing values straight into the
adapter key, which bypasses the INF range check:

| raw registry value | driver verdict | value applied |
|---|---|---|
| 999 | out of range | 0x3f (63, default kept) |
| 5   | out of range | 0x3f (63, default kept) |
| 20  | accepted     | 0x14 |
| 256 | accepted     | 0x100 |
| 63  | accepted     | 0x3f |

So the driver-side range check holds independently of the INF/UI validation and
falls back to the default rather than to a garbage value. Small-packet TCP load
at the default 63 (40k x 200-byte sends plus HTTPS traffic) shows
`OutboundPacketErrors = 0` with the link staying up.

Note on removing the macro: I added `MAX_FRAGMENTS_IN_ONE_NB` myself and I think
it now conflicts with the parameter rather than complementing it — the INF
materialises the parameter's default into the adapter key at install, so a vendor
build overriding the macro silently has no effect, leaving two sources of truth
for the same default. Happy to restore it and drive the INF default from a
substitution token instead (the way `SeparateTail` uses
`INX_NETKVM_SEPARATE_TAIL`) if you'd rather keep the compile-time override
authoritative.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **TX Fragmentation Limit** network adapter setting.
  * The setting defaults to 63 and supports values from 20 to 256.
  * Configuring this value adjusts how transmit data is coalesced and can affect effective queue capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->