### PR TITLE
netkvm: enable mergeable buffers by default for CI testing[JUST FOR TEST]

### DIFF
--- a/NetKVM/netkvm-base.txt
+++ b/NetKVM/netkvm-base.txt
@@ -225,7 +225,7 @@ HKR, Ndi\params\MinRxBufferPercent,         max,        0,          "100"
 HKR, Ndi\params\MinRxBufferPercent,         step,       0,          "1"
 
 HKR, Ndi\Params\MergeableBuffers,           ParamDesc,  0,          %MergeableBuffers%
-HKR, Ndi\Params\MergeableBuffers,           Default,    0,          "0"
+HKR, Ndi\Params\MergeableBuffers,           Default,    0,          "1"
 HKR, Ndi\Params\MergeableBuffers,           type,       0,          "enum"
 HKR, Ndi\Params\MergeableBuffers\enum,      "1",        0,          %Enable%
 HKR, Ndi\Params\MergeableBuffers\enum,      "0",        0,          %Disable%


### PR DESCRIPTION
This PR is mainly a conversation starter about CI coverage for non-default paths — the INF flip below just demonstrates the idea on a working branch.

## Motivation

`MergeableBuffers` defaults to `"0"` in the INF, so CI (including HCK/HLK) never exercises the mergeable RX path. This test-only branch flips the default so the full CI pipeline runs with that path active — the goal is simply path coverage: functional regressions, crashes and leaks in the mergeable RX code surface on every rebase against upstream master.


## Plan

- Keep this branch rebased on upstream master; each push re-runs CI with mergeable enabled. This is admittedly clumsy — it needs a manual rebase every time — so if the CI already has (or could gain) a mechanism to cover non-default paths in HCK testing, that would be far better; happy to retire this branch in favor of it.
- **Not meant to be merged** — the product default stays `"0"`. If merged, coverage would just move to the non-mergeable path.
- Happy to drop this in favor of a proper mechanism instead, e.g. a CI matrix leg installing the driver with `MergeableBuffers=1`, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled mergeable buffers by default for the NetKVM driver, which may improve network performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->