### PR TITLE
netkvm: fix shared page array corruption in mergeable RX assembly

### DIFF
--- a/NetKVM/Common/ParaNdis-RX.h
+++ b/NetKVM/Common/ParaNdis-RX.h
@@ -78,9 +78,6 @@ class CParaNdisRX : public CParaNdisTemplatePath<CVirtQueue>, public CNdisAlloca
         UINT16 ExpectedBuffers;
         UINT16 CollectedBuffers;
         UINT32 TotalPacketLength;
-
-        // Pre-allocated array for merged packet assembly (eliminates allocate/copy/free in hot path)
-        tCompletePhysicalAddress PhysicalPages[VIRTIO_NET_MAX_MRG_BUFS];
     } m_MergeContext;
 
     void ReuseReceiveBufferNoLock(pRxNetDescriptor pBuffersDescriptor);

--- a/NetKVM/Common/ParaNdis_RX.cpp
+++ b/NetKVM/Common/ParaNdis_RX.cpp
@@ -310,16 +310,18 @@ pRxNetDescriptor CParaNdisRX::CreateMergeableRxDescriptorOnInit()
         goto error_exit;
     }
 
-    p->PhysicalPages = (tCompletePhysicalAddress *)ParaNdis_AllocateMemory(m_Context, sizeof(tCompletePhysicalAddress));
+    // The page array must hold mappings for all pages of a merged packet:
+    // page 0 for header + payload of this buffer, one page per each additional
+    // buffer of the largest mergeable packet (VIRTIO_NET_MAX_MRG_BUFS total).
+    p->PhysicalPages = (tCompletePhysicalAddress *)ParaNdis_AllocateMemory(m_Context,
+                                                                           sizeof(tCompletePhysicalAddress) * VIRTIO_NET_MAX_MRG_BUFS);
     if (p->PhysicalPages == NULL)
     {
         DPrintf(0, "ERROR: Failed to allocate PhysicalPages array");
         goto error_exit;
     }
 
-    NdisZeroMemory(p->PhysicalPages, sizeof(tCompletePhysicalAddress));
-
-    p->OriginalPhysicalPages = p->PhysicalPages;
+    NdisZeroMemory(p->PhysicalPages, sizeof(tCompletePhysicalAddress) * VIRTIO_NET_MAX_MRG_BUFS);
 
     if (!ParaNdis_InitialAllocatePhysicalMemory(m_Context, PAGE_SIZE, &p->PhysicalPages[0]))
     {
@@ -414,7 +416,6 @@ pRxNetDescriptor CParaNdisRX::CreateRxDescriptorOnInit()
     p->HeaderPage = m_Context->RxLayout.ReserveForHeader ? 0 : 1;
     p->FirstRxDataPage = 1;
     p->DataStartOffset = (p->HeaderPage == 0) ? 0 : (USHORT)m_Context->nVirtioHeaderSize;
-    p->OriginalPhysicalPages = p->PhysicalPages;
     auto &pageNumber = p->NumPages;
 
     while (ulNumDataPages > 0)
@@ -578,7 +579,6 @@ void CParaNdisRX::DisassembleMergedPacket(pRxNetDescriptor pBuffer)
         pMDL = pNextMDL;
     }
 
-    pBuffer->PhysicalPages = pBuffer->OriginalPhysicalPages;
     pBuffer->NumPages = 1;
     pBuffer->NumOwnedPages = 1;
     pBuffer->MergedBufferCount = 0;
@@ -1150,8 +1150,6 @@ pRxNetDescriptor CParaNdisRX::AssembleMergedPacket()
     // - First buffer: 1 page (header + data in same page)
     // - Each additional buffer: 1 page (subsequent buffers contain only data, no virtio header)
     USHORT totalPages = (USHORT)m_MergeContext.CollectedBuffers;
-    pAssembledBuffer->PhysicalPages = m_MergeContext.PhysicalPages;
-    pAssembledBuffer->PhysicalPages[0] = pAssembledBuffer->OriginalPhysicalPages[0];
 
     USHORT destPageIdx = 1;
     for (UINT i = 1; i < m_MergeContext.CollectedBuffers; i++)

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -456,8 +456,6 @@ struct _tagRxNetDescriptor
     USHORT DataStartOffset;
     struct VirtIOBufferDescriptor *BufferSGArray;
     tCompletePhysicalAddress *PhysicalPages;
-    // Saved pointer for restoration after merge
-    tCompletePhysicalAddress *OriginalPhysicalPages;
     tCompletePhysicalAddress IndirectArea;
     tPacketHolderType Holder;
 

