### PR TITLE
RHEL-256099: vioscsi: fix branch condition and length check for standard INQUIRY parsing

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -2105,8 +2105,13 @@ VOID VioScsiSaveInquiryData(IN PVOID DeviceExtension, IN OUT PSRB_TYPE Srb)
     }
     else if (cdb->CDB6INQUIRY3.PageCode == VPD_SUPPORTED_PAGES)
     {
+        // Process Standard INQUIRY response (EVPD == 0, PageCode == 0).
+        // Extracts basic device identity strings: Vendor ID (8B), Product ID (16B), and Revision Level (4B).
+        // Memory bounds are validated using FIELD_OFFSET to ensure dataLen reaches at least the end of
+        // ProductRevisionLevel (36 bytes total), preventing out-of-bounds reads on probe responses
         PINQUIRYDATA InquiryData = (PINQUIRYDATA)dataBuffer;
-        if (InquiryData && dataLen)
+        if (InquiryData &&
+            dataLen >= FIELD_OFFSET(INQUIRYDATA, ProductRevisionLevel) + sizeof(InquiryData->ProductRevisionLevel))
         {
             CopyBufferToAnsiString(adaptExt->ven_id, InquiryData->VendorId, ' ', sizeof(InquiryData->VendorId));
             CopyBufferToAnsiString(adaptExt->prod_id, InquiryData->ProductId, ' ', sizeof(InquiryData->ProductId));


### PR DESCRIPTION

Two related bugs in how VioScsiSaveInquiryData() decides to parse, and then parses, the standard INQUIRY response (Vendor ID / Product ID / Revision Level):

1. The response was only parsed when the CDB's PageCode field happened to equal VPD_SUPPORTED_PAGES. That field is reserved and undefined when EnableVitalProductData (EVPD) is 0, so this branch only ran by coincidence, depending on whatever value a given initiator happened to leave in that reserved byte.

2. Once inside, only dataLen != 0 was checked before reading VendorId, ProductId and ProductRevisionLevel. A short transfer (dataLen > 0 but smaller than the fields being read) could still cause an out-of-bounds read past the end of the SRB data buffer.

Fixing only the branch condition (1) without also fixing the length check (2) would make the still-insufficiently-validated read unconditionally reachable instead of only reachable by coincidence, so both are fixed together here: the condition becomes a plain "else" so standard INQUIRY data is always parsed whenever EVPD is 0, and dataLen is required to reach at least the end of ProductRevisionLevel (computed via FIELD_OFFSET) before any of these fields are copied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SCSI device identification across standard inquiry responses, including responses with varied page codes.
  - Added safer validation of inquiry data lengths to prevent incomplete probe responses from being processed incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->