### PR TITLE
RHEL-244431: vioscsi: fix integer overflow/underflow in VPD identification page length calculation

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1924,10 +1924,10 @@ VOID VioScsiIoControl(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     EXIT_FN_SRB();
 }
 
-UCHAR
+USHORT
 ParseIdentificationDescr(IN PVOID DeviceExtension,
                          IN PVPD_IDENTIFICATION_DESCRIPTOR IdentificationDescr,
-                         IN UCHAR PageLength)
+                         IN USHORT PageLength)
 {
     PADAPTER_EXTENSION adaptExt;
     UCHAR CodeSet = 0;
@@ -1938,7 +1938,7 @@ ParseIdentificationDescr(IN PVOID DeviceExtension,
     {
         CodeSet = IdentificationDescr->CodeSet;               //(UCHAR)(((PCHAR)IdentificationDescr)[0]);
         IdentifierType = IdentificationDescr->IdentifierType; //(UCHAR)(((PCHAR)IdentificationDescr)[1]);
-        if (PageLength < IdentificationDescr->IdentifierLength)
+        if (PageLength < sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + IdentificationDescr->IdentifierLength)
         {
             RhelDbgPrint(TRACE_LEVEL_INFORMATION,
                          " Skipping VPD identifier's descriptor as its length"
@@ -2073,31 +2073,35 @@ VOID VioScsiSaveInquiryData(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
                 {
                     PVPD_IDENTIFICATION_PAGE IdentificationPage;
                     PVPD_IDENTIFICATION_DESCRIPTOR IdentificationDescr;
-                    UCHAR PageLength = 0;
+                    USHORT PageLength = 0;
                     IdentificationPage = (PVPD_IDENTIFICATION_PAGE)dataBuffer;
-                    PageLength = min((UCHAR)(dataLen & 0xFF) - sizeof(VPD_IDENTIFICATION_PAGE),
-                                     IdentificationPage->PageLength);
                     RhelDbgPrint(TRACE_LEVEL_VERBOSE, " SRB's DataTransferLength: 0x%x\n", dataLen);
-                    RhelDbgPrint(TRACE_LEVEL_VERBOSE,
-                                 " Identification page's length: 0x%x\n",
-                                 IdentificationPage->PageLength);
-                    RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Total PageLength: 0x%x\n", PageLength);
-                    if (PageLength >= sizeof(VPD_IDENTIFICATION_DESCRIPTOR))
+                    if (dataLen >= sizeof(VPD_IDENTIFICATION_PAGE))
                     {
-                        UCHAR IdentifierLength = 0;
-                        IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)IdentificationPage->Descriptors;
-                        do
+                        size_t available = dataLen - sizeof(VPD_IDENTIFICATION_PAGE);
+                        // IdentificationPage->PageLength is a UCHAR, so the result is always <= 255 and fits USHORT.
+                        PageLength = (USHORT)min(available, IdentificationPage->PageLength);
+                        RhelDbgPrint(TRACE_LEVEL_VERBOSE,
+                                     " Identification page's length: 0x%x\n",
+                                     IdentificationPage->PageLength);
+                        RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Total PageLength: 0x%x\n", PageLength);
+                        if (PageLength >= sizeof(VPD_IDENTIFICATION_DESCRIPTOR))
                         {
-                            UCHAR offset = 0;
-                            IdentifierLength = ParseIdentificationDescr(DeviceExtension,
-                                                                        IdentificationDescr,
-                                                                        PageLength);
-                            offset = sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + IdentifierLength;
-                            PageLength -= min(PageLength, offset);
-                            IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)((ULONG_PTR)IdentificationDescr +
-                                                                                   offset);
-                            RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Remaining PageLength: 0x%x\n", PageLength);
-                        } while (PageLength >= sizeof(VPD_IDENTIFICATION_DESCRIPTOR));
+                            USHORT IdentifierLength = 0;
+                            IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)IdentificationPage->Descriptors;
+                            do
+                            {
+                                USHORT offset = 0;
+                                IdentifierLength = ParseIdentificationDescr(DeviceExtension,
+                                                                            IdentificationDescr,
+                                                                            PageLength);
+                                offset = (USHORT)sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + IdentifierLength;
+                                PageLength -= min(PageLength, offset);
+                                IdentificationDescr = (PVPD_IDENTIFICATION_DESCRIPTOR)((ULONG_PTR)IdentificationDescr +
+                                                                                       offset);
+                                RhelDbgPrint(TRACE_LEVEL_VERBOSE, " Remaining PageLength: 0x%x\n", PageLength);
+                            } while (PageLength >= sizeof(VPD_IDENTIFICATION_DESCRIPTOR));
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
Two related bugs in how VioScsiSaveInquiryData()/ParseIdentificationDescr()
compute the identification page's remaining length:

1. The original PageLength calculation for VPD_DEVICE_IDENTIFIERS was:
```C
     PageLength = min((UCHAR)(dataLen & 0xFF) - sizeof(VPD_IDENTIFICATION_PAGE),
                      IdentificationPage->PageLength);
```
If dataLen (truncated to a byte) was smaller than sizeof(VPD_IDENTIFICATION_PAGE), the subtraction underflows before min() is applied, producing a large bogus PageLength instead of treating the response as too short to parse.

2. PageLength/offset/IdentifierLength were all UCHAR. In the descriptor walk, 
```C
offset = sizeof(VPD_IDENTIFICATION_DESCRIPTOR) + IdentifierLength
```
can exceed 255 and wrap around an 8-bit value, corrupting the pointer arithmetic used to advance to the next descriptor and potentially causing the loop to run past the actual buffer or spin without making progress. This is the bug originally reported here.

Fix both: guard the calculation with an explicit 
```C
dataLen >= sizeof(VPD_IDENTIFICATION_PAGE)
```
check before subtracting, and widen PageLength (and ParseIdentificationDescr's parameter/return type), IdentifierLength and offset from UCHAR to USHORT so the arithmetic cannot wrap within the range of values these fields can actually take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SCSI device identification data, including larger identification descriptors.
  - Prevented incorrect length calculations and potential parsing errors for device information.
  - Added validation to ensure identification data is sufficiently large before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->