--- a/NetKVM/Common/ndis56common.h
+++ b/NetKVM/Common/ndis56common.h
@@ -475,12 +475,12 @@ struct _tagRxNetDescriptor
     //
     // Field semantics:
     //   MergedBufferCount: Number of ADDITIONAL buffers (NOT including this descriptor)
-    //                      Range: 0 (single buffer) to 16 (max merged packet)
-    //   MergedBuffersInline: Array storing pointers to the 16 additional buffers
-    //                        (this descriptor itself is not stored in the array)
-#define MAX_MERGED_BUFFERS 16
+    //                      Range: 0 (single buffer) to VIRTIO_NET_MAX_MRG_BUFS - 1
+    //   MergedBuffers: Array storing pointers to the additional buffers
+    //                  (this descriptor itself is not stored in the array,
+    //                  hence one entry less than VIRTIO_NET_MAX_MRG_BUFS)
     USHORT MergedBufferCount;
-    pRxNetDescriptor MergedBuffers[MAX_MERGED_BUFFERS];
+    pRxNetDescriptor MergedBuffers[VIRTIO_NET_MAX_MRG_BUFS - 1];
 };
 
 struct _PARANDIS_ADAPTER : public CNdisAllocatable<_PARANDIS_ADAPTER, 'DCTX'>


### PR DESCRIPTION
## Problem

`AssembleMergedPacket` redirected the first buffer's `PhysicalPages` to a **single per-queue array** embedded in `m_MergeContext`. While a merged packet waits in an RSS/unclassified receive queue, the next multi-buffer packet assembled on the same queue **overwrites the shared array** — so the consumer (`ParaNdis_PrepareReceivedPacket`) reads a **foreign page mapping** when it fetches the virtio header and runs checksum verification.

## Why this is serious

This is a data-integrity bug, not a performance issue:

- **Valid packets get discarded**: a good packet inherits the verdict computed over a foreign buffer, gets flagged with a failed checksum, and is dropped by the protocol stack — visible at the application as packet loss (TCP retransmits/throughput collapse, silent UDP data loss).
- **Corrupted packets get delivered**: a packet with a genuinely bad checksum can inherit a *pass* verdict and reach the application — the end-to-end checksum protection is silently defeated.
- The trigger is common, not exotic: with jumbo MTU and `MergeableBuffers=1`, any DPC that processes ≥2 multi-buffer packets hits the window. Under bursted jumbo traffic we measured **91.6%** of merged packets reading a foreign page mapping.
- It is nearly invisible to conventional testing: packet *data* (the MDL chain) stays correct, nothing crashes, no error counters move — and since the feature defaults to disabled and standard-MTU traffic never takes the multi-buffer path, the bug never showed up in regular runs.

## Fix

The page array now lives with the descriptor: `CreateMergeableRxDescriptorOnInit` allocates `VIRTIO_NET_MAX_MRG_BUFS` entries per descriptor, so `PhysicalPages` always points at memory owned by the packet that carries it. The `OriginalPhysicalPages` save/restore machinery and the queue-shared array, which only existed to support the redirect, are removed. Cost: +384 bytes per mergeable descriptor, paid only when the feature is enabled.

The second commit is an independent cleanup: `MergedBuffers` is now sized as `VIRTIO_NET_MAX_MRG_BUFS - 1` instead of a standalone `MAX_MERGED_BUFFERS` constant, making the off-by-one relationship explicit.

## Reproducing

Environment: Win2022 guest with netkvm, test NIC on a jumbo bridge (MTU 8500), advanced property *Mergeable Rx Buffers* = Enabled, RX checksum offloads at defaults.

1. On the host, put the sender IP on the bridge and allow the guest to reach it:
   ```
   ip addr add 10.66.0.99/24 dev virbrmrg
   ```
2. On the guest (elevated PowerShell), open the echo port and start the echo listener (no extra tools needed):
   ```
   New-NetFirewallRule -DisplayName mrgrepro -Direction Inbound -Protocol UDP -LocalPort 9999 -Action Allow
   $u=New-Object System.Net.Sockets.UdpClient 9999;$c=New-Object System.Net.Sockets.UdpClient;while($true){$e=New-Object System.Net.IPEndPoint([System.Net.IPAddress]::Any,0);$d=$u.Receive([ref]$e);$c.Send($d,$d.Length,'10.66.0.99',9998)|Out-Null}
   ```
3. On the host, run the reproducer (attached below):
   ```
   sudo python3 repro_mrg_rx_race.py 52:54:00:6d:02:02 10.66.0.2
   ```

It injects bursted 8K jumbo UDP packets — even sequence numbers carry a valid IP checksum, odd ones a deliberately corrupted one — and derives the verdict from which sequence numbers the application echoes back:

