### PR TITLE
RHEL-185365: [vioserial] clamp invalid max_nr_ports to 1

### DIFF
--- a/vioserial/sys/Device.c
+++ b/vioserial/sys/Device.c
@@ -201,6 +201,13 @@ VIOSerialEvtDevicePrepareHardware(IN WDFDEVICE Device,
                            FIELD_OFFSET(CONSOLE_CONFIG, max_nr_ports),
                            &pContext->consoleConfig.max_nr_ports,
                            sizeof(pContext->consoleConfig.max_nr_ports));
+        if (pContext->consoleConfig.max_nr_ports == 0)
+        {
+            TraceEvents(TRACE_LEVEL_ERROR,
+                        DBG_INIT,
+                        "Invalid max_nr_ports from device config: 0, using 1\n");
+            pContext->consoleConfig.max_nr_ports = 1;
+        }
         TraceEvents(TRACE_LEVEL_INFORMATION,
                     DBG_PNP,
                     "VirtIOConsoleConfig->max_nr_ports %d\n",


### PR DESCRIPTION
## Summary
- Reject `max_nr_ports == 0` in `VIOSerialEvtDevicePrepareHardware` before allocating `in_vqs` / `out_vqs`.
- Fixes [RHEL-185365](https://redhat.atlassian.net/browse/RHEL-185365).
## Test plan
- [ ] Build `vioserial`.
- [ ] `bash Tools/clang-format-helper.sh check './vioserial' './.clang-format' './sys/trace.h'`
- [ ] Confirm a normal virtio-serial device (non-zero `max_nr_ports`) still enumerates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device initialization for configurations that report zero available ports by continuing with a single port.
  * Added logging for invalid zero-port configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->