### PR TITLE
RHEL-243268: NetKVM: validate num_buffers range in merged buffer processing

### DIFF
--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -1043,6 +1043,19 @@ pRxNetDescriptor CParaNdisRX::ProcessMergedBuffers(pRxNetDescriptor pFirstBuffer
         return pFirstBuffer;
     }
 
+    // num_buffers comes from the device - supplied header — not trustworthy.
+    // Merge context arrays are fixed at VIRTIO_NET_MAX_MRG_BUFS (17) entries.
+    if (numBuffers == 0 || numBuffers > VIRTIO_NET_MAX_MRG_BUFS)
+    {
+        DPrintf(0,
+                "ERROR: num_buffers=%u is out of the valid range [1,%u] - VirtIO protocol violation, dropping packet",
+                numBuffers,
+                VIRTIO_NET_MAX_MRG_BUFS);
+        m_Context->Statistics.ifInErrors++;
+        m_Context->Statistics.ifInDiscards++;
+        ReuseReceiveBufferNoLock(pFirstBuffer);
+        return NULL;
+    }
     // Multi-buffer packet: collect and assemble
     // Initialize merge context with first buffer
     m_MergeContext.BufferSequence[0] = pFirstBuffer;


### PR DESCRIPTION
**Summary**:

Fixes a potential kernel pool corruption and BSOD caused by handling invalid numBuffers values in incoming VirtIO packets.
Coalescing or copying to a single buffer cannot be used to handle unaligned or large scatter-gather chains in this scenario because an out-of-spec numBuffers value represents a corrupted header or a non-compliant device state, rather than a valid large payload.

**Root Cause & Technical Details**:

•	Array Bounds Violation: The m_MergeContext tracking arrays (BufferSequence[], BufferActualLengths[], PhysicalPages[]) are fixed-size arrays allocated for VIRTIO_NET_MAX_MRG_BUFS (17) entries. Any attempt to collect descriptors when numBuffers > 17 causes an immediate out-of-bounds memory write during the collection phase—before any buffer allocation or coalescing can take place.
•	VirtIO Protocol Bounds: Per the VirtIO spec, the maximum packet size (‭$64\text{ KiB}$‬‭‬) divided by the page size (‭$4\text{ KiB}$‬‭‬) yields a physical limit of 16 full pages plus 1 header page (12 bytes), capping valid merged buffers at 17 (VIRTIO_NET_MAX_MRG_BUFS). A value where numBuffers == 0 or numBuffers > 17 violates the specification.
•	Virtqueue State Corruption: Trusting an out-of-spec numBuffers count risks dequeuing unrelated or invalid virtqueue ring entries, leading to host/guest state desynchronization.

**Solution**:

Validate numBuffers prior to processing. If numBuffers < 1 or numBuffers > 17, the packet is immediately dropped and the initial buffer is returned to prevent driver desynchronization and BSODs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network packet handling when an invalid buffer count is received.
  * Invalid packets are now safely discarded and counted as receive errors, preventing potential processing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->