### PR TITLE
viosock: Fix TxEnqueued counter leak wedging non-blocking sends

### DIFF
--- a/viosock/sys/Tx.c
+++ b/viosock/sys/Tx.c
@@ -592,6 +592,7 @@ _Requires_lock_not_held_(pContext->TxLock) VOID VIOSockTxCleanup(PDEVICE_CONTEXT
 
             CurrentEntry = CurrentEntry->Blink;
             RemoveEntryList(&pTxEntry->ListEntry);
+            InterlockedDecrement(&pContext->TxEnqueued);
 
             InsertTailList(&CompletionList, &pTxEntry->ListEntry); // complete later
 
@@ -661,6 +662,7 @@ static VOID VIOSockTxEnqueueCancel(IN WDFREQUEST Request)
 
     WdfSpinLockAcquire(pContext->TxLock);
     RemoveEntryList(&pTxEntry->ListEntry);
+    InterlockedDecrement(&pContext->TxEnqueued);
     VIOSockTxPutCredit(pSocket, pTxEntry->len);
 
     if (pTxEntry->Timeout)


### PR DESCRIPTION
VIOSockTxCleanup and VIOSockTxEnqueueCancel unlink TX entries from the TxList without decrementing pContext->TxEnqueued, so every send request that is canceled or cleaned up on socket teardown leaks one count. VIOSockWriteIsAvailable gates non-blocking sends on

    TxEnqueued + TxPktAllocated >= TxPktNum

so once the leaked counts accumulate to the TX ring size (128 with QEMU defaults), every non-blocking send on every socket permanently fails with WSAEWOULDBLOCK; only a driver reload recovers. A short-lived non-blocking connection leaks at least one count on close, which makes the wedge reachable by simply opening, sending and closing ~128 times.

Decrement TxEnqueued at both unlink sites, keeping the counter balanced with the two insertion sites in VIOSockTxEnqueue/VIOSockSendResetNoSock and the dequeue site in VIOSockTxDequeue.

Fixes: #1623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transmission queue tracking by keeping the queued transmission count accurate when entries are removed or canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->