### PR TITLE
RHEL-256869: vioscsi: fix LUN WWN vs target port WWN identification

### DIFF
--- a/vioscsi/vioscsi.c
+++ b/vioscsi/vioscsi.c
@@ -1932,12 +1932,14 @@ ParseIdentificationDescr(IN PVOID DeviceExtension,
     PADAPTER_EXTENSION adaptExt;
     UCHAR CodeSet = 0;
     UCHAR IdentifierType = 0;
+    UCHAR Association = 0;
     adaptExt = (PADAPTER_EXTENSION)DeviceExtension;
     ENTER_FN();
     if (IdentificationDescr)
     {
         CodeSet = IdentificationDescr->CodeSet;               //(UCHAR)(((PCHAR)IdentificationDescr)[0]);
         IdentifierType = IdentificationDescr->IdentifierType; //(UCHAR)(((PCHAR)IdentificationDescr)[1]);
+        Association = IdentificationDescr->Association;
         if (PageLength < IdentificationDescr->IdentifierLength)
         {
             RhelDbgPrint(TRACE_LEVEL_INFORMATION,
@@ -1973,27 +1975,26 @@ ParseIdentificationDescr(IN PVOID DeviceExtension,
                 break;
             case VioscsiVpdIdentifierTypeFCPHName:
                 {
+                    // NAA identifier: Association tells us whether it names the logical unit or the target port.
                     if ((CodeSet == VioscsiVpdCodeSetBinary) &&
                         (IdentificationDescr->IdentifierLength == sizeof(ULONGLONG)))
                     {
-                        REVERSE_BYTES_QUAD(&adaptExt->wwn, IdentificationDescr->Identifier);
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " wwn %llu\n", (ULONGLONG)adaptExt->wwn);
-                    }
-                }
-                break;
-            case VioscsiVpdIdentifierTypeFCTargetPortPHName:
-                {
-                    if ((CodeSet == VioscsiVpdCodeSetSASBinary) &&
-                        (IdentificationDescr->IdentifierLength == sizeof(ULONGLONG)))
-                    {
-                        REVERSE_BYTES_QUAD(&adaptExt->port_wwn, IdentificationDescr->Identifier);
-                        RhelDbgPrint(TRACE_LEVEL_INFORMATION, " port wwn %llu\n", (ULONGLONG)adaptExt->port_wwn);
+                        if (Association == VioscsiVpdAssociationLogicalUnit)
+                        {
+                            REVERSE_BYTES_QUAD(&adaptExt->wwn, IdentificationDescr->Identifier);
+                            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " wwn %llu\n", (ULONGLONG)adaptExt->wwn);
+                        }
+                        else if (Association == VioscsiVpdAssociationTargetPort)
+                        {
+                            REVERSE_BYTES_QUAD(&adaptExt->port_wwn, IdentificationDescr->Identifier);
+                            RhelDbgPrint(TRACE_LEVEL_INFORMATION, " port wwn %llu\n", (ULONGLONG)adaptExt->port_wwn);
+                        }
                     }
                 }
                 break;
             case VioscsiVpdIdentifierTypeFCTargetPortRelativeTargetPort:
                 {
-                    if ((CodeSet == VioscsiVpdCodeSetSASBinary) &&
+                    if ((CodeSet == VioscsiVpdCodeSetBinary) &&
                         (IdentificationDescr->IdentifierLength == sizeof(ULONG)))
                     {
                         REVERSE_BYTES(&adaptExt->port_idx, IdentificationDescr->Identifier);

--- a/vioscsi/vioscsi.h
+++ b/vioscsi/vioscsi.h
@@ -394,7 +394,6 @@ typedef enum VIOSCSI_VPD_CODE_SET
 {
     VioscsiVpdCodeSetBinary = 1,
     VioscsiVpdCodeSetAscii = 2,
-    VioscsiVpdCodeSetSASBinary = 0x61,
 } VIOSCSI_VPD_CODE_SET, *PVIOSCSI_VPD_CODE_SET;
 
 typedef enum VIOSCSI_VPD_IDENTIFIER_TYPE
@@ -402,9 +401,16 @@ typedef enum VIOSCSI_VPD_IDENTIFIER_TYPE
     VioscsiVpdIdentifierTypeVendorSpecific = 0,
     VioscsiVpdIdentifierTypeVendorId = 1,
     VioscsiVpdIdentifierTypeEUI64 = 2,
-    VioscsiVpdIdentifierTypeFCPHName = 3,
-    VioscsiVpdIdentifierTypeFCTargetPortPHName = 0x93,
-    VioscsiVpdIdentifierTypeFCTargetPortRelativeTargetPort = 0x94,
+    VioscsiVpdIdentifierTypeFCPHName = 3, // NAA; also used for the target port's WWN, see VIOSCSI_VPD_ASSOCIATION
+    VioscsiVpdIdentifierTypeFCTargetPortRelativeTargetPort = 4,
 } VIOSCSI_VPD_IDENTIFIER_TYPE, *PVIOSCSI_VPD_IDENTIFIER_TYPE;
+
+// SPC IDENTIFICATION DESCRIPTOR ASSOCIATION field (2 bits): what the identifier refers to.
+typedef enum VIOSCSI_VPD_ASSOCIATION
+{
+    VioscsiVpdAssociationLogicalUnit = 0,
+    VioscsiVpdAssociationTargetPort = 1,
+    VioscsiVpdAssociationTargetDevice = 2,
+} VIOSCSI_VPD_ASSOCIATION, *PVIOSCSI_VPD_ASSOCIATION;
 
 #endif ___VIOSCSI__H__


### PR DESCRIPTION
ParseIdentificationDescr() tried to tell a logical unit's NAA WWN apart from a target port's NAA WWN using switch cases and checks that can never match: the target port branch only ran when IdentifierType equaled VioscsiVpdIdentifierTypeFCTargetPortPHName (0x93), and the relative target port branch only ran when IdentifierType equaled VioscsiVpdIdentifierTypeFCTargetPortRelativeTargetPort (0x94) AND CodeSet equaled VioscsiVpdCodeSetSASBinary (0x61). CodeSet and IdentifierType are both 4-bit fields (max value 15), so a real device can never send 0x93, 0x94 or 0x61 in either of them - both branches were dead code.

Both a logical unit's and a target port's NAA identifier actually use the same IdentifierType (3) and CodeSet (1, binary). Which one a given descriptor is telling us about is carried in a separate field, Association (0 = logical unit, 1 = target port). Read Association and use it to route the identifier to adaptExt->wwn or adaptExt->port_wwn, and fix the relative target port branch to check CodeSet against the valid Binary constant and use the correct IdentifierType value (4, not 0x94).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage device identification by correctly associating Fibre Channel identifiers with logical units and target ports.
  - Updated VPD identifier handling to provide more accurate worldwide name information for connected storage resources.
  - Refined identifier definitions to better align with supported SCSI identification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->