```
before fix:  good: 532/1000 delivered, 468 lost    bad: 291/1000 delivered  -> BUG PRESENT
after fix:   good: 1000/1000 delivered, 0 lost     bad: 0/1000 delivered    -> HEALTHY
```

<details>
<summary>repro_mrg_rx_race.py (click to expand)</summary>

```python
#!/usr/bin/env python3
"""Reproduce the netkvm mergeable-RX race on a jumbo-enabled guest.

Send N bursted jumbo UDP packets; even seq = good IP checksum, odd seq =
corrupted. The guest must echo UDP:9999 back to this host:9998. A healthy
driver delivers all good packets and drops all bad ones; the buggy driver
loses good packets and delivers bad ones.
"""
import socket
import struct
import sys
import threading
import time

N = 2000          # packets: N/2 good + N/2 bad
BURST = 16        # packets back-to-back per burst (opens the race window)
PAYLOAD = 8192    # > 4084 so the packet spans multiple mergeable buffers
PORT = 9999       # echo port on the guest
LISTEN = 9998     # echo return port on this host
SRC_IP = "10.66.0.99"
DST_MAC = sys.argv[1] if len(sys.argv) > 1 else "52:54:00:6d:02:02"
DST_IP = sys.argv[2] if len(sys.argv) > 2 else "10.66.0.2"
SRC_MAC = bytes.fromhex("020000000001")
DST = bytes.fromhex(DST_MAC.replace(":", "").replace("-", ""))


def csum16(data):
    s = 0
    for i in range(0, len(data), 2):
        s += (data[i] << 8) | data[i + 1]
    while s >> 16:
        s = (s & 0xFFFF) + (s >> 16)
    return (~s) & 0xFFFF


# UDP checksum base over everything except the 4-byte seq
FILLER = b"U" * (PAYLOAD - 8)
UDP_HDR = struct.pack(">HHHH", PORT, PORT, 8 + PAYLOAD, 0)
PSEUDO = socket.inet_aton(SRC_IP) + socket.inet_aton(DST_IP) + \
    struct.pack(">BBH", 0, 17, 8 + PAYLOAD)
_base = PSEUDO + UDP_HDR + b"MRGR" + b"\0" * 4 + FILLER
BASE_SUM = sum((_base[i] << 8) | _base[i + 1] for i in range(0, len(_base) - 1, 2))

echoed = set()


def rx():
    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
    s.bind(("0.0.0.0", LISTEN))
    s.settimeout(1)
    while True:
        try:
            d, _ = s.recvfrom(65535)
            if d[:4] == b"MRGR":
                echoed.add(struct.unpack("<I", d[4:8])[0])
        except socket.timeout:
            pass


threading.Thread(target=rx, daemon=True).start()

tx = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
tx.bind(("virbrmrg", 0))

for burst in range(0, N, BURST):
    for seq in range(burst, min(burst + BURST, N)):
        # valid UDP checksum (netkvm rejects absent UDP checksums)
        s = BASE_SUM
        s += ((seq & 0xFF) << 8) | ((seq >> 8) & 0xFF)
        s += (((seq >> 16) & 0xFF) << 8) | ((seq >> 24) & 0xFF)
        while s >> 16:
            s = (s & 0xFFFF) + (s >> 16)
        udp = struct.pack(">HHHH", PORT, PORT, 8 + PAYLOAD, (~s) & 0xFFFF)

        payload = b"MRGR" + struct.pack("<I", seq) + FILLER
        ip = struct.pack(">BBHHHBBH4s4s", 0x45, 0, 20 + 8 + PAYLOAD,
                         seq & 0xFFFF, 0, 64, 17, 0,
                         socket.inet_aton(SRC_IP), socket.inet_aton(DST_IP))
        cs = csum16(ip)
        if seq % 2:
            cs ^= 0x55AA  # corrupt IP checksum on odd seq
        ip = ip[:10] + struct.pack(">H", cs) + ip[12:]
        tx.send(DST + SRC_MAC + b"\x08\x00" + ip + udp + payload)
    time.sleep(0.003)

time.sleep(10)
good = [s for s in range(0, N, 2) if s in echoed]
bad = [s for s in range(1, N, 2) if s in echoed]
print("good: %d/%d delivered, %d lost" % (len(good), N // 2, N // 2 - len(good)))
print("bad:  %d/%d delivered (expected 0)" % (len(bad), N // 2))
print("RESULT: " + ("BUG PRESENT" if bad or len(good) < N // 2 else "HEALTHY"))
sys.exit(1 if bad or len(good) < N // 2 else 0)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receive-buffer handling for large merged VirtIO network packets.
  * Updated buffer capacity calculations to align with the maximum supported merged-packet size.
  * Reduced reliance on saved buffer state during packet assembly and disassembